### PR TITLE
fix: more permissive redirect check

### DIFF
--- a/changelog/unreleased/bugfix-ensure-valid-redirect-uri.md
+++ b/changelog/unreleased/bugfix-ensure-valid-redirect-uri.md
@@ -1,0 +1,8 @@
+Bugfix: ensure the redirect URI for the IDP is valid
+
+The URI sent as redirect URI for the IDP will be validated in oCIS.
+Invalid URIs will return a 500 error. Note that this should never happen
+under normal circumstances.
+
+https://github.com/owncloud/ocis/pull/12444
+https://github.com/owncloud/ocis/pull/12479

--- a/services/idp/pkg/middleware/checkredirect.go
+++ b/services/idp/pkg/middleware/checkredirect.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
@@ -16,12 +17,10 @@ func CheckRedirect(cfg *config.Config, logger log.Logger) func(http.Handler) htt
 				return
 			}
 
-			for _, client := range cfg.Clients {
-				for _, redirect_uri := range client.RedirectURIs {
-					if uriString == redirect_uri {
-						next.ServeHTTP(w, r)
-						return
-					}
+			if parsedUri, ok := url.Parse(uriString); ok == nil {
+				if isValidRedirect(parsedUri, cfg) {
+					next.ServeHTTP(w, r)
+					return
 				}
 			}
 
@@ -29,4 +28,28 @@ func CheckRedirect(cfg *config.Config, logger log.Logger) func(http.Handler) htt
 			http.Error(w, "Unknown URI", http.StatusInternalServerError)
 		})
 	}
