### PR TITLE
feat: [OCISDEV-950] make logo click-through URL configurable

### DIFF
--- a/changelog/unreleased/enhancement-logo-href.md
+++ b/changelog/unreleased/enhancement-logo-href.md
@@ -1,0 +1,7 @@
+Enhancement: Configurable logo click-through URL
+
+We've added an optional `href` field to the `logo` theme configuration. When set,
+clicking the topbar logo navigates to the configured URL instead of the default
+files navigation. When not set, the existing default behavior is unchanged.
+
+https://github.com/owncloud/ocis/pull/OCISDEV-950

--- a/web/docs/theming/_index.md
+++ b/web/docs/theming/_index.md
@@ -145,6 +145,19 @@ Here, you can specify the images to be used in the `"topbar"`, for the `"favicon
 },
 ```
 
+Optionally, you can set `"href"` to a URL. If set, clicking the logo in the topbar
+navigates to that URL instead of the default behavior of navigating to the user's
+files. If not set, the default navigation behavior is used.
+
+```json
+"logo": {
+  "topbar": "themes/owncloud/assets/logo.svg",
+  "favicon": "themes/owncloud/assets/favicon.jpg",
+  "login": "themes/owncloud/assets/logo.svg",
+  "href": "https://example.com"
+},
+```
+
 ##### The "loginPage" options
 
 You can set the background image for the login page by providing an image file in the `"backgroundImg"` option.

--- a/web/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/web/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -54,7 +54,8 @@ const Logo = z.object({
   topbarSm: z.string().optional(),
   favicon: z.string(),
   login: z.string(),
-  notFound: z.string().optional()
+  notFound: z.string().optional(),
+  href: z.string().optional()
 })
 
 const Icons = z.object({

--- a/web/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/web/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -9,7 +9,18 @@
         v-if="appMenuExtensions.length && !isEmbedModeEnabled && !hideAppSwitcher"
         :menu-items="appMenuExtensions"
       />
-      <router-link v-if="!hideLogo" :to="homeLink" class="oc-logo-href">
+      <!-- eslint-disable-next-line vuejs-accessibility/anchor-has-content -->
+      <a v-if="!hideLogo && logoHref" :href="logoHref" class="oc-logo-href">
+        <oc-responsive-image
+          :src="{
+            xs: currentTheme.logo.topbarSm,
+            md: currentTheme.logo.topbar
+          }"
+          :alt="sidebarLogoAlt"
+          class="oc-logo-image"
+        />
+      </a>
+      <router-link v-else-if="!hideLogo" :to="homeLink" class="oc-logo-href">
         <oc-responsive-image
           :src="{
             xs: currentTheme.logo.topbarSm,
@@ -149,6 +160,8 @@ export default {
       )
     })
 
+    const logoHref = computed(() => unref(currentTheme).logo.href)
+
     const homeLink = computed(() => {
       if (authStore.publicLinkContextReady && !authStore.userContextReady) {
         return {
@@ -228,6 +241,7 @@ export default {
       isEmbedModeEnabled,
       isSideBarToggleVisible,
       isSideBarToggleDisabled,
+      logoHref,
       homeLink,
       topBarCenterExtensionPoint,
       appMenuExtensions,

--- a/web/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/web/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -2,17 +2,24 @@ import { Capabilities } from '@ownclouders/web-client/ocs'
 import {
   ApplicationInformation,
   AppMenuItemExtension,
-  useExtensionRegistry
+  useExtensionRegistry,
+  WebThemeType
 } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { computed } from 'vue'
 import TopBar from '../../../../src/components/Topbar/TopBar.vue'
+import defaultTheme from '@ownclouders/web-test-helpers/src/mocks/theme.json'
 import {
   defaultComponentMocks,
   defaultPlugins,
   PiniaMockOptions,
   shallowMount
 } from '@ownclouders/web-test-helpers'
+
+const defaultOwnCloudTheme = {
+  ...defaultTheme.clients.web.defaults,
+  ...defaultTheme.clients.web.themes[0]
+}
 
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isEnabled: computed(() => false) })
 
@@ -90,16 +97,37 @@ describe('Top Bar component', () => {
       expect(wrapper.find(`${componentName}-stub`).exists()).toBeFalsy()
     }
   )
+  describe('logo', () => {
+    it('links to the internal home route when no href is configured', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find('.oc-logo-href').attributes('href')).toBeUndefined()
+      expect(wrapper.find('router-link-stub').exists()).toBeTruthy()
+    })
+    it('links to the configured href when set', () => {
+      const { wrapper } = getWrapper({ logoHref: 'https://example.com' })
+      expect(wrapper.find('router-link-stub').exists()).toBeFalsy()
+      expect(wrapper.find('.oc-logo-href').attributes('href')).toBe('https://example.com')
+    })
+    it('is not rendered when hideLogo is "true", even if href is configured', () => {
+      const { wrapper } = getWrapper({
+        options: { hideLogo: true },
+        logoHref: 'https://example.com'
+      })
+      expect(wrapper.find('.oc-logo-href').exists()).toBeFalsy()
+    })
+  })
 })
 
 const getWrapper = ({
   capabilities = {},
   userContextReady = true,
-  options
+  options,
+  logoHref
 }: {
   capabilities?: Partial<Capabilities['capabilities']>
   userContextReady?: boolean
   options?: PiniaMockOptions['configState']['options']
+  logoHref?: string
 } = {}) => {
   const mocks = { ...defaultComponentMocks() }
 
@@ -107,7 +135,13 @@ const getWrapper = ({
     piniaOptions: {
       authState: { userContextReady },
       capabilityState: { capabilities },
-      configState: { options: { disableFeedbackLink: false, ...options } }
+      configState: { options: { disableFeedbackLink: false, ...options } },
+      themeState: {
+        currentTheme: mock<WebThemeType>({
+          ...defaultOwnCloudTheme,
+          logo: { ...defaultOwnCloudTheme.logo, href: logoHref }
+        })
+      }
     }
   })
 


### PR DESCRIPTION
# Description

Adds an optional href field to the theme's logo config in theme.json. When set, clicking the topbar logo navigates to that configured URL instead of the default navigation. When href is unset, existing behavior is unchanged.

# Related Issue
- Fixes [OCISDEV-950](https://kiteworks.atlassian.net/browse/OCISDEV-950)

# Motivation and Context
Operators want to be able to configure, per deployment, where clicking the logo sends the user (e.g. to their company homepage), without changing the existing logo image configuration (logo.topbar/logo.login/logo.favicon), which is a separate, unrelated concern.

How Has This Been Tested?
- test environment: unit tests (vitest) in web/
- test case 1: no href configured — logo renders as router-link to the internal home route (existing behavior, unchanged)
- test case 2: href configured — logo renders as a plain anchor pointing to the configured URL
- test case 3: hideLogo is true — logo is not rendered even when href is configured
- Ran TopBar.spec.ts (19/19 passing) and the theme store's theme.spec.ts (7/7 passing); linted the changed files (no errors)

Screenshots (if appropriate):

Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
