### PR TITLE
[tests-only][full-ci] test: add oc:spaceid to REPORT response acceptance tests

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -4642,6 +4642,14 @@ class SpacesContext implements Context {
 						'wrong "remote-item-id" in the response',
 					);
 					break;
+				case "oc:spaceid":
+					$expectedValue = GraphHelper::jsonSchemaRegexToPureRegex($expectedValue);
+					Assert::assertMatchesRegularExpression(
+						$expectedValue,
+						$actualValue,
+						'wrong "spaceid" in the response',
+					);
+					break;
 				default:
 					Assert::assertEquals($expectedValue, $actualValue, "wrong '$itemToFind' in the response");
 					break;

--- a/tests/acceptance/features/apiContract/sharesReport.feature
+++ b/tests/acceptance/features/apiContract/sharesReport.feature
@@ -35,6 +35,7 @@ Feature: REPORT request to Shares space
       | d:getcontenttype  | httpd/unix-directory |
       | oc:permissions    | S                    |
       | oc:remote-item-id | %file_id_pattern%    |
+      | oc:spaceid        | %space_id_pattern%   |
     Examples:
       | dav-path-version |
       | old              |
@@ -50,15 +51,16 @@ Feature: REPORT request to Shares space
     And the following headers should match these regular expressions
       | X-Request-Id | %request_id_pattern% |
     And as user "Brian" the REPORT response should contain a resource "frodo.txt" with these key and value pairs:
-      | key                | value             |
-      | oc:fileid          | %file_id_pattern% |
-      | oc:file-parent     | %file_id_pattern% |
-      | oc:shareroot       | /folderMain       |
-      | oc:name            | frodo.txt         |
-      | d:getcontenttype   | text/plain        |
-      | oc:permissions     | S                 |
-      | d:getcontentlength | 34                |
-      | oc:remote-item-id  | %file_id_pattern% |
+      | key                | value              |
+      | oc:fileid          | %file_id_pattern%  |
+      | oc:file-parent     | %file_id_pattern%  |
+      | oc:shareroot       | /folderMain        |
+      | oc:name            | frodo.txt          |
+      | d:getcontenttype   | text/plain         |
+      | oc:permissions     | S                  |
+      | d:getcontentlength | 34                 |
+      | oc:remote-item-id  | %file_id_pattern%  |
+      | oc:spaceid         | %space_id_pattern% |
     Examples:
       | dav-path-version |
       | old              |
@@ -112,17 +114,19 @@ Feature: REPORT request to Shares space
       | oc:permissions    | SMX                  |
       | oc:size           | 14                   |
       | oc:remote-item-id | %file_id_pattern%    |
+      | oc:spaceid        | %space_id_pattern%   |
     When user "Brian" searches for "secure.txt" using the WebDAV API
     And the following headers should match these regular expressions
       | X-Request-Id | %request_id_pattern% |
     Then the HTTP status code should be "207"
     And as user "Brian" the REPORT response should contain a resource "secure.txt" with these key and value pairs:
-      | key                | value         |
-      | oc:shareroot       | /secureFolder |
-      | oc:name            | secure.txt    |
-      | d:getcontenttype   | text/plain    |
-      | oc:permissions     | SX            |
-      | d:getcontentlength | 14            |
+      | key                | value              |
+      | oc:shareroot       | /secureFolder      |
+      | oc:name            | secure.txt         |
+      | d:getcontenttype   | text/plain         |
+      | oc:permissions     | SX                 |
+      | d:getcontentlength | 14                 |
+      | oc:spaceid         | %space_id_pattern% |
     Examples:
       | dav-path-version |
       | old              |
@@ -146,12 +150,13 @@ Feature: REPORT request to Shares space
     And the following headers should match these regular expressions
       | X-Request-Id | %request_id_pattern% |
     And as user "Brian" the REPORT response should contain a resource "secure.txt" with these key and value pairs:
-      | key                | value       |
-      | oc:shareroot       | /secure.txt |
-      | oc:name            | secure.txt  |
-      | d:getcontenttype   | text/plain  |
-      | oc:permissions     | SMX         |
-      | d:getcontentlength | 14          |
+      | key                | value              |
+      | oc:shareroot       | /secure.txt        |
+      | oc:name            | secure.txt         |
+      | d:getcontenttype   | text/plain         |
+      | oc:permissions     | SMX                |
+      | d:getcontentlength | 14                 |
+      | oc:spaceid         | %space_id_pattern% |
     Examples:
       | dav-path-version |
       | old              |

--- a/tests/acceptance/features/apiContract/spacesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesReport.feature
@@ -22,13 +22,14 @@ Feature: REPORT request to project space
     And the following headers should match these regular expressions
       | X-Request-Id | %request_id_pattern% |
     And as user "Alice" the REPORT response should contain a resource "testFile.txt" with these key and value pairs:
-      | key                | value             |
-      | oc:fileid          | %file_id_pattern% |
-      | oc:file-parent     | %file_id_pattern% |
-      | oc:name            | testFile.txt      |
-      | d:getcontenttype   | text/plain        |
-      | oc:permissions     | RDNVW             |
-      | d:getcontentlength | 12                |
+      | key                | value              |
+      | oc:fileid          | %file_id_pattern%  |
+      | oc:file-parent     | %file_id_pattern%  |
+      | oc:name            | testFile.txt       |
+      | d:getcontenttype   | text/plain         |
+      | oc:permissions     | RDNVW              |
+      | d:getcontentlength | 12                 |
+      | oc:spaceid         | %space_id_pattern% |
 
 
   Scenario: check the response of the searched sub-file
@@ -48,6 +49,7 @@ Feature: REPORT request to project space
       | d:getcontenttype   | text/plain          |
       | oc:permissions     | RDNVW               |
       | d:getcontentlength | 12                  |
+      | oc:spaceid         | %space_id_pattern%  |
 
 
   Scenario: check the response of the searched folder
@@ -66,6 +68,7 @@ Feature: REPORT request to project space
       | d:getcontenttype | httpd/unix-directory |
       | oc:permissions   | RDNVCK               |
       | oc:size          | 0                    |
+      | oc:spaceid       | %space_id_pattern%   |
 
 
   Scenario: check the response of the searched sub-folder
@@ -85,3 +88,4 @@ Feature: REPORT request to project space
       | d:getcontenttype | httpd/unix-directory |
       | oc:permissions   | RDNVCK               |
       | oc:size          | 0                    |
+      | oc:spaceid       | %space_id_pattern%   |

--- a/tests/acceptance/features/apiContract/spacesSharesReport.feature
+++ b/tests/acceptance/features/apiContract/spacesSharesReport.feature
@@ -38,6 +38,7 @@ Feature: Report test
       | oc:permissions    | S                    |
       | oc:size           | 12                   |
       | oc:remote-item-id | %file_id_pattern%    |
+      | oc:spaceid        | %space_id_pattern%   |
     Examples:
       | dav-path-version |
       | old              |
@@ -68,6 +69,7 @@ Feature: Report test
       | oc:permissions     | SD                  |
       | d:getcontentlength | 12                  |
       | oc:remote-item-id  | %file_id_pattern%   |
+      | oc:spaceid         | %space_id_pattern%  |
     Examples:
       | dav-path-version |
       | old              |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Add `oc:spaceid` assertions to REPORT response acceptance tests to cover the server-side change from PR #12028, which added `spaceid` to WebDAV REPORT search responses.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
