### PR TITLE
feat(ocis): [OCISDEV-877] add clean-corrupt-public-shares command

### DIFF
--- a/changelog/unreleased/clean-corrupt-public-shares.md
+++ b/changelog/unreleased/clean-corrupt-public-shares.md
@@ -1,0 +1,15 @@
+Enhancement: Add `ocis shares clean-corrupt-public-shares` maintenance command
+
+A single public-share entry with a nil/empty `resource_id` makes the json
+public-share manager's `ListPublicShares` panic with a nil-pointer dereference.
+Because the manager reads all entries and filters them in memory, that one bad
+entry poisons the endpoint for the whole tenant: every Members/permissions panel
+load and every password-protected link creation fails.
+
+The new `ocis shares clean-corrupt-public-shares` command detects and removes
+such corrupt entries. It reads the raw persistence (so it never triggers the
+panic itself) and writes back through the same metadata storage path the manager
+uses, recomputing blob size, mtime and etag automatically. It defaults to
+`--dry-run` and supports the `jsoncs3` and `json` public-share drivers.
+
+https://github.com/owncloud/ocis/pull/12494

--- a/ocis/pkg/command/public_shares.go
+++ b/ocis/pkg/command/public_shares.go
@@ -1,0 +1,196 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	"github.com/owncloud/reva/v2/pkg/publicshare/manager/json/persistence"
+	pcs3 "github.com/owncloud/reva/v2/pkg/publicshare/manager/json/persistence/cs3"
+	pfile "github.com/owncloud/reva/v2/pkg/publicshare/manager/json/persistence/file"
+	metadatacs3 "github.com/owncloud/reva/v2/pkg/storage/utils/metadata"
+	"github.com/owncloud/reva/v2/pkg/utils"
+	"github.com/urfave/cli/v2"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/config"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/parser"
+	mregistry "github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	sharingparser "github.com/owncloud/ocis/v2/services/sharing/pkg/config/parser"
+)
+
+// cleanCorruptPublicSharesCmd removes corrupt public-share entries (those with a
+// missing/nil resource_id) from the public-share manager persistence.
+//
+// Background: a single public-share row with a nil resource_id makes the json
+// public-share manager's ListPublicShares panic with a nil-pointer dereference,
+// because it builds a cache key from resource_id without a nil-check. As the
+// manager reads all rows and filters in memory, that one bad row poisons the
+// endpoint for the whole tenant: every Members/permissions panel load and every
+// link-with-password creation fails. This command removes the offending rows so
+// affected deployments can be unblocked until the code fix is rolled out.
+//
+// It reads the raw persistence (it does NOT call ListPublicShares, so it never
+// hits the panic) and writes back through the same metadata storage path the
+// manager uses, so blob size, mtime and etag are recomputed automatically and no
+// on-disk metadata surgery is required.
+func cleanCorruptPublicSharesCmd(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name:  "clean-corrupt-public-shares",
+		Usage: `Remove corrupt public-share entries (nil resource_id) that crash ListPublicShares.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Value: true,
+				Usage: "Only report corrupt entries, do not modify anything",
+			},
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Usage:   "Verbose logging enabled",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			if err := parser.ParseConfig(cfg, true); err != nil {
+				return configlog.ReturnError(err)
+			}
+			cfg.Sharing.Commons = cfg.Commons
+			return configlog.ReturnError(sharingparser.ParseConfig(cfg.Sharing))
+		},
+		Action: func(c *cli.Context) error {
+			return cleanCorruptPublicShares(c, cfg)
+		},
+	}
+}
+
+func cleanCorruptPublicShares(c *cli.Context, cfg *config.Config) error {
+	dryRun := c.Bool("dry-run")
+	verbose := c.Bool("verbose")
+
+	// Initialize the service registry so the jsoncs3 driver can resolve the
+	// storage-system provider via service discovery.
+	_ = mregistry.GetRegistry()
+
+	driver := cfg.Sharing.PublicSharingDriver
+	p, err := publicSharePersistence(driver, cfg)
+	if err != nil {
+		return configlog.ReturnError(err)
+	}
+
+	ctx := context.Background()
+	if err := p.Init(ctx); err != nil {
+		return configlog.ReturnError(fmt.Errorf("failed to initialize public-share persistence: %w", err))
+	}
+
+	db, err := p.Read(ctx)
+	if err != nil {
+		return configlog.ReturnError(fmt.Errorf("failed to read public shares: %w", err))
+	}
+
+	if dryRun {
+		fmt.Print("Dry run mode enabled: no entries will be removed\n\n")
+	}
+	fmt.Printf("Scanning %d public-share entries (driver=%s)\n", len(db), driver)
+
+	corrupt := findCorruptPublicShares(db)
+	for _, f := range corrupt {
+		fmt.Printf("  CORRUPT id=%s token=%s: %s\n", f.ID, f.Token, f.Reason)
+	}
+	if verbose {
+		for id, raw := range db {
+			share, ok := decodePublicShare(raw)
+			if ok && share.GetResourceId() != nil && share.GetResourceId().GetStorageId() != "" {
+				fmt.Printf("  ok id=%s token=%s resource_id=%s\n", id, share.GetToken(), share.GetResourceId().GetOpaqueId())
+			}
+		}
+	}
+
+	if len(corrupt) == 0 {
+		fmt.Println("\nNo corrupt public-share entries found. Nothing to do.")
+		return nil
+	}
+
+	if dryRun {
+		fmt.Printf("\nDry run: found %d corrupt entr(y/ies). Re-run with --dry-run=false to remove them.\n", len(corrupt))
+		return nil
+	}
+
+	for _, f := range corrupt {
+		delete(db, f.ID)
+	}
+	if err := p.Write(ctx, db); err != nil {
+		return configlog.ReturnError(fmt.Errorf("failed to write public shares: %w", err))
+	}
+
+	fmt.Printf("\nRemoved %d corrupt public-share entr(y/ies). %d entr(y/ies) remaining.\n", len(corrupt), len(db))
+	return nil
+}
+
+// corruptShare identifies a public-share persistence entry that would crash the
+// json public-share manager (or that the manager cannot decode at all).
+type corruptShare struct {
+	ID     string
+	Token  string
+	Reason string
+}
+
+// findCorruptPublicShares returns the entries that must be removed: those whose
+// stored value is not a decodable public-share record, and those with a nil or
+// empty resource_id (the condition that makes ListPublicShares panic).
+func findCorruptPublicShares(db persistence.PublicShares) []corruptShare {
+	var out []corruptShare
+	for id, raw := range db {
+		share, ok := decodePublicShare(raw)
+		if !ok {
+			out = append(out, corruptShare{ID: id, Reason: "entry is not a valid public-share record"})
+			continue
+		}
+		if share.GetResourceId() == nil || share.GetResourceId().GetStorageId() == "" {
+			out = append(out, corruptShare{ID: id, Token: share.GetToken(), Reason: "nil/empty resource_id"})
+		}
+	}
+	return out
+}
+
+// decodePublicShare extracts the cs3 PublicShare from a raw persistence entry.
+// The persistence stores each entry as map{"share": <json-encoded-PublicShare>, "password": <string>}.
+// It returns ok=false when the entry does not match that shape.
+func decodePublicShare(raw interface{}) (*link.PublicShare, bool) {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	s, ok := m["share"].(string)
+	if !ok {
+		return nil, false
+	}
+	var ps link.PublicShare
+	if err := utils.UnmarshalJSONToProtoV1([]byte(s), &ps); err != nil {
+		return nil, false
+	}
+	return &ps, true
+}
+
+// publicSharePersistence builds the persistence backend for the configured public-share
+// driver, mirroring how reva's json public-share manager constructs it. Only the file-backed
+// ("json") and cs3-backed ("jsoncs3") drivers store data in a way this command can repair.
+func publicSharePersistence(driver string, cfg *config.Config) (persistence.Persistence, error) {
+	switch driver {
+	case "jsoncs3":
+		d := cfg.Sharing.PublicSharingDrivers.JSONCS3
+		s, err := metadatacs3.NewCS3Storage(d.ProviderAddr, d.ProviderAddr, d.SystemUserID, d.SystemUserIDP, d.SystemUserAPIKey)
+		if err != nil {
+			return nil, err
+		}
+		return pcs3.New(s), nil
+	case "json":
+		file := cfg.Sharing.PublicSharingDrivers.JSON.File
+		if file == "" {
+			file = "/var/tmp/reva/publicshares"
+		}
+		return pfile.New(file), nil
+	default:
+		return nil, errors.New("clean-corrupt-public-shares is only implemented for the 'jsoncs3' and 'json' public-share drivers, got: " + driver)
+	}
+}

--- a/ocis/pkg/command/public_shares_test.go
+++ b/ocis/pkg/command/public_shares_test.go
@@ -1,0 +1,166 @@
+package command
+
+import (
+	"testing"
+
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/owncloud/reva/v2/pkg/publicshare/manager/json/persistence"
+	"github.com/owncloud/reva/v2/pkg/utils"
+)
+
+// encodeEntry builds a persistence entry the same way the reva json public-share
+// manager does: map{"share": <json-encoded PublicShare>, "password": <string>}.
+func encodeEntry(t *testing.T, ps *link.PublicShare) map[string]interface{} {
+	t.Helper()
+	enc, err := utils.MarshalProtoV1ToJSON(ps)
+	if err != nil {
+		t.Fatalf("failed to marshal public share: %v", err)
+	}
+	return map[string]interface{}{
+		"share":    string(enc),
+		"password": "",
+	}
+}
+
+func validShare(id, token string) *link.PublicShare {
+	return &link.PublicShare{
+		Id:    &link.PublicShareId{OpaqueId: id},
+		Token: token,
+		ResourceId: &provider.ResourceId{
+			StorageId: "storage-1",
+			SpaceId:   "space-1",
+			OpaqueId:  "node-1",
+		},
+	}
+}
+
+func TestFindCorruptPublicShares(t *testing.T) {
+	t.Run("nil resource_id is corrupt", func(t *testing.T) {
+		ps := validShare("bad-nil", "tok-nil")
+		ps.ResourceId = nil
+		db := persistence.PublicShares{
+			"good":   encodeEntry(t, validShare("good", "tok-good")),
+			"bad-nil": encodeEntry(t, ps),
+		}
+
+		got := findCorruptPublicShares(db)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 corrupt entry, got %d (%v)", len(got), got)
+		}
+		if got[0].ID != "bad-nil" {
+			t.Errorf("expected corrupt id 'bad-nil', got %q", got[0].ID)
+		}
+		if got[0].Token != "tok-nil" {
+			t.Errorf("expected token 'tok-nil', got %q", got[0].Token)
+		}
+	})
+
+	t.Run("empty storage_id is corrupt", func(t *testing.T) {
+		ps := validShare("bad-empty", "tok-empty")
+		ps.ResourceId = &provider.ResourceId{StorageId: "", SpaceId: "s", OpaqueId: "o"}
+		db := persistence.PublicShares{
+			"bad-empty": encodeEntry(t, ps),
+		}
+
+		got := findCorruptPublicShares(db)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 corrupt entry, got %d", len(got))
+		}
+		if got[0].ID != "bad-empty" {
+			t.Errorf("expected corrupt id 'bad-empty', got %q", got[0].ID)
+		}
+	})
+
+	t.Run("undecodable entry is corrupt", func(t *testing.T) {
+		db := persistence.PublicShares{
+			"not-a-record":  "just a string",
+			"missing-share": map[string]interface{}{"password": ""},
+			"bad-json":      map[string]interface{}{"share": "{not json", "password": ""},
+		}
+
+		got := findCorruptPublicShares(db)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 corrupt entries, got %d (%v)", len(got), got)
+		}
+	})
+
+	t.Run("all valid yields none", func(t *testing.T) {
+		db := persistence.PublicShares{
+			"a": encodeEntry(t, validShare("a", "tok-a")),
+			"b": encodeEntry(t, validShare("b", "tok-b")),
+		}
+
+		got := findCorruptPublicShares(db)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 corrupt entries, got %d (%v)", len(got), got)
+		}
+	})
+
+	t.Run("empty db yields none", func(t *testing.T) {
+		if got := findCorruptPublicShares(persistence.PublicShares{}); len(got) != 0 {
+			t.Fatalf("expected 0 corrupt entries, got %d", len(got))
+		}
+	})
+
+	t.Run("only corrupt entries are removed, valid ones preserved", func(t *testing.T) {
+		bad := validShare("bad", "tok-bad")
+		bad.ResourceId = nil
+		db := persistence.PublicShares{
+			"keep-1": encodeEntry(t, validShare("keep-1", "tok-1")),
+			"bad":    encodeEntry(t, bad),
+			"keep-2": encodeEntry(t, validShare("keep-2", "tok-2")),
+		}
+
+		for _, f := range findCorruptPublicShares(db) {
+			delete(db, f.ID)
+		}
+
+		if len(db) != 2 {
+			t.Fatalf("expected 2 entries remaining, got %d", len(db))
+		}
+		if _, ok := db["bad"]; ok {
+			t.Error("corrupt entry 'bad' was not removed")
+		}
+		if _, ok := db["keep-1"]; !ok {
+			t.Error("valid entry 'keep-1' was removed")
+		}
+		if _, ok := db["keep-2"]; !ok {
+			t.Error("valid entry 'keep-2' was removed")
+		}
+	})
+}
+
+func TestDecodePublicShare(t *testing.T) {
+	t.Run("valid entry decodes", func(t *testing.T) {
+		entry := encodeEntry(t, validShare("x", "tok-x"))
+		ps, ok := decodePublicShare(entry)
+		if !ok {
+			t.Fatal("expected decode to succeed")
+		}
+		if ps.GetToken() != "tok-x" {
+			t.Errorf("expected token 'tok-x', got %q", ps.GetToken())
+		}
+		if ps.GetResourceId().GetStorageId() != "storage-1" {
+			t.Errorf("expected storage_id 'storage-1', got %q", ps.GetResourceId().GetStorageId())
+		}
+	})
+
+	t.Run("non-map entry fails", func(t *testing.T) {
+		if _, ok := decodePublicShare("not a map"); ok {
+			t.Error("expected decode to fail for non-map entry")
+		}
+	})
+
+	t.Run("missing share key fails", func(t *testing.T) {
+		if _, ok := decodePublicShare(map[string]interface{}{"password": ""}); ok {
+			t.Error("expected decode to fail when 'share' key is missing")
+		}
+	})
+
+	t.Run("invalid json fails", func(t *testing.T) {
+		if _, ok := decodePublicShare(map[string]interface{}{"share": "{broken"}); ok {
+			t.Error("expected decode to fail for invalid json")
+		}
+	})
+}

--- a/ocis/pkg/command/shares.go
+++ b/ocis/pkg/command/shares.go
@@ -66,6 +66,7 @@ func SharesCommand(cfg *config.Config) *cli.Command {
 			cleanupCmd(cfg),
 			cleanOrphanedGrantsCmd(cfg),
 			moveStuckUploadBlobsCmd(cfg),
+			cleanCorruptPublicSharesCmd(cfg),
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds an `ocis shares clean-corrupt-public-shares` maintenance command that removes public-share entries with a nil/empty `resource_id`.

Such an entry makes the json public-share manager's `ListPublicShares` panic with a nil-pointer dereference (it builds a cache key from `resource_id` without a nil-check). Because the manager reads **all** entries and filters them in memory, a single bad row poisons the endpoint for the whole tenant: every "Shared via link" listing and password-protected link creation fails.

The nil-check fix already exists in reva, but deployments running an older build need a way to unblock affected tenants until that fix rolls out. This command provides that.

## How it works

- Reads the raw persistence via `persistence.Read` — it does **not** call `ListPublicShares`, so it never hits the panic itself.
- Removes entries whose stored share has a nil/empty `resource_id` (or that cannot be decoded at all).
- Writes back through the same metadata storage path the manager uses, so blob size, mtime and etag are recomputed automatically (no on-disk metadata surgery).
- Defaults to `--dry-run=true`; supports the `jsoncs3` and `json` public-share drivers.

## Testing

- Unit tests for the corrupt-detection and decode logic (`public_shares_test.go`).
- Validated end-to-end on a local instance: reproduced the `ListPublicShares` panic by injecting a nil-`resource_id` row into the `jsoncs3` public-share metadata space, ran the command, and confirmed listing/creation recovered with no panics.

## Notes

- Related: OCISDEV-877

🤖 Generated with [Claude Code](https://claude.com/claude-code)