### PR TITLE
feat: [OCISDEV-948] add configurable software license and help page links

### DIFF
--- a/changelog/unreleased/enhancement-configurable-legal-links.md
+++ b/changelog/unreleased/enhancement-configurable-legal-links.md
@@ -1,0 +1,7 @@
+Enhancement: Add configurable software license and help page links
+
+Themes can now set `common.urls.softwareLicense` and `common.urls.helpPage` to
+surface deployment-specific legal/help links in the web UI. When set, links
+appear in a new "Help" menu in the topbar and on the account page.
+
+https://github.com/owncloud/ocis/pull/12528

--- a/web/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/web/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -26,7 +26,9 @@ const CommonSection = z.object({
     privacy: z.string(),
     accessibilityStatement: z.string().optional(),
     universalAccessEasyLanguage: z.string().optional(),
-    universalAccessSignLanguage: z.string().optional()
+    universalAccessSignLanguage: z.string().optional(),
+    softwareLicense: z.string().optional(),
+    helpPage: z.string().optional()
   }),
   shareRoles: z.record(
     z.string(),

--- a/web/packages/web-runtime/src/components/Topbar/HelpMenu.vue
+++ b/web/packages/web-runtime/src/components/Topbar/HelpMenu.vue
@@ -1,0 +1,116 @@
+<template>
+  <template v-if="isHelpMenuEnabled">
+    <oc-button
+      id="_helpMenuButton"
+      ref="menuButton"
+      v-oc-tooltip="
+        $pgettext(
+          'Top bar: tooltip for the “Help” icon; imperative sentence that opens a menu with license/help links.',
+          'Open help menu'
+        )
+      "
+      appearance="raw-inverse"
+      variation="brand"
+      :aria-label="$pgettext('Top bar: label for the help menu trigger; Title Case.', 'Help')"
+    >
+      <oc-icon name="question" fill-type="line" />
+    </oc-button>
+    <oc-drop ref="menu" toggle="#_helpMenuButton" mode="click" close-on-click padding-size="small">
+      <oc-list class="help-menu-list">
+        <li v-if="softwareLicenseUrl">
+          <oc-button
+            appearance="raw"
+            type="a"
+            :href="softwareLicenseUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="help-menu-software-license-link"
+          >
+            <oc-icon name="scales" fill-type="line" />
+            <span
+              v-text="
+                $pgettext(
+                  'Help menu: link label; opens the software license information page.',
+                  'Software License Information'
+                )
+              "
+            />
+          </oc-button>
+        </li>
+        <li v-if="helpPageUrl">
+          <oc-button
+            appearance="raw"
+            type="a"
+            :href="helpPageUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="help-menu-help-page-link"
+          >
+            <oc-icon name="question" fill-type="line" />
+            <span
+              v-text="$pgettext('Help menu: link label; opens the help pages.', 'Help Pages')"
+            />
+          </oc-button>
+        </li>
+      </oc-list>
+    </oc-drop>
+  </template>
+</template>
+
+<script lang="ts" setup>
+import { storeToRefs } from 'pinia'
+import { computed, unref, onMounted, useTemplateRef } from 'vue'
+import { useThemeStore } from '@ownclouders/web-pkg'
+import { OcDrop } from '@ownclouders/design-system/components'
+import { useGettext } from 'vue3-gettext'
+
+const { $pgettext } = useGettext()
+const themeStore = useThemeStore()
+const { currentTheme } = storeToRefs(themeStore)
+
+const softwareLicenseUrl = computed(() => unref(currentTheme).common?.urls?.softwareLicense)
+const helpPageUrl = computed(() => unref(currentTheme).common?.urls?.helpPage)
+const isHelpMenuEnabled = computed(() => !!(unref(softwareLicenseUrl) || unref(helpPageUrl)))
+
+const menu = useTemplateRef<InstanceType<typeof OcDrop>>('menu')
+
+onMounted(() => {
+  menu.value?.tippy?.setProps({
+    onHidden: () => unref(menu).$el.focus(),
+    onShown: () => unref(menu).$el.querySelector('a:first-of-type').focus()
+  })
+})
+</script>
+
+<style lang="scss" scoped>
+.help-menu-list {
+  li {
+    align-items: center;
+    display: flex;
+    margin: var(--oc-space-xsmall) 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    gap: var(--oc-space-medium);
+    justify-content: flex-start;
+    min-height: 3rem;
+    padding-left: var(--oc-space-small);
+    width: 100%;
+
+    &:focus,
+    &:hover {
+      background-color: var(--oc-color-background-hover);
+      color: var(--oc-color-swatch-passive-default);
+      text-decoration: none;
+    }
+  }
+}
+</style>

--- a/web/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/web/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -64,6 +64,7 @@
           v-bind="feedbackLinkOptions"
         />
         <universal-access-dropdown v-if="isUniversalAccessEnabled" />
+        <help-menu v-if="!hideAccountMenu" />
       </portal>
       <portal to="app.runtime.header.right" :order="100">
         <notifications v-if="isNotificationBellEnabled && !hideAccountMenu" />
@@ -84,6 +85,7 @@ import Notifications from './Notifications.vue'
 import FeedbackLink from './FeedbackLink.vue'
 import SideBarToggle from './SideBarToggle.vue'
 import UniversalAccessDropdown from './UniversalAccessDropdown.vue'
+import HelpMenu from './HelpMenu.vue'
 import {
   ApplicationInformation,
   CustomComponentTarget,
@@ -107,6 +109,7 @@ export default {
     ApplicationsMenu,
     CustomComponentTarget,
     FeedbackLink,
+    HelpMenu,
     Notifications,
     SideBarToggle,
     UserMenu,

--- a/web/packages/web-runtime/src/helpers/staticAppMenuItems.ts
+++ b/web/packages/web-runtime/src/helpers/staticAppMenuItems.ts
@@ -1,0 +1,40 @@
+import { AppMenuItemExtension, WebThemeType } from '@ownclouders/web-pkg'
+import { Language } from 'vue3-gettext'
+
+export const buildStaticAppMenuItems = (
+  common: WebThemeType['common'],
+  $pgettext: Language['$pgettext']
+): AppMenuItemExtension[] => {
+  const items: AppMenuItemExtension[] = []
+
+  const softwareLicenseUrl = common?.urls?.softwareLicense
+  const helpPageUrl = common?.urls?.helpPage
+
+  if (softwareLicenseUrl) {
+    items.push({
+      id: 'app.runtime.header.app-menu.software-license',
+      type: 'appMenuItem',
+      label: () =>
+        $pgettext(
+          'Apps menu: link label; opens the software license information page.',
+          'Software License Information'
+        ),
+      icon: 'scales',
+      priority: 900,
+      url: softwareLicenseUrl
+    })
+  }
+
+  if (helpPageUrl) {
+    items.push({
+      id: 'app.runtime.header.app-menu.help-page',
+      type: 'appMenuItem',
+      label: () => $pgettext('Apps menu: link label; opens the help pages.', 'Help Pages'),
+      icon: 'question',
+      priority: 910,
+      url: helpPageUrl
+    })
+  }
+
+  return items
+}

--- a/web/packages/web-runtime/src/index.ts
+++ b/web/packages/web-runtime/src/index.ts
@@ -1,6 +1,6 @@
 import { loadDesignSystem, pages, loadTranslations, supportedLanguages } from './defaults'
 import { router } from './router'
-import { PortalTarget, useVault } from '@ownclouders/web-pkg'
+import { PortalTarget, useThemeStore, useVault } from '@ownclouders/web-pkg'
 import { createHead } from '@vueuse/head'
 import { abilitiesPlugin } from '@casl/vue'
 import { createMongoAbility } from '@casl/ability'
@@ -39,7 +39,8 @@ import {
   PublicSpaceResource
 } from '@ownclouders/web-client'
 import { loadCustomTranslations } from './helpers/customTranslations'
-import { createApp, onWatcherCleanup, watch } from 'vue'
+import { buildStaticAppMenuItems } from './helpers/staticAppMenuItems'
+import { createApp, computed, onWatcherCleanup, watch } from 'vue'
 import PortalVue, { createWormhole } from 'portal-vue'
 import { createPinia } from 'pinia'
 import Avatar from './components/Avatar.vue'
@@ -145,6 +146,13 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
       applicationsPromise,
       themePromise
     ])
+
+    app.runWithContext(() => {
+      const themeStore = useThemeStore()
+      extensionRegistry.registerExtensions(
+        computed(() => buildStaticAppMenuItems(themeStore.currentTheme.common, gettext.$pgettext))
+      )
+    })
 
     // Important: has to happen AFTER native applications are loaded.
     // Reason: the `external` app serves as a blueprint for creating the app provider apps.

--- a/web/packages/web-runtime/src/pages/account.vue
+++ b/web/packages/web-runtime/src/pages/account.vue
@@ -40,6 +40,34 @@
             <span v-else v-text="$gettext('No email has been set up')" />
           </oc-td>
         </oc-tr>
+        <oc-tr v-if="softwareLicenseUrl" class="account-page-info-software-license">
+          <oc-td>{{ $gettext('Software License Information') }}</oc-td>
+          <oc-td>
+            <oc-button
+              type="a"
+              appearance="raw"
+              :href="softwareLicenseUrl"
+              target="_blank"
+              data-testid="account-page-software-license-link"
+            >
+              {{ softwareLicenseUrl }}
+            </oc-button>
+          </oc-td>
+        </oc-tr>
+        <oc-tr v-if="helpPageUrl" class="account-page-info-help-page">
+          <oc-td>{{ $gettext('Help Pages') }}</oc-td>
+          <oc-td>
+            <oc-button
+              type="a"
+              appearance="raw"
+              :href="helpPageUrl"
+              target="_blank"
+              data-testid="account-page-help-page-link"
+            >
+              {{ helpPageUrl }}
+            </oc-button>
+          </oc-td>
+        </oc-tr>
         <oc-tr
           v-if="user.crossInstanceReference"
           class="account-page-info-cross-instance-reference"
@@ -338,6 +366,7 @@ import {
   useModals,
   useResourcesStore,
   useSpacesStore,
+  useThemeStore,
   useUserStore,
   useSharesStore,
   useClipboard
@@ -392,6 +421,7 @@ export default defineComponent({
     const spacesStore = useSpacesStore()
     const capabilityStore = useCapabilityStore()
     const configStore = useConfigStore()
+    const themeStore = useThemeStore()
     const {
       options: notificationsOptions,
       emailOptions: emailNotificationsOptions,
@@ -829,6 +859,8 @@ export default defineComponent({
       updateDisableEmailNotifications,
       updateViewOptionsWebDavDetails,
       accountEditLink: computed(() => configStore.options.accountEditLink),
+      softwareLicenseUrl: computed(() => themeStore.currentTheme.common?.urls?.softwareLicense),
+      helpPageUrl: computed(() => themeStore.currentTheme.common?.urls?.helpPage),
       showLogout,
       showGdprExport,
       showNotifications,

--- a/web/packages/web-runtime/tests/unit/components/Topbar/HelpMenu.spec.ts
+++ b/web/packages/web-runtime/tests/unit/components/Topbar/HelpMenu.spec.ts
@@ -1,0 +1,74 @@
+import HelpMenu from '../../../../src/components/Topbar/HelpMenu.vue'
+import { defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+import { WebThemeType } from '@ownclouders/web-pkg'
+import { mock } from 'vitest-mock-extended'
+
+describe('HelpMenu component', () => {
+  describe('trigger button', () => {
+    it('is rendered when at least one url is set', () => {
+      const { wrapper } = getWrapper({ softwareLicenseUrl: 'https://example.com/license' })
+      expect(wrapper.find('button').exists()).toBeTruthy()
+    })
+    it('is not rendered when both urls are unset', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find('button').exists()).toBeFalsy()
+    })
+  })
+  describe('software license link', () => {
+    it('is rendered when softwareLicenseUrl is set', () => {
+      const { wrapper } = getWrapper({ softwareLicenseUrl: 'https://example.com/license' })
+      const link = wrapper.find('[data-testid="help-menu-software-license-link"]')
+      expect(link.exists()).toBeTruthy()
+      expect(link.attributes('href')).toEqual('https://example.com/license')
+    })
+    it('is not rendered when softwareLicenseUrl is unset', () => {
+      const { wrapper } = getWrapper({ helpPageUrl: 'https://example.com/help' })
+      const link = wrapper.find('[data-testid="help-menu-software-license-link"]')
+      expect(link.exists()).toBeFalsy()
+    })
+  })
+  describe('help page link', () => {
+    it('is rendered when helpPageUrl is set', () => {
+      const { wrapper } = getWrapper({ helpPageUrl: 'https://example.com/help' })
+      const link = wrapper.find('[data-testid="help-menu-help-page-link"]')
+      expect(link.exists()).toBeTruthy()
+      expect(link.attributes('href')).toEqual('https://example.com/help')
+    })
+    it('is not rendered when helpPageUrl is unset', () => {
+      const { wrapper } = getWrapper({ softwareLicenseUrl: 'https://example.com/license' })
+      const link = wrapper.find('[data-testid="help-menu-help-page-link"]')
+      expect(link.exists()).toBeFalsy()
+    })
+  })
+})
+
+function getWrapper({
+  softwareLicenseUrl = undefined,
+  helpPageUrl = undefined
+}: {
+  softwareLicenseUrl?: string
+  helpPageUrl?: string
+} = {}) {
+  return {
+    wrapper: mount(HelpMenu, {
+      global: {
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              themeState: {
+                currentTheme: mock<WebThemeType>({
+                  common: {
+                    urls: {
+                      softwareLicense: softwareLicenseUrl,
+                      helpPage: helpPageUrl
+                    }
+                  }
+                })
+              }
+            }
+          })
+        ]
+      }
+    })
+  }
+}

--- a/web/packages/web-runtime/tests/unit/helpers/staticAppMenuItems.spec.ts
+++ b/web/packages/web-runtime/tests/unit/helpers/staticAppMenuItems.spec.ts
@@ -1,0 +1,45 @@
+import { buildStaticAppMenuItems } from '../../../src/helpers/staticAppMenuItems'
+import { WebThemeType } from '@ownclouders/web-pkg'
+
+const $pgettext = (context: string, msgid: string) => msgid
+
+describe('buildStaticAppMenuItems', () => {
+  it('returns an empty array when neither url is set', () => {
+    const items = buildStaticAppMenuItems({ urls: {} } as WebThemeType['common'], $pgettext)
+    expect(items).toHaveLength(0)
+  })
+  it('returns one item when only softwareLicense is set', () => {
+    const items = buildStaticAppMenuItems(
+      { urls: { softwareLicense: 'https://example.com/license' } } as WebThemeType['common'],
+      $pgettext
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0].url).toEqual('https://example.com/license')
+    expect(items[0].label()).toEqual('Software License Information')
+  })
+  it('returns one item when only helpPage is set', () => {
+    const items = buildStaticAppMenuItems(
+      { urls: { helpPage: 'https://example.com/help' } } as WebThemeType['common'],
+      $pgettext
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0].url).toEqual('https://example.com/help')
+    expect(items[0].label()).toEqual('Help Pages')
+  })
+  it('returns two items when both urls are set, sorted after real apps by priority', () => {
+    const items = buildStaticAppMenuItems(
+      {
+        urls: {
+          softwareLicense: 'https://example.com/license',
+          helpPage: 'https://example.com/help'
+        }
+      } as WebThemeType['common'],
+      $pgettext
+    )
+    expect(items).toHaveLength(2)
+    items.forEach((item) => {
+      expect(item.priority).toBeGreaterThanOrEqual(900)
+      expect(item.type).toEqual('appMenuItem')
+    })
+  })
+})

