### PR TITLE
[tests-only][full-ci]: Add search operator test coverage for metadata queries

### DIFF
--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -406,7 +406,7 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 - [apiSearchContent/metadataSerch.feature:53](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/metadataSerch.feature#L53)
 - [apiSearchContent/metadataSerch.feature:78](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/metadataSerch.feature#L78)
 - [apiSearchContent/metadataSerch.feature:108](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/metadataSerch.feature#L108)
-- [apiSearchContent/metadataSerch.feature:138](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/metadataSerch.feature#L138)
+- [apiSearchContent/metadataSerch.feature:140](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSearchContent/metadataSerch.feature#L140)
 
 
 Note: always have an empty line at the end of this file.

--- a/tests/acceptance/features/apiSearchContent/metadataSerch.feature
+++ b/tests/acceptance/features/apiSearchContent/metadataSerch.feature
@@ -123,19 +123,33 @@ Feature: metadata type search
       | permissionsRole | Space Viewer |
     When user "Brian" searches for '<query>' using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain "1" entries
+    And the search result should contain "<expectedCount>" entries
     And the search result of user "Brian" should contain these entries:
-      | testavatar.jpg |
+      | <expectedFile1> |
+      | <expectedFile2> |
     Examples:
-      | query                             |
-      | photo.cameraMake=NIKON            |
-      | photo.cameraModel="COOLPIX P6000" |
-      | photo.exposureDenominator=178     |
-      | photo.exposureNumerator=1         |
-      | photo.fNumber=4.5                 |
-      | photo.focalLength=6               |
-      | photo.orientation=1               |
-      | photo.takenDateTime=2008-10-22    |
-      | location.latitude=43.467157       |
-      | location.longitude=11.885395      |
-      | location.altitude=100             |
+      | query                                  | expectedCount | expectedFile1  | expectedFile2  |
+      | photo.cameraMake=NIKON                 | 1             | testavatar.jpg |                |
+      | photo.cameraMake=CANON                 | 0             |                |                |
+      | photo.cameraModel="COOLPIX P6000"      | 1             | testavatar.jpg |                |
+      | photo.exposureDenominator=178          | 1             | testavatar.jpg |                |
+      | photo.exposureNumerator=1              | 1             | testavatar.jpg |                |
+      | photo.fNumber=4.5                      | 1             | testavatar.jpg |                |
+      | photo.focalLength=6                    | 1             | testavatar.jpg |                |
+      | photo.orientation=1                    | 1             | testavatar.jpg |                |
+      | photo.takenDateTime=2008-10-22         | 1             | testavatar.jpg |                |
+      | location.latitude=43.467157            | 1             | testavatar.jpg |                |
+      | location.longitude=11.885395           | 1             | testavatar.jpg |                |
+      | location.altitude=100                  | 1             | testavatar.jpg |                |
+      | NOT photo.cameraMake=CANON             | 2             | testavatar.jpg | testavatar.png |
+      | NOT photo.orientation=2                | 2             | testavatar.jpg | testavatar.png |
+      | NOT photo.exposureDenominator=180      | 2             | testavatar.jpg | testavatar.png |
+      | photo.exposureDenominator&lt;180       | 1             | testavatar.jpg |                |
+      | photo.focalLength&lt;10                | 1             | testavatar.jpg |                |
+      | photo.exposureDenominator&lt;=178      | 1             | testavatar.jpg |                |
+      | photo.focalLength&lt;=6                | 1             | testavatar.jpg |                |
+      | photo.fNumber&gt;4                     | 1             | testavatar.jpg |                |
+      | photo.focalLength&gt;4                 | 1             | testavatar.jpg |                |
+      | location.altitude&gt;=100              | 1             | testavatar.jpg |                |
+      | photo.focalLength&gt;=6                | 1             | testavatar.jpg |                |
+      | photo.focalLength&gt;8                 | 0             |                |                |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR extended metadata search acceptance tests for KQL search operators:

- Added test coverage for NOT, <, <=, >, and >= operators.
- Included positive and negative search scenarios for some metadata.
- Added validation for queries returning both matching results and no results.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
