### PR TITLE
[tests-only][full-ci] test(cli): add cli test for idm resetpassword

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -111,6 +111,32 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator resets the password of existing user "([^"]*)" to "([^"]*)" with user type "([^"]*)" using the CLI$/
+	 *
+	 * @param string $user
+	 * @param string $password
+	 * @param string $userType
+	 *
+	 * @return void
+	 */
+	public function theAdministratorResetsThePasswordOfUserWithUserTypeUsingTheCLI(
+		string $user,
+		string $password,
+		string $userType,
+	): void {
+		$command = "idm resetpassword -u $user --user-type $userType";
+		$body = [
+			"command" => $command,
+			"inputs" => [$password, $password],
+		];
+
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+		if ($userType === "user") {
+			$this->featureContext->updateUserPassword($user, $password);
+		}
+	}
+
+	/**
 	 * @When the administrator deletes the empty trashbin folders using the CLI
 	 *
 	 * @return void

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -37,6 +37,7 @@ use Psr\Http\Message\ResponseInterface;
 class CliContext implements Context {
 	private FeatureContext $featureContext;
 	private SpacesContext $spacesContext;
+	private string $storedServiceUserPassword = '';
 
 	/**
 	 * @BeforeScenario
@@ -134,6 +135,108 @@ class CliContext implements Context {
 		if ($userType === "user") {
 			$this->featureContext->updateUserPassword($user, $password);
 		}
+	}
+
+	/**
+	 * @Given the original password for service user :user has been stored
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theOriginalPasswordForServiceUserHasBeenStored(string $user): void {
+		$servicePassword = '';
+		$passwordSourceEnvs = [
+			'IDM_REVASVC_PASSWORD',
+			'AUTH_BASIC_LDAP_BIND_PASSWORD',
+			'USERS_LDAP_BIND_PASSWORD',
+			'GROUPS_LDAP_BIND_PASSWORD',
+		];
+		foreach ($passwordSourceEnvs as $envName) {
+			$envPassword = \getenv($envName);
+			if ($envPassword !== false && $envPassword !== '') {
+				$servicePassword = $envPassword;
+				break;
+			}
+		}
+
+		if ($servicePassword === '') {
+			$configFile = $this->featureContext->getOcisDataPath() . '/config/ocis.yaml';
+			if (\file_exists($configFile)) {
+				$content = \file_get_contents($configFile);
+				if ($content !== false && \preg_match('/reva_password:\s*(.+)/', $content, $matches)) {
+					$servicePassword = \trim($matches[1]);
+				}
+			}
+		}
+
+		$errorMessage = "Could not determine original password for service user '$user'";
+		Assert::assertNotSame(
+			'',
+			$servicePassword,
+			$errorMessage,
+		);
+
+		$this->storedServiceUserPassword = $servicePassword;
+	}
+
+	/**
+	 * @When the administrator resets the password of service user :user to the stored original password using the CLI
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theAdministratorResetsThePasswordOfServiceUserToStoredOriginalUsingTheCLI(string $user): void {
+		Assert::assertNotSame('', $this->storedServiceUserPassword, 'Stored service user password is empty');
+		$command = "idm resetpassword -u $user --user-type service";
+		$body = [
+			"command" => $command,
+			"inputs" => [$this->storedServiceUserPassword, $this->storedServiceUserPassword],
+		];
+
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
+	 * @When the administrator configures service bind credentials to :password
+	 *
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorConfiguresServiceBindCredentialsTo(string $password): void {
+		$envs = [
+			'IDM_REVASVC_PASSWORD' => $password,
+			'OCIS_LDAP_BIND_PASSWORD' => $password,
+			'AUTH_BASIC_LDAP_BIND_PASSWORD' => $password,
+			'USERS_LDAP_BIND_PASSWORD' => $password,
+			'GROUPS_LDAP_BIND_PASSWORD' => $password,
+		];
+		$response = OcisConfigHelper::reConfigureOcis($envs);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
+	}
+
+	/**
+	 * @When the administrator configures service bind credentials to the stored original password
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorConfiguresServiceBindCredentialsToTheStoredOriginalPassword(): void {
+		Assert::assertNotSame('', $this->storedServiceUserPassword, 'Stored service user password is empty');
+		$password = $this->storedServiceUserPassword;
+		// Keep all bind credentials aligned with the restored service-user password for stable restarts.
+		$envs = [
+			'IDM_REVASVC_PASSWORD' => $password,
+			'OCIS_LDAP_BIND_PASSWORD' => $password,
+			'AUTH_BASIC_LDAP_BIND_PASSWORD' => $password,
+			'USERS_LDAP_BIND_PASSWORD' => $password,
+			'GROUPS_LDAP_BIND_PASSWORD' => $password,
+		];
+		$response = OcisConfigHelper::reConfigureOcis($envs);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $response);
 	}
 
 	/**

--- a/tests/acceptance/features/cliCommands/resetUserPassword.feature
+++ b/tests/acceptance/features/cliCommands/resetUserPassword.feature
@@ -53,3 +53,26 @@ Feature: reset user password via CLI command
     But the command output should not contain "Failed to update user password: entry does not exist"
     And the administrator starts the server
     And user "superUser" using password "newpass" should be able to create a new user "Brian" with default attributes
+
+
+  Scenario: try to reset password of regular user with --user-type service
+    Given the user "Admin" has created a new user with the following attributes:
+      | userName    | Alice        |
+      | displayName | Alice Hansen |
+      | password    | %alt1%       |
+    And the administrator has stopped the server
+    When the administrator resets the password of existing user "Alice" to "newpass" with user type "service" using the CLI
+    Then the command should be successful
+    But the command output should contain "Failed to update user password: entry does not exist"
+    And the administrator has started the server
+    And user "Alice" should be able to create folder "newFolder" using password "%alt1%"
+    But user "Alice" should not be able to create folder "anotherFolder" using password "newpass"
+
+
+  Scenario: reset password of service user using --user-type flag
+    Given the administrator has stopped the server
+    When the administrator resets the password of existing user "reva" to "newpass" with user type "service" using the CLI
+    Then the command should be successful
+    And the command output should contain "Password for user 'uid=reva,ou=sysusers,o=libregraph-idm' updated."
+    But the command output should not contain "Failed to update user password"
+    And the administrator has started the server

--- a/tests/acceptance/features/cliCommands/resetUserPassword.feature
+++ b/tests/acceptance/features/cliCommands/resetUserPassword.feature
@@ -55,7 +55,7 @@ Feature: reset user password via CLI command
     And user "superUser" using password "newpass" should be able to create a new user "Brian" with default attributes
 
 
-  Scenario: try to reset password of regular user with --user-type service
+  Scenario: try to reset password of regular user using service user type
     Given the user "Admin" has created a new user with the following attributes:
       | userName    | Alice        |
       | displayName | Alice Hansen |
@@ -69,10 +69,19 @@ Feature: reset user password via CLI command
     But user "Alice" should not be able to create folder "anotherFolder" using password "newpass"
 
 
-  Scenario: reset password of service user using --user-type flag
-    Given the administrator has stopped the server
+  Scenario: reset password of service user
+    Given the original password for service user "reva" has been stored
+    And the administrator has stopped the server
     When the administrator resets the password of existing user "reva" to "newpass" with user type "service" using the CLI
     Then the command should be successful
     And the command output should contain "Password for user 'uid=reva,ou=sysusers,o=libregraph-idm' updated."
     But the command output should not contain "Failed to update user password"
-    And the administrator has started the server
+    # Reconfigure updates bind credentials and restarts oCIS via ociswrapper.
+    # Successful 200 here verifies restart with the new password works.
+    And the administrator configures service bind credentials to "newpass"
+    # resetpassword requires IDM DB to be offline, so stop again before cleanup reset.
+    And the administrator has stopped the server
+    And the administrator resets the password of service user "reva" to the stored original password using the CLI
+    And the command should be successful
+    # Restore original bind credentials so following scenarios and @env-config rollback remain stable.
+    And the administrator configures service bind credentials to the stored original password


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Summary
Add acceptance tests for the `idm resetpassword --user-type` flag (PR #12118), and stabilize the service-user reset flow so it does not leak state into the rest of the suite.

## Problem
oCIS stores the `reva` service user's password in two independent places that must always match:

- **IDM data store (boltdb):** the actual password of the `reva` account, kept in a local database file. `idm resetpassword` writes the new password here.
- **Server config / env:** the password the server and its services use to authenticate as `reva` on every start (`IDM_REVASVC_PASSWORD`, `OCIS_LDAP_BIND_PASSWORD`, `AUTH_BASIC_LDAP_BIND_PASSWORD`, `USERS_LDAP_BIND_PASSWORD`, `GROUPS_LDAP_BIND_PASSWORD`). This comes from `ocis.yaml` / the test wrapper's env.

`idm resetpassword` updates only the boltdb file. The config is left at the old value. The test wrapper applies the config as a temporary in-memory override that the `@env-config` rollback throws away after the scenario, reverting to the baseline (original) password. The boltdb change, however, is permanent on disk. So after the scenario: config = original, boltdb = new password. The server can no longer authenticate as `reva`, which breaks the rollback restart and every following scenario.

## Fix
- Store the original `reva` password before the test (read from env or parsed from `reva_password:` in `ocis.yaml`).
- After resetting `reva` to a test password, reconfigure all bind credentials to the same value and verify the server restarts successfully (HTTP 200).
- At cleanup, reset the boltdb password back to the stored original and restore the bind credentials, so the environment is left exactly as found.

## Changes
- `resetUserPassword.feature`: add `--user-type` scenarios (regular user with `service` type fails; service user `reva` resets successfully).
- `CliContext.php`: store original service-user password, sync bind credentials after reset, and restore both at cleanup.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