--- a/web/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/web/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -28,6 +28,8 @@ exports[`account page > account information section > displays basic user inform
       </tr>
       <!--v-if-->
       <!--v-if-->
+      <!--v-if-->
+      <!--v-if-->
       <tr class="account-page-info-groups">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Group memberships</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="group-names"><span data-testid="group-names-empty">You are not part of any group</span></td>

--- a/web/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/web/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -14,7 +14,8 @@ import {
   useExtensionRegistry,
   useMessages,
   useSharesStore,
-  useResourcesStore
+  useResourcesStore,
+  WebThemeType
 } from '@ownclouders/web-pkg'
 import { LanguageOption, SettingsBundle, SettingsValue } from '../../../src/helpers/settings'
 import { User } from '@ownclouders/web-client/graph/generated'
@@ -34,6 +35,8 @@ const selectors = {
   editUrlButton: '[data-testid="account-page-edit-url-btn"]',
   editPasswordButton: '[data-testid="account-page-edit-password-btn"]',
   logoutButton: '[data-testid="account-page-logout-url-btn"]',
+  softwareLicenseLink: '[data-testid="account-page-software-license-link"]',
+  helpPageLink: '[data-testid="account-page-help-page-link"]',
   accountPageInfo: '.account-page-info',
   groupNames: '[data-testid="group-names"]',
   groupNamesEmpty: '[data-testid="group-names-empty"]',
@@ -74,6 +77,44 @@ describe('account page', () => {
 
         const editUrlButton = wrapper.find(selectors.editUrlButton)
         expect(editUrlButton.exists()).toBeFalsy()
+      })
+    })
+    describe('software license link', () => {
+      it('should be displayed if defined via config', async () => {
+        const { wrapper } = getWrapper({
+          softwareLicenseUrl: 'https://example.com/license'
+        })
+        await blockLoadingState(wrapper)
+
+        const link = wrapper.find(selectors.softwareLicenseLink)
+        expect(link.exists()).toBeTruthy()
+        expect(link.attributes('href')).toEqual('https://example.com/license')
+      })
+      it('should not be displayed if not defined via config', async () => {
+        const { wrapper } = getWrapper()
+        await blockLoadingState(wrapper)
+
+        const link = wrapper.find(selectors.softwareLicenseLink)
+        expect(link.exists()).toBeFalsy()
+      })
+    })
+    describe('help page link', () => {
+      it('should be displayed if defined via config', async () => {
+        const { wrapper } = getWrapper({
+          helpPageUrl: 'https://example.com/help'
+        })
+        await blockLoadingState(wrapper)
+
+        const link = wrapper.find(selectors.helpPageLink)
+        expect(link.exists()).toBeTruthy()
+        expect(link.attributes('href')).toEqual('https://example.com/help')
+      })
+      it('should not be displayed if not defined via config', async () => {
+        const { wrapper } = getWrapper()
+        await blockLoadingState(wrapper)
+
+        const link = wrapper.find(selectors.helpPageLink)
+        expect(link.exists()).toBeFalsy()
       })
     })
   })
@@ -423,6 +464,8 @@ function getWrapper({
   user = mock<User>({ memberOf: [] }),
   capabilities = {},
   accountEditLink = undefined,
+  softwareLicenseUrl = undefined,
+  helpPageUrl = undefined,
   spaces = [],
   isPublicLinkContext = false,
   isUserContext = true,
@@ -432,6 +475,8 @@ function getWrapper({
   user?: User
   capabilities?: Partial<Capabilities['capabilities']>
   accountEditLink?: OptionsConfig['accountEditLink']
+  softwareLicenseUrl?: string
+  helpPageUrl?: string
   spaces?: SpaceResource[]
   isPublicLinkContext?: boolean
   isUserContext?: boolean
@@ -452,6 +497,16 @@ function getWrapper({
           logoutUrl: 'https://account-manager/logout',
           ...(accountEditLink && { accountEditLink })
         }
+      },
+      themeState: {
+        currentTheme: mock<WebThemeType>({
+          common: {
+            urls: {
+              softwareLicense: softwareLicenseUrl,
+              helpPage: helpPageUrl
+            }
+          }
+        })
       }
     }
   })


### PR DESCRIPTION
# Description
Adds support for deployment-specific legal/help links via the theme configuration. Two new optional fields, common.urls.softwareLicense and common.urls.helpPage, can be set in theme.json. When present, they are surfaced in two places in the web UI:
- A new "Help" menu button in the topbar (HelpMenu.vue), shown only when at least one of the URLs is configured.
- The account page, as additional info rows linking out to the configured URLs.

Internally, the theme schema (web-pkg/composables/piniaStores/theme.ts) was extended to validate these new optional string fields, and a buildStaticAppMenuItems helper was added to register them as app-menu extensions so they also appear in the app switcher.

# Related Issue
- Fixes [OCISDEV-948](https://kiteworks.atlassian.net/browse/OCISDEV-948)

# Motivation and Context
Different oCIS deployments need to point users to their own software license and help documentation instead of ownCloud's defaults. Previously there was no configurable place for this per-deployment legal/help content in the web UI.

How Has This Been Tested?
- test environment: local web-runtime dev server against a themed theme.json with softwareLicense/helpPage URLs set
- test case 1: only softwareLicense set — Help menu and account page show only that link
- test case 2: only helpPage set — Help menu and account page show only that link
- test case 3: neither set — Help menu button is not rendered
- test case 4: both set — both links render in menu and account page, app-menu items sorted by priority
- Unit tests added for HelpMenu.vue and staticAppMenuItems.ts

Screenshots (if appropriate):

Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>