### PR TITLE
[tests-only][full-ci]test(cli): add clean-orphaned-grants CLI test scenarios

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1224,4 +1224,57 @@ class CliContext implements Context {
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
 
+	/**
+	 * @Given the share grants for space :spaceName owned by :user have been orphaned
+	 *
+	 * @param string $spaceName
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theShareGrantsForSpaceHaveBeenOrphaned(string $spaceName, string $user): void {
+		$parts = \explode('$', $this->spacesContext->getSpaceIdByName($user, $spaceName));
+		$spaceOpaqueId = $parts[1] ?? '';
+		$deadSpaceId = '00000000-0000-0000-0000-000000000000';
+
+		$blobsRoot = $this->featureContext->getOcisDataPath() . '/storage/metadata/spaces/js';
+		$found = false;
+		foreach (['jsoncs3-share-manager-metadata', 'oncs3-share-manager-metadata'] as $metaSpace) {
+			$blobDir = $blobsRoot . '/' . $metaSpace . '/blobs';
+			if (!\is_dir($blobDir)) {
+				continue;
+			}
+			// walk all blob files recursively (blobs/{hex}/{hex}/{hex}/{hex}/{filename})
+			$dirIterator = new \RecursiveDirectoryIterator($blobDir, \RecursiveDirectoryIterator::SKIP_DOTS);
+			$fileIterator = new \RecursiveIteratorIterator($dirIterator);
+			foreach ($fileIterator as $file) {
+				if (!$file->isFile()) {
+					continue;
+				}
+				$data = \json_decode(\file_get_contents($file->getPathname()), true);
+				if (!isset($data['Shares'])) {
+					continue;
+				}
+				$matched = false;
+				foreach ($data['Shares'] as $key => $share) {
+					if (($share['resource_id']['space_id'] ?? '') !== $spaceOpaqueId) {
+						continue;
+					}
+					$data['Shares'][$key]['resource_id']['space_id'] = $deadSpaceId;
+					$matched = true;
+				}
+				if (!$matched) {
+					continue;
+				}
+				\file_put_contents(
+					$file->getPathname(),
+					\json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+				);
+				$found = true;
+			}
+		}
+
+		Assert::assertTrue($found, "Could not find blob for space $spaceName ($spaceOpaqueId)");
+	}
 }

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1154,4 +1154,101 @@ class CliContext implements Context {
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
+
+	/**
+	 * @Given the administrator has configured service account credentials
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorHasConfiguredServiceAccountCredentials(): void {
+		$envs = [
+			"OCIS_SERVICE_ACCOUNT_ID" => $this->getServiceAccountId(),
+			"OCIS_SERVICE_ACCOUNT_SECRET" => $this->getServiceAccountSecret(),
+		];
+		$response = OcisConfigHelper::reConfigureOcis($envs);
+		$this->featureContext->theHTTPStatusCodeShouldBe(
+			200,
+			"Failed to configure service account credentials",
+			$response,
+		);
+	}
+
+	/**
+	 * @When the administrator runs clean-orphaned-grants in dry-run mode
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsCleanOrphanedGrantsInDryRunMode(): void {
+		$command = "shares clean-orphaned-grants"
+			. " --service-account-id=" . $this->getServiceAccountId()
+			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --dry-run=true";
+		$body = ["command" => $command];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator runs clean-orphaned-grants in non-dry-run mode
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsCleanOrphanedGrantsInNonDryRunMode(): void {
+		$command = "shares clean-orphaned-grants"
+			. " --service-account-id=" . $this->getServiceAccountId()
+			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --dry-run=false";
+		$body = ["command" => $command];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator runs clean-orphaned-grants for space :spaceName owned by :user
+	 *
+	 * @param string $spaceName
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsCleanOrphanedGrantsForSpaceOwnedBy(
+		string $spaceName,
+		string $user,
+	): void {
+		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
+		$command = "shares clean-orphaned-grants"
+			. " --service-account-id=" . $this->getServiceAccountId()
+			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --space-id=" . $spaceId
+			. " --dry-run=false";
+		$body = ["command" => $command];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator runs clean-orphaned-grants with force flag
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsCleanOrphanedGrantsWithForceFlag(): void {
+		$command = "shares clean-orphaned-grants"
+			. " --service-account-id=" . $this->getServiceAccountId()
+			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --force --dry-run=false";
+		$body = ["command" => $command];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getServiceAccountId(): string {
+		return "service-account-id";
+	}
+
+	/**
+	 * @return string
+	 */
+	private function getServiceAccountSecret(): string {
+		return "service-account-secret";
+	}
 }

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1163,8 +1163,8 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorHasConfiguredServiceAccountCredentials(): void {
 		$envs = [
-			"OCIS_SERVICE_ACCOUNT_ID" => $this->getServiceAccountId(),
-			"OCIS_SERVICE_ACCOUNT_SECRET" => $this->getServiceAccountSecret(),
+			"OCIS_SERVICE_ACCOUNT_ID" => "service-account-id",
+			"OCIS_SERVICE_ACCOUNT_SECRET" => "service-account-secret",
 		];
 		$response = OcisConfigHelper::reConfigureOcis($envs);
 		$this->featureContext->theHTTPStatusCodeShouldBe(
@@ -1175,28 +1175,14 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator runs clean-orphaned-grants in dry-run mode
-	 *
-	 * @return void
-	 */
-	public function theAdministratorRunsCleanOrphanedGrantsInDryRunMode(): void {
-		$command = "shares clean-orphaned-grants"
-			. " --service-account-id=" . $this->getServiceAccountId()
-			. " --service-account-secret=" . $this->getServiceAccountSecret()
-			. " --dry-run=true";
-		$body = ["command" => $command];
-		$this->featureContext->setResponse(CliHelper::runCommand($body));
-	}
-
-	/**
 	 * @When the administrator runs clean-orphaned-grants in non-dry-run mode
 	 *
 	 * @return void
 	 */
 	public function theAdministratorRunsCleanOrphanedGrantsInNonDryRunMode(): void {
 		$command = "shares clean-orphaned-grants"
-			. " --service-account-id=" . $this->getServiceAccountId()
-			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --service-account-id=service-account-id"
+			. " --service-account-secret=service-account-secret"
 			. " --dry-run=false";
 		$body = ["command" => $command];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
@@ -1216,8 +1202,8 @@ class CliContext implements Context {
 	): void {
 		$spaceId = $this->spacesContext->getSpaceIdByName($user, $spaceName);
 		$command = "shares clean-orphaned-grants"
-			. " --service-account-id=" . $this->getServiceAccountId()
-			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --service-account-id=service-account-id"
+			. " --service-account-secret=service-account-secret"
 			. " --space-id=" . $spaceId
 			. " --dry-run=false";
 		$body = ["command" => $command];
@@ -1231,24 +1217,11 @@ class CliContext implements Context {
 	 */
 	public function theAdministratorRunsCleanOrphanedGrantsWithForceFlag(): void {
 		$command = "shares clean-orphaned-grants"
-			. " --service-account-id=" . $this->getServiceAccountId()
-			. " --service-account-secret=" . $this->getServiceAccountSecret()
+			. " --service-account-id=service-account-id"
+			. " --service-account-secret=service-account-secret"
 			. " --force --dry-run=false";
 		$body = ["command" => $command];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}
 
-	/**
-	 * @return string
-	 */
-	private function getServiceAccountId(): string {
-		return "service-account-id";
-	}
-
-	/**
-	 * @return string
-	 */
-	private function getServiceAccountSecret(): string {
-		return "service-account-secret";
-	}
 }

--- a/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
+++ b/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
@@ -1,0 +1,39 @@
+@env-config
+Feature: clean orphaned grants using CLI
+  As an administrator
+  I want to clean orphaned share-manager grants using the CLI
+  So that I can fix orphaned shares in the system
+
+  Background:
+    Given user "Alice" has been created with default attributes
+    And the administrator has configured service account credentials
+
+
+  Scenario: administrator runs clean-orphaned-grants in dry-run mode
+    When the administrator runs clean-orphaned-grants in dry-run mode
+    Then the command should be successful
+    And the command output should contain "== Pre-flight =="
+    And the command output should contain "mode: dry run enabled"
+    And the command output should contain "== Primary scan =="
+    And the command output should contain "Dry run mode: no grants were modified"
+    And the command output should contain "== Reverse orphan scan =="
+
+
+  Scenario: administrator runs clean-orphaned-grants in non-dry-run mode
+    When the administrator runs clean-orphaned-grants in non-dry-run mode
+    Then the command should be successful
+    And the command output should contain "mode: dry run disabled: grants may be changed"
+
+
+  Scenario: administrator runs clean-orphaned-grants with space-id filter
+    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "project1" with the default quota using the Graph API
+    When the administrator runs clean-orphaned-grants for space "project1" owned by "Alice"
+    Then the command should be successful
+    And the command output should contain "scope: limiting scan to space"
+
+
+  Scenario: administrator runs clean-orphaned-grants with force flag
+    When the administrator runs clean-orphaned-grants with force flag
+    Then the command should be successful
+    And the command output should contain "flags: --force active"

--- a/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
+++ b/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
@@ -2,11 +2,28 @@
 Feature: clean orphaned grants using CLI
   As an administrator
   I want to clean orphaned share-manager grants using the CLI
-  So that I can fix orphaned shares in the system
+  So that I can remove orphaned shares in the system
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given these users have been created with default attributes:
+      | username |
+      | Alice    |
+      | Brian    |
     And the administrator has configured service account credentials
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "orphan-test" with the default quota using the Graph API
+    And using spaces DAV path
+    And user "Alice" has uploaded a file inside space "orphan-test" with content "test content" to "orphanFile.txt"
+    And using new DAV path
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | orphanFile.txt |
+      | space           | orphan-test    |
+      | sharee          | Brian          |
+      | shareType       | user           |
+      | permissionsRole | Viewer         |
+    And the administrator has stopped the server
+    And the share grants for space "orphan-test" owned by "Alice" have been orphaned
+    And the administrator has started the server
 
 
   Scenario: administrator runs clean-orphaned-grants in non-dry-run mode
@@ -14,20 +31,18 @@ Feature: clean orphaned grants using CLI
     Then the command should be successful
     And the command output should contain "mode: dry run disabled: grants may be changed"
     And the command output should contain "Summary:"
-    And the command output should contain "Orphans: 0 candidate(s)"
-    And the command output should contain "Reverse orphans: 0 candidate(s)"
+    And the command output should contain "Orphans: 1 candidate(s), 1 removed"
+    And the command output should contain "Reverse orphans: 0 candidate(s), 0 removed"
 
 
   Scenario: administrator runs clean-orphaned-grants with space-id filter
-    Given the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a space "project1" with the default quota using the Graph API
-    When the administrator runs clean-orphaned-grants for space "project1" owned by "Alice"
+    When the administrator runs clean-orphaned-grants for space "orphan-test" owned by "Alice"
     Then the command should be successful
     And the command output should contain "scope: limiting scan to space"
     And the command output should contain "1 target space(s)"
     And the command output should contain "Summary:"
-    And the command output should contain "Orphans: 0 candidate(s)"
-    And the command output should contain "Reverse orphans: 0 candidate(s)"
+    And the command output should contain "Orphans: 1 candidate(s), 1 removed"
+    And the command output should contain "Reverse orphans: 0 candidate(s), 0 removed"
 
 
   Scenario: administrator runs clean-orphaned-grants with force flag
@@ -35,24 +50,14 @@ Feature: clean orphaned grants using CLI
     Then the command should be successful
     And the command output should contain "flags: --force active"
     And the command output should contain "Summary:"
-    And the command output should contain "Orphans: 0 candidate(s)"
-    And the command output should contain "Reverse orphans: 0 candidate(s)"
+    And the command output should contain "Orphans: 1 candidate(s), 1 removed"
+    And the command output should contain "Reverse orphans: 0 candidate(s), 0 removed"
 
 
   Scenario: administrator runs clean-orphaned-grants on a space with shares
-    Given these users have been created with default attributes:
-      | username |
-      | Brian    |
-    And user "Alice" has uploaded file with content "test content" to "testfile.txt"
-    And user "Alice" has sent the following resource share invitation:
-      | resource        | testfile.txt |
-      | space           | Personal     |
-      | sharee          | Brian        |
-      | shareType       | user         |
-      | permissionsRole | Viewer       |
     When the administrator runs clean-orphaned-grants in non-dry-run mode
     Then the command should be successful
     And the command output should contain "== Primary scan =="
     And the command output should contain "Summary:"
-    And the command output should contain "Orphans: 0 candidate(s)"
-    And the command output should contain "Reverse orphans: 0 candidate(s)"
+    And the command output should contain "Orphans: 1 candidate(s), 1 removed"
+    And the command output should contain "Reverse orphans: 0 candidate(s), 0 removed"

--- a/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
+++ b/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
@@ -14,7 +14,9 @@ Feature: clean orphaned grants using CLI
     Then the command should be successful
     And the command output should contain "== Pre-flight =="
     And the command output should contain "mode: dry run enabled"
+    And the command output should contain "target space(s)"
     And the command output should contain "== Primary scan =="
+    And the command output should contain "Summary:"
     And the command output should contain "Dry run mode: no grants were modified"
     And the command output should contain "== Reverse orphan scan =="
 
@@ -23,6 +25,9 @@ Feature: clean orphaned grants using CLI
     When the administrator runs clean-orphaned-grants in non-dry-run mode
     Then the command should be successful
     And the command output should contain "mode: dry run disabled: grants may be changed"
+    And the command output should contain "Summary:"
+    And the command output should contain "Orphans: 0 candidate(s)"
+    And the command output should contain "Reverse orphans: 0 candidate(s)"
 
 
   Scenario: administrator runs clean-orphaned-grants with space-id filter
@@ -31,9 +36,35 @@ Feature: clean orphaned grants using CLI
     When the administrator runs clean-orphaned-grants for space "project1" owned by "Alice"
     Then the command should be successful
     And the command output should contain "scope: limiting scan to space"
+    And the command output should contain "1 target space(s)"
+    And the command output should contain "Summary:"
+    And the command output should contain "Orphans: 0 candidate(s)"
+    And the command output should contain "Reverse orphans: 0 candidate(s)"
 
 
   Scenario: administrator runs clean-orphaned-grants with force flag
     When the administrator runs clean-orphaned-grants with force flag
     Then the command should be successful
     And the command output should contain "flags: --force active"
+    And the command output should contain "Summary:"
+    And the command output should contain "Orphans: 0 candidate(s)"
+    And the command output should contain "Reverse orphans: 0 candidate(s)"
+
+
+  Scenario: administrator runs clean-orphaned-grants on a space with shares
+    Given these users have been created with default attributes:
+      | username |
+      | Brian    |
+    And user "Alice" has uploaded file with content "test content" to "testfile.txt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | testfile.txt |
+      | space           | Personal     |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Viewer       |
+    When the administrator runs clean-orphaned-grants in non-dry-run mode
+    Then the command should be successful
+    And the command output should contain "== Primary scan =="
+    And the command output should contain "Summary:"
+    And the command output should contain "Orphans: 0 candidate(s)"
+    And the command output should contain "Reverse orphans: 0 candidate(s)"

--- a/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
+++ b/tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature
@@ -9,18 +9,6 @@ Feature: clean orphaned grants using CLI
     And the administrator has configured service account credentials
 
 
-  Scenario: administrator runs clean-orphaned-grants in dry-run mode
-    When the administrator runs clean-orphaned-grants in dry-run mode
-    Then the command should be successful
-    And the command output should contain "== Pre-flight =="
-    And the command output should contain "mode: dry run enabled"
-    And the command output should contain "target space(s)"
-    And the command output should contain "== Primary scan =="
-    And the command output should contain "Summary:"
-    And the command output should contain "Dry run mode: no grants were modified"
-    And the command output should contain "== Reverse orphan scan =="
-
-
   Scenario: administrator runs clean-orphaned-grants in non-dry-run mode
     When the administrator runs clean-orphaned-grants in non-dry-run mode
     Then the command should be successful


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

Add acceptance tests proving the `clean-orphaned-grants` CLI command detects and removes orphaned share grants.

**New test scenarios (`tests/acceptance/features/cliCommands/cleanOrphanedGrants.feature`) 4 scenarios covering clean-orphaned-grants under different modes:**

| Scenario | Unique Assertion |
|----------|-----------------|
| non-dry-run mode | `"mode: dry run disabled: grants may be changed"` |
| space-id filter | `"scope: limiting scan to space"` + `"1 target space(s)"` |
| force flag | `"flags: --force active"` |
| on a space with shares | `"== Primary scan =="` |

All scenarios follow: create project space → upload → share → stop oCIS → orphan grant → start oCIS → run CLI → assert `"Orphans: 1 candidate(s), 1 removed"`.

### New step: `theShareGrantsForSpaceHaveBeenOrphaned`

### Orphan creation flow
Test creates orphaned grants by surgically modifying oCIS metadata on disk, so `clean-orphaned-grants` has real orphans to find:

1. **Stop oCIS** - server must be down before modifying blob files, otherwise writes may be lost or corrupted by the running process.

2. **Get space opaque ID** - space ID from Graph API is `storageId$opaqueId`; split on `$`, take second part (the actual space UUID). E.g. `cbc25bff-...$2b255be2-...` → `2b255be2-...`.

3. **Walk blob files** - iterate share-manager metadata blobs at:
   ocis-data/storage/metadata/spaces/js/{jsoncs3|oncs3}-share-manager-metadata/blobs/
Each blob is stored by full UUID, split into 4 hex directory levels + filename.
   Full UUID:   6c627973-37c8-4132-9d2b-a552d315efcd
                ├─┬─┬─┬─┴──────────────────────────┘
   Blob path:  blobs/6c/62/79/73/-37c8-4132-9d2b-a552d315efcd
The first 8 hex chars (`6c627973`) become 4 directory levels (`6c/62/79/73/`). The remaining UUID portion (including first hyphen) is the filename.

4. **Match grant by space_id** - each blob contains JSON like:
```json
{
  "Shares": {
    "cbc25bff-...:2b255be2-...:c8102449-...": {
      "resource_id": {
        "space_id": "2b255be2-..."
      }
    }
  }
}
```
   If `resource_id.space_id` matches the target space UUID, change it to 00000000-0000-0000-0000-000000000000 (dead UUID - no space exists with this ID).

5. **Write blob back** - JSON-encode the modified blob and write to disk.

6. **Assert** - `Assert::assertTrue($found)` ensures at least one grant was actually modified.

7. **Start oCIS** - server restarts with the orphaned grant in metadata. After restart, the grant's space_id points to a non-existent space → clean-orphaned-grants reports it as orphan.

Only the matching grant entry is altered (surgical). No blobs deleted, no unrelated grants touched.
 

## Related Issue

- Fixes https://github.com/owncloud/ocis/issues/11989

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
