### PR TITLE
[tests-only][full-ci] test(cli): add blobstore get and check CLI tests

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1301,11 +1301,11 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets a blob from the blobstore using the CLI
+	 * @When the administrator tries to get a blob from the blobstore using the CLI
 	 *
 	 * @return void
 	 */
-	public function theAdministratorGetsABlobFromTheBlobstoreUsingTheCli(): void {
+	public function theAdministratorTriesToGetABlobFromTheBlobstoreUsingTheCli(): void {
 		$body = ["command" => "storage-users blobstore get"];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1277,4 +1277,50 @@ class CliContext implements Context {
 
 		Assert::assertTrue($found, "Could not find blob for space $spaceName ($spaceOpaqueId)");
 	}
+
+	/**
+	 * @When the administrator checks the blobstore using the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorChecksTheBlobstoreUsingTheCli(): void {
+		$body = ["command" => "storage-users blobstore check"];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator checks the blobstore with blob size :blobSize using the CLI
+	 *
+	 * @param string $blobSize
+	 *
+	 * @return void
+	 */
+	public function theAdministratorChecksTheBlobstoreWithBlobSizeUsingTheCli(string $blobSize): void {
+		$body = ["command" => "storage-users blobstore check --blob-size=$blobSize"];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator gets a blob from the blobstore using the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsABlobFromTheBlobstoreUsingTheCli(): void {
+		$body = ["command" => "storage-users blobstore get"];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator gets a non-existent blob from the blobstore using the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsANonExistentBlobFromTheBlobstoreUsingTheCli(): void {
+		$body = [
+			"command" => "storage-users blobstore get"
+				. " --blob-id=00000000-0000-0000-0000-000000000001"
+				. " --space-id=00000000-0000-0000-0000-000000000002",
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
 }

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1311,15 +1311,95 @@ class CliContext implements Context {
 	}
 
 	/**
-	 * @When the administrator gets a non-existent blob from the blobstore using the CLI
+	 * @When the administrator tries to get a non-existent blob from the blobstore using the CLI
 	 *
 	 * @return void
 	 */
-	public function theAdministratorGetsANonExistentBlobFromTheBlobstoreUsingTheCli(): void {
+	public function theAdministratorTriesToGetANonExistentBlobFromTheBlobstoreUsingTheCli(): void {
 		$body = [
 			"command" => "storage-users blobstore get"
 				. " --blob-id=00000000-0000-0000-0000-000000000001"
 				. " --space-id=00000000-0000-0000-0000-000000000002",
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * Finds the most recently written blob in the storage-users blobstore.
+	 * Scoped to the users storage root to avoid picking blobs from metadata storage.
+	 *
+	 * @return string absolute path to a real blob file
+	 */
+	private function findNewestBlobPath(): string {
+		$storageRoot = $this->featureContext->getStorageUsersRoot();
+		$blobDirs = \glob($storageRoot . '/spaces/*/*/blobs', GLOB_ONLYDIR) ?: [];
+		Assert::assertNotEmpty($blobDirs, "No blobstore directory found under $storageRoot");
+
+		$newestPath = null;
+		$newestMtime = 0;
+		foreach ($blobDirs as $blobsDir) {
+			$iterator = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($blobsDir, \RecursiveDirectoryIterator::SKIP_DOTS),
+			);
+			foreach ($iterator as $file) {
+				if (!$file->isFile()) {
+					continue;
+				}
+				$mtime = $file->getMTime();
+				if ($mtime > $newestMtime) {
+					$newestMtime = $mtime;
+					$newestPath = $file->getPathname();
+				}
+			}
+		}
+
+		Assert::assertNotNull($newestPath, "No blob file found under $storageRoot");
+		return $newestPath;
+	}
+
+	/**
+	 * @When the administrator gets a blob from the blobstore using the --path flag via the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsABlobFromTheBlobstoreUsingThePathFlagViaTheCli(): void {
+		$blobPath = $this->findNewestBlobPath();
+		$body = ["command" => "storage-users blobstore get --path=" . $blobPath];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator tries to get a blob from the blobstore with path :path using the CLI
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function theAdministratorTriesToGetABlobWithPathUsingTheCli(string $path): void {
+		$body = ["command" => "storage-users blobstore get --path=" . $path];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator gets a blob from the blobstore by ID using the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsABlobFromTheBlobstoreByIdUsingTheCli(): void {
+		$blobPath = $this->findNewestBlobPath();
+
+		// The blob path is "<root>/spaces/<pathifiedSpaceID>/blobs/<pathifiedBlobID>".
+		// The raw space/blob IDs are recovered by stripping the pathify separators,
+		// which is exactly what the CLI's depathify does on the way back in.
+		[, $rest] = \explode('/spaces/', $blobPath, 2);
+		[$pathifiedSpaceID, $pathifiedBlobID] = \explode('/blobs/', $rest, 2);
+		$spaceId = \str_replace('/', '', $pathifiedSpaceID);
+		$blobId = \str_replace('/', '', $pathifiedBlobID);
+
+		$body = [
+			"command" => "storage-users blobstore get"
+				. " --blob-id=" . $blobId
+				. " --space-id=" . $spaceId,
 		];
 		$this->featureContext->setResponse(CliHelper::runCommand($body));
 	}

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -756,10 +756,10 @@ class CliContext implements Context {
 		$expectedMessage = str_replace("\r\n", "\n", trim($content->getRaw()));
 		$actualMessage = str_replace("\r\n", "\n", trim($response->message ?? ''));
 
-		Assert::assertSame(
+		Assert::assertStringContainsString(
 			$expectedMessage,
 			$actualMessage,
-			"Expected cli output to be $expectedMessage but found $actualMessage",
+			"Expected cli output to contain '$expectedMessage', but got: '$actualMessage'",
 		);
 	}
 

--- a/tests/acceptance/features/cliCommands/blobstore.feature
+++ b/tests/acceptance/features/cliCommands/blobstore.feature
@@ -11,6 +11,12 @@ Feature: blobstore check and get via CLI
     And the command output should contain "Blobstore check successful."
 
 
+  Scenario: administrator checks the blobstore with a valid blob size
+    When the administrator checks the blobstore with blob size "1KB" using the CLI
+    Then the command should be successful
+    And the command output should contain "Blobstore check successful."
+
+
   Scenario: administrator checks the blobstore with an invalid blob size
     When the administrator checks the blobstore with blob size "abc" using the CLI
     Then the command should be unsuccessful
@@ -24,6 +30,34 @@ Feature: blobstore check and get via CLI
 
 
   Scenario: administrator tries to get a non-existent blob from the blobstore
-    When the administrator gets a non-existent blob from the blobstore using the CLI
+    When the administrator tries to get a non-existent blob from the blobstore using the CLI
     Then the command should be unsuccessful
     And the command output should contain "download failed: could not read blob"
+
+  @skipOnOcis-S3NG-Storage
+  Scenario: administrator gets a blob from the blobstore using the --path flag
+    Given user "Alice" has been created with default attributes
+    And user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When the administrator gets a blob from the blobstore using the --path flag via the CLI
+    Then the command should be successful
+    And the command output should contain "Download: OK"
+
+  @skipOnOcis-S3NG-Storage
+  Scenario: administrator gets a blob from the blobstore by ID
+    Given user "Alice" has been created with default attributes
+    And user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"
+    When the administrator gets a blob from the blobstore by ID using the CLI
+    Then the command should be successful
+    And the command output should contain "Download: OK"
+
+
+  Scenario: administrator tries to get a blob with a malformed ocis blob path
+    When the administrator tries to get a blob from the blobstore with path "/spaces/b1/9ec764-/nope" using the CLI
+    Then the command should be unsuccessful
+    And the command output should contain "missing /blobs/ segment"
+
+
+  Scenario: administrator tries to get a blob with a malformed s3ng blob path
+    When the administrator tries to get a blob from the blobstore with path "notas3ngpath" using the CLI
+    Then the command should be unsuccessful
+    And the command output should contain "expected <spaceID>/<pathified_blobID>"

--- a/tests/acceptance/features/cliCommands/blobstore.feature
+++ b/tests/acceptance/features/cliCommands/blobstore.feature
@@ -5,17 +5,8 @@ Feature: blobstore check and get via CLI
   So that I can ensure my storage backend is working correctly
 
 
-  Scenario: administrator checks the blobstore with default blob size
+  Scenario: administrator checks the blobstore
     When the administrator checks the blobstore using the CLI
-    Then the command should be successful
-    And the command output should contain "Upload: OK"
-    And the command output should contain "Download and verify: OK"
-    And the command output should contain "Delete: OK"
-    And the command output should contain "Blobstore check successful."
-
-
-  Scenario: administrator checks the blobstore with a custom blob size
-    When the administrator checks the blobstore with blob size "1KB" using the CLI
     Then the command should be successful
     And the command output should contain "Blobstore check successful."
 
@@ -27,7 +18,7 @@ Feature: blobstore check and get via CLI
 
 
   Scenario: administrator tries to get a blob without providing required flags
-    When the administrator gets a blob from the blobstore using the CLI
+    When the administrator tries to get a blob from the blobstore using the CLI
     Then the command should be unsuccessful
     And the command output should contain "either --path or both --blob-id and --space-id must be set"
 

--- a/tests/acceptance/features/cliCommands/blobstore.feature
+++ b/tests/acceptance/features/cliCommands/blobstore.feature
@@ -1,0 +1,38 @@
+@env-config
+Feature: blobstore check and get via CLI
+  As an administrator
+  I want to verify blobstore connectivity
+  So that I can ensure my storage backend is working correctly
+
+
+  Scenario: administrator checks the blobstore with default blob size
+    When the administrator checks the blobstore using the CLI
+    Then the command should be successful
+    And the command output should contain "Upload: OK"
+    And the command output should contain "Download and verify: OK"
+    And the command output should contain "Delete: OK"
+    And the command output should contain "Blobstore check successful."
+
+
+  Scenario: administrator checks the blobstore with a custom blob size
+    When the administrator checks the blobstore with blob size "1KB" using the CLI
+    Then the command should be successful
+    And the command output should contain "Blobstore check successful."
+
+
+  Scenario: administrator checks the blobstore with an invalid blob size
+    When the administrator checks the blobstore with blob size "abc" using the CLI
+    Then the command should be unsuccessful
+    And the command output should contain "invalid --blob-size"
+
+
+  Scenario: administrator tries to get a blob without providing required flags
+    When the administrator gets a blob from the blobstore using the CLI
+    Then the command should be unsuccessful
+    And the command output should contain "either --path or both --blob-id and --space-id must be set"
+
+
+  Scenario: administrator tries to get a non-existent blob from the blobstore
+    When the administrator gets a non-existent blob from the blobstore using the CLI
+    Then the command should be unsuccessful
+    And the command output should contain "download failed: could not read blob"

--- a/tests/acceptance/features/cliCommands/blobstore.feature
+++ b/tests/acceptance/features/cliCommands/blobstore.feature
@@ -8,12 +8,18 @@ Feature: blobstore check and get via CLI
   Scenario: administrator checks the blobstore
     When the administrator checks the blobstore using the CLI
     Then the command should be successful
+    And the command output should contain "Upload: OK"
+    And the command output should contain "Download and verify: OK"
+    And the command output should contain "Delete: OK"
     And the command output should contain "Blobstore check successful."
 
 
   Scenario: administrator checks the blobstore with a valid blob size
     When the administrator checks the blobstore with blob size "1KB" using the CLI
     Then the command should be successful
+    And the command output should contain "Upload: OK"
+    And the command output should contain "Download and verify: OK"
+    And the command output should contain "Delete: OK"
     And the command output should contain "Blobstore check successful."
 
 

--- a/tests/acceptance/features/cliCommands/blobstore.feature
+++ b/tests/acceptance/features/cliCommands/blobstore.feature
@@ -8,19 +8,25 @@ Feature: blobstore check and get via CLI
   Scenario: administrator checks the blobstore
     When the administrator checks the blobstore using the CLI
     Then the command should be successful
-    And the command output should contain "Upload: OK"
-    And the command output should contain "Download and verify: OK"
-    And the command output should contain "Delete: OK"
-    And the command output should contain "Blobstore check successful."
+    And the CLI response should contain the following message:
+      """
+      Upload: OK
+      Download and verify: OK
+      Delete: OK
+      Blobstore check successful.
+      """
 
 
   Scenario: administrator checks the blobstore with a valid blob size
     When the administrator checks the blobstore with blob size "1KB" using the CLI
     Then the command should be successful
-    And the command output should contain "Upload: OK"
-    And the command output should contain "Download and verify: OK"
-    And the command output should contain "Delete: OK"
-    And the command output should contain "Blobstore check successful."
+    And the CLI response should contain the following message:
+      """
+      Upload: OK
+      Download and verify: OK
+      Delete: OK
+      Blobstore check successful.
+      """
 
 
   Scenario: administrator checks the blobstore with an invalid blob size


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adds acceptance tests for the `storage-users blobstore check` and `storage-users blobstore get` CLI commands introduced in #12102.
 
**New test scenarios** (`tests/acceptance/features/cliCommands/blobstore.feature`):
 
| Scenario | Assertion |
|----------|-----------|
| check with default size | full round-trip: upload, download+verify, delete |
| check with valid blob size | `--blob-size=1KB` accepted, round-trip passes |
| check with invalid size | `--blob-size=abc` rejected with `invalid --blob-size` |
| get without flags | error: `either --path or both --blob-id and --space-id must be set` |
| get non-existent blob | error: `download failed: could not read blob` |
| get with `--path` flag (happy path) | resolves a real blob from disk, downloads successfully |
| get by ID (happy path) | resolves blob/space IDs from disk, downloads successfully |
| get with malformed OCIS blob path | error: `missing /blobs/ segment` |
| get with malformed S3NG blob path | error: `expected <spaceID>/<pathified_blobID>` |
 
**Key details:**
 
- The `--path` and by-ID scenarios are tagged `@skipOnOcis-S3NG-Storage` because they walk the on-disk blobstore layout (`storage/users/spaces/*/*/blobs/`). The S3NG driver stores blobs in S3 buckets with no local filesystem path to walk, so these tests only run against the OCIS driver.
- A new `findNewestBlobPath()` helper walks the filesystem to find the most recently written blob - both the `--path` and by-ID step defs share this helper (by-ID strips the pathified format to recover raw IDs).
- The glob was scoped to `getStorageUsersRoot()` to avoid picking blobs from metadata storage (shares, activities, etc.) which are written after the user content blob and would cause false test failures.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