+}
+
+// urisMatch will check if both URL match. They match if they have the same
+// scheme, hostname and opaque; other elements (in particular the port)
+// are ignored. Note that we need to deal with URLs like
+// "[scheme:][//[userinfo@]host][/]path[?query][#fragment]"
+// and also like "scheme:opaque[?query][#fragment]"
+func urisMatch(u1, u2 *url.URL) bool {
+	return u1.Scheme == u2.Scheme && u1.Hostname() == u2.Hostname() && u1.Opaque == u2.Opaque
+}
+
+// isValidRedirect check if the u1 URL is part of the configured redirect URIs.
+// This will use the urisMatch for matching.
+func isValidRedirect(u1 *url.URL, cfg *config.Config) bool {
+	for _, client := range cfg.Clients {
+		for _, redirect_uri := range client.RedirectURIs {
+			if parsedRedirect, ok2 := url.Parse(redirect_uri); ok2 == nil {
+				if urisMatch(u1, parsedRedirect) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/services/idp/pkg/middleware/checkredirect.go
+++ b/services/idp/pkg/middleware/checkredirect.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 
@@ -17,7 +18,7 @@ func CheckRedirect(cfg *config.Config, logger log.Logger) func(http.Handler) htt
 				return
 			}
 
-			if parsedUri, ok := url.Parse(uriString); ok == nil {
+			if parsedUri, err := url.Parse(uriString); err == nil {
 				if isValidRedirect(parsedUri, cfg) {
 					next.ServeHTTP(w, r)
 					return
@@ -30,13 +31,31 @@ func CheckRedirect(cfg *config.Config, logger log.Logger) func(http.Handler) htt
 	}
 }
 
-// urisMatch will check if both URL match. They match if they have the same
-// scheme, hostname and opaque; other elements (in particular the port)
-// are ignored. Note that we need to deal with URLs like
+// urisMatch will check if both URL match. In case of localhost, only the port
+// will be ignored. Note that we need to deal with URLs like
 // "[scheme:][//[userinfo@]host][/]path[?query][#fragment]"
 // and also like "scheme:opaque[?query][#fragment]"
 func urisMatch(u1, u2 *url.URL) bool {
-	return u1.Scheme == u2.Scheme && u1.Hostname() == u2.Hostname() && u1.Opaque == u2.Opaque
+	if isLocalhost(u1) && isLocalhost(u2) {
+		copyu1 := *u1
+		copyu2 := *u2
+		// if there is a port, remove it from the URL
+		if copyu1.Port() != "" {
+			host1, _, _ := net.SplitHostPort(copyu1.Host)
+			copyu1.Host = host1
+		}
+		if copyu2.Port() != "" {
+			host2, _, _ := net.SplitHostPort(copyu2.Host)
+			copyu2.Host = host2
+		}
+		return copyu1.String() == copyu2.String()
+	}
+	return u1.String() == u2.String()
+}
+
+func isLocalhost(u1 *url.URL) bool {
+	hostname := u1.Hostname()
+	return hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1"
 }
 
 // isValidRedirect check if the u1 URL is part of the configured redirect URIs.
@@ -44,7 +63,7 @@ func urisMatch(u1, u2 *url.URL) bool {
 func isValidRedirect(u1 *url.URL, cfg *config.Config) bool {
 	for _, client := range cfg.Clients {
 		for _, redirect_uri := range client.RedirectURIs {
-			if parsedRedirect, ok2 := url.Parse(redirect_uri); ok2 == nil {
+			if parsedRedirect, err := url.Parse(redirect_uri); err == nil {
 				if urisMatch(u1, parsedRedirect) {
 					return true
 				}

--- a/services/idp/pkg/middleware/checkredirect.go
+++ b/services/idp/pkg/middleware/checkredirect.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
@@ -39,14 +40,22 @@ func urisMatch(u1, u2 *url.URL) bool {
 	if isLocalhost(u1) && isLocalhost(u2) {
 		copyu1 := *u1
 		copyu2 := *u2
-		// if there is a port, remove it from the URL
+		// If there is a port, remove it from the URL.
+		// Note that the SplitHostPort will remove the "[" and "]"
+		// from the ipv6 address, so we need to get them back.
 		if copyu1.Port() != "" {
 			host1, _, _ := net.SplitHostPort(copyu1.Host)
 			copyu1.Host = host1
+			if addr, err := netip.ParseAddr(host1); err == nil && addr.Is6() {
+				copyu1.Host = "[" + host1 + "]"
+			}
 		}
 		if copyu2.Port() != "" {
 			host2, _, _ := net.SplitHostPort(copyu2.Host)
 			copyu2.Host = host2
+			if addr, err := netip.ParseAddr(host2); err == nil && addr.Is6() {
+				copyu2.Host = "[" + host2 + "]"
+			}
 		}
 		return copyu1.String() == copyu2.String()
 	}

--- a/services/idp/pkg/middleware/checkredirect_test.go
+++ b/services/idp/pkg/middleware/checkredirect_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
+)
+
+var _ = Describe("check redirect", func() {
+	clients := []config.Client{
+		// just set the ID and RedirectURIs, no need for more at the moment
+		config.Client{
+			ID:           "web1",
+			RedirectURIs: []string{"https://good.server.prv/", "https://good.server.prv/oidc-callback.html"},
+		},
+		config.Client{
+			ID:           "web2",
+			RedirectURIs: []string{"https://another.server.prv:6767/", "https://another.server.prv:6767/oidc-callback.html"},
+		},
+		config.Client{
+			ID:           "custom_scheme1",
+			RedirectURIs: []string{"oc://custom.server/"},
+		},
+		config.Client{
+			ID:           "custom_scheme2",
+			RedirectURIs: []string{"ios://ios.custom.server/"},
+		},
+		config.Client{
+			ID:           "localhost1",
+			RedirectURIs: []string{"http://localhost/"},
+		},
+		config.Client{
+			ID:           "with_opaque",
+			RedirectURIs: []string{"app:open?path=/personal/folder"},
+		},
+	}
+	cfg := &config.Config{
+		Clients: clients,
+	}
+
+	DescribeTable("is URL allowed",
+		func(input string, status int) {
+			req, _ := http.NewRequest(http.MethodGet, "https://demo.hidden.missing.server.prv/", nil)
+			values := req.URL.Query()
+			values.Add("redirect_uri", input)
+			req.URL.RawQuery = values.Encode()
+
+			rr := httptest.NewRecorder()
+			middle := CheckRedirect(cfg, log.NopLogger())
+			handler := middle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			handler.ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(status))
+		},
+		Entry("https web", "https://good.server.prv/oidc-callback.html", http.StatusOK),
+		Entry("https web port", "https://another.server.prv:6767/oidc-callback.html", http.StatusOK),
+		Entry("http web", "http://good.server.prv/oidc-callback.html", http.StatusInternalServerError),
+		Entry("wrong web", "https://nonexisting.server.prv/", http.StatusInternalServerError),
+		Entry("wrong web path", "https://nonexisting.server.prv/very-wrong", http.StatusInternalServerError),
+		Entry("wrong web port", "https://good.server.prv:12345/oidc-callback.html", http.StatusInternalServerError),
+		Entry("android", "oc://custom.server/", http.StatusOK),
+		Entry("ios", "ios://ios.custom.server/", http.StatusOK),
+		Entry("localhost", "http://localhost/", http.StatusOK),
+		Entry("localhost port", "http://localhost:51515/", http.StatusOK),
+		Entry("localhost wrong scheme", "https://localhost:51515/", http.StatusInternalServerError),
+		Entry("opaque", "app:open?path=/personal/folder", http.StatusOK),
+	)
+})

--- a/services/idp/pkg/middleware/checkredirect_test.go
+++ b/services/idp/pkg/middleware/checkredirect_test.go
@@ -32,7 +32,7 @@ var _ = Describe("check redirect", func() {
 		},
 		config.Client{
 			ID:           "localhost1",
-			RedirectURIs: []string{"http://localhost/"},
+			RedirectURIs: []string{"http://localhost/", "http://127.0.0.1/", "http://[::1]/"},
 		},
 		config.Client{
 			ID:           "with_opaque",
@@ -60,6 +60,7 @@ var _ = Describe("check redirect", func() {
 		},
 		Entry("https web", "https://good.server.prv/oidc-callback.html", http.StatusOK),
 		Entry("https web port", "https://another.server.prv:6767/oidc-callback.html", http.StatusOK),
+		Entry("https web wrong path", "https://good.server.prv/evil", http.StatusInternalServerError),
 		Entry("http web", "http://good.server.prv/oidc-callback.html", http.StatusInternalServerError),
 		Entry("wrong web", "https://nonexisting.server.prv/", http.StatusInternalServerError),
 		Entry("wrong web path", "https://nonexisting.server.prv/very-wrong", http.StatusInternalServerError),
@@ -68,6 +69,11 @@ var _ = Describe("check redirect", func() {
 		Entry("ios", "ios://ios.custom.server/", http.StatusOK),
 		Entry("localhost", "http://localhost/", http.StatusOK),
 		Entry("localhost port", "http://localhost:51515/", http.StatusOK),
+		Entry("local addr", "http://127.0.0.1/", http.StatusOK),
+		Entry("local addr port", "http://127.0.0.1:51515/", http.StatusOK),
+		Entry("ip6 local addr", "http://[::1]/", http.StatusOK),
+		Entry("ip6 local addr port", "http://[::1]:51515/", http.StatusOK),
+		Entry("userinfo spoof", "http://localhost:8080@evil.com/", http.StatusInternalServerError),
 		Entry("localhost wrong scheme", "https://localhost:51515/", http.StatusInternalServerError),
 		Entry("opaque", "app:open?path=/personal/folder", http.StatusOK),
 	)

--- a/services/idp/pkg/middleware/middleware_suite_test.go
+++ b/services/idp/pkg/middleware/middleware_suite_test.go
@@ -1,0 +1,13 @@
+package middleware_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMiddleware(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IDP Middleware Suite")
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
There were problems with the redirect check with the desktop client because the check was too strict. Desktop client uses a random port on localhost, which was preventing a successful login from the desktop client.
The check is now more permissive in order to fix the issue.

## Related Issue
https://github.com/owncloud/ocis/issues/12474

## Motivation and Context
Desktop must login

## How Has This Been Tested?
Manually tested. Both web and desktop client can login.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
