### PR TITLE
ci: add SonarQube analysis workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,56 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow helps you trigger a SonarQube analysis of your code and populates
+# GitHub Code Scanning alerts with the vulnerabilities found.
+# (this feature is available starting from SonarQube 9.7, Developer Edition and above)
+
+# 1. Make sure you add a valid GitHub configuration to your SonarQube (Administration > DevOps platforms > GitHub)
+
+# 2. Import your project on SonarQube
+#     * Add your repository as a new project by clicking "Create project" from your homepage.
+#
+# 3. Select GitHub Actions as your CI and follow the tutorial
+#     * a. Generate a new token and add it to your GitHub repository's secrets using the name SONAR_TOKEN
+#          (On SonarQube, click on your avatar on top-right > My account > Security or ask your administrator)
+#
+#     * b. Copy/paste your SonarQube host URL to your GitHub repository's secrets using the name SONAR_HOST_URL
+#
+#     * c. Copy/paste the project Key into the args parameter below
+#          (You'll find this information in SonarQube by following the tutorial or by clicking on Project Information at the top-right of your project's homepage)
+
+# Feel free to take a look at our documentation (https://docs.sonarqube.org/latest/analysis/github-integration/)
+# or reach out to our community forum if you need some help (https://community.sonarsource.com/c/sq/10)
+
+name: SonarQube analysis
+
+on:
+  push:
+    branches: [ "master", "education-*", "experimental", "stable-*" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read # allows SonarQube to decorate PRs with analysis results
+
+jobs:
+  Analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
+
+      - name: Analyze with SonarQube
+
+        # You can pin the exact commit or the version.
+        # uses: SonarSource/sonarqube-scan-action@v8.2.0
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Generate a token on SonarQube, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow (`.github/workflows/sonarqube.yml`) that runs a SonarQube static analysis of the codebase and populates GitHub Code Scanning alerts with the findings.

- Triggers on pushes to the maintained branches (`master`, `education-*`, `experimental`, `stable-*`), on pull requests targeting `master`, and on manual `workflow_dispatch`.
- Uses the `SonarSource/sonarqube-scan-action` at v8.2.0, pinned to its commit SHA (`713881670b6b3676cda39549040e2d88c70d582e`) rather than a floating tag.
- Relies on the `SONAR_TOKEN` repository secret, plus the built-in `GITHUB_TOKEN` for PR decoration.

Generated from SonarSource's official GitHub Actions template.

## Related Issue

Re-creates #12530, which was closed with an empty template description.

## Motivation and Context

Adds continuous static analysis / security scanning of the codebase, surfacing results directly in GitHub Code Scanning.

## How Has This Been Tested?

CI-only change. The workflow YAML was validated locally (parses cleanly). A full scan run requires the `SONAR_TOKEN` secret to be configured on the repository by an administrator; until then the scan step will not succeed, which is expected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised:

_CI/tooling configuration only — no source changes, so no unit/acceptance tests apply._
