### PR TITLE
fix(web): keep session on transient network errors during context init

### DIFF
--- a/changelog/unreleased/bugfix-web-preserve-session-on-network-error.md
+++ b/changelog/unreleased/bugfix-web-preserve-session-on-network-error.md
@@ -1,0 +1,11 @@
+Bugfix: Keep the web session on transient network errors during context init
+
+We've fixed a bug in the web frontend where a temporary connectivity failure (e.g. a
+fast page reload cancelling in-flight requests, or a short offline period) while
+re-establishing the authenticated context on page load was treated like an expired or
+invalid token. This forced a full logout and redirected the user to the "trouble
+connecting to the login service" page. Network/connectivity errors now preserve the
+existing session, while genuine authentication rejections (e.g. a 401) still trigger
+the regular logout flow as before.
+
+https://github.com/owncloud/web/issues/12980

--- a/web/packages/web-runtime/src/services/auth/authService.ts
+++ b/web/packages/web-runtime/src/services/auth/authService.ts
@@ -26,6 +26,40 @@ import { PublicLinkType } from '@ownclouders/web-client'
 import { WebWorkersStore } from '@ownclouders/web-pkg'
 import { isSilentRedirectRoute } from '../../helpers/silentRedirect'
 
+/**
+ * Distinguishes a transient network/connectivity failure from a genuine
+ * authentication rejection.
+ *
+ * When the context is (re-)established on page reload, user data is fetched over
+ * HTTP. If that request fails because of a temporary connectivity issue (offline,
+ * DNS, a page refresh cancelling in-flight requests, ...) we must NOT treat it like
+ * an expired/invalid token and tear down the session. Only errors that carry an HTTP
+ * response (e.g. a `401`) are real auth rejections.
+ *
+ * Recognised connectivity failures:
+ * - Axios errors without an HTTP `response`, with code `ERR_NETWORK` (connection
+ *   refused / DNS / CORS / offline) or `ECONNABORTED` (timeout).
+ * - Browser `fetch` failures, which surface as a `TypeError` (Safari: "Load failed",
+ *   Chromium: "Failed to fetch", Firefox: "NetworkError when attempting to fetch ...").
+ */
+export const isNetworkError = (e: unknown): boolean => {
+  if (e instanceof TypeError) {
+    return /load failed|failed to fetch|networkerror/i.test(e.message)
+  }
+
+  if (e && typeof e === 'object') {
+    const err = e as { response?: unknown; code?: string }
+    // An error that carries an HTTP response is an answered request, not a
+    // connectivity failure - let the regular auth-error handling deal with it.
+    if (err.response) {
+      return false
+    }
+    return err.code === 'ERR_NETWORK' || err.code === 'ECONNABORTED'
+  }
+
+  return false
+}
+
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
   private configStore: ConfigStore
@@ -194,7 +228,11 @@ export class AuthService implements AuthServiceInterface {
             this.updateMfaExpiryTimer()
           } catch (e) {
             console.error(e)
-            await this.handleAuthError(unref(this.router.currentRoute))
+            // A transient connectivity failure must not force a logout - keep the
+            // session and let the regular auth flow recover once back online.
+            if (!isNetworkError(e)) {
+              await this.handleAuthError(unref(this.router.currentRoute))
+            }
           }
         })
 
@@ -259,7 +297,11 @@ export class AuthService implements AuthServiceInterface {
           }
         } catch (e) {
           console.error(e)
-          await this.handleAuthError(unref(this.router.currentRoute))
+          // A transient connectivity failure must not force a logout - keep the
+          // session and let the regular auth flow recover once back online.
+          if (!isNetworkError(e)) {
+            await this.handleAuthError(unref(this.router.currentRoute))
+          }
         }
       }
     }

--- a/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigStore, useAuthStore, useConfigStore } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { Router } from 'vue-router'
-import { AuthService } from '../../../../src/services/auth/authService'
+import { AuthService, isNetworkError } from '../../../../src/services/auth/authService'
 import { UserManager } from '../../../../src/services/auth/userManager'
 import { RouteLocation, createRouter, createTestingPinia } from '@ownclouders/web-test-helpers'
 import { User } from 'oidc-client-ts'
@@ -222,6 +222,108 @@ describe('AuthService', () => {
 
       await authService.requireAcr('advanced', '/')
       expect(mockSignInRedirect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isNetworkError', () => {
+    it.each([
+      ['axios ERR_NETWORK (offline / connection refused)', { code: 'ERR_NETWORK' }, true],
+      ['axios ECONNABORTED (timeout)', { code: 'ECONNABORTED' }, true],
+      ['fetch TypeError - Safari "Load failed"', new TypeError('Load failed'), true],
+      ['fetch TypeError - Chromium "Failed to fetch"', new TypeError('Failed to fetch'), true],
+      [
+        'fetch TypeError - Firefox "NetworkError ..."',
+        new TypeError('NetworkError when attempting to fetch resource.'),
+        true
+      ],
+      ['an answered request carrying an HTTP response (401)', { response: { status: 401 } }, false],
+      [
+        'an ERR_NETWORK code that nonetheless carries a response',
+        { code: 'ERR_NETWORK', response: { status: 500 } },
+        false
+      ],
+      ['an unrelated TypeError (real bug)', new TypeError('foo is not a function'), false],
+      ['an error with an unknown code', { code: 'ERR_BAD_REQUEST' }, false],
+      ['a null error', null, false],
+      ['a plain string error', 'boom', false]
+    ])('returns %s => %s', (_desc, error, expected) => {
+      expect(isNetworkError(error)).toBe(expected)
+    })
+  })
+
+  describe('initializeContext auth-error classification', () => {
+    const buildAuthService = (rejection: unknown) => {
+      const authService = new AuthService()
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
+          updateContext: vi.fn().mockRejectedValue(rejection)
+        })
+      })
+      const router = createRouter()
+      initAuthService({ authService, router })
+      const handleAuthErrorSpy = vi
+        .spyOn(authService, 'handleAuthError')
+        .mockResolvedValue(undefined)
+      return { authService, handleAuthErrorSpy }
+    }
+
+    it('preserves the session (no handleAuthError) when updateContext fails with a network error on reload', async () => {
+      const { authService, handleAuthErrorSpy } = buildAuthService({ code: 'ERR_NETWORK' })
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(handleAuthErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('triggers handleAuthError when updateContext fails with a 401 on reload', async () => {
+      const { authService, handleAuthErrorSpy } = buildAuthService({ response: { status: 401 } })
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(handleAuthErrorSpy).toHaveBeenCalled()
+    })
+
+    it('addUserLoaded handler preserves the session on a network error but logs out on an auth rejection', async () => {
+      const authService = new AuthService()
+      let userLoadedCb: (user: User) => Promise<void>
+      const updateContext = vi.fn()
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          // skip the reload branch, we drive the addUserLoaded handler directly
+          getAccessToken: vi.fn().mockResolvedValue(null),
+          // force event-handler registration (mock<> would otherwise make this truthy)
+          areEventHandlersRegistered: false,
+          updateContext,
+          events: {
+            addAccessTokenExpired: vi.fn(),
+            addAccessTokenExpiring: vi.fn(),
+            addUserLoaded: vi.fn().mockImplementation((cb) => {
+              userLoadedCb = cb
+            }),
+            addUserUnloaded: vi.fn(),
+            addSilentRenewError: vi.fn()
+          } as unknown as UserManager['events']
+        })
+      })
+      const router = createRouter()
+      initAuthService({ authService, router })
+      const handleAuthErrorSpy = vi
+        .spyOn(authService, 'handleAuthError')
+        .mockResolvedValue(undefined)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      // network error -> session preserved
+      updateContext.mockRejectedValueOnce({ code: 'ERR_NETWORK' })
+      await userLoadedCb(mock<User>({ access_token: 'tok', expires_in: 3600 }))
+      expect(handleAuthErrorSpy).not.toHaveBeenCalled()
+
+      // auth rejection -> existing logout flow
+      updateContext.mockRejectedValueOnce({ response: { status: 401 } })
+      await userLoadedCb(mock<User>({ access_token: 'tok', expires_in: 3600 }))
+      expect(handleAuthErrorSpy).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Description
Ported from **owncloud/web#13941** (owncloud/web is deprecated; the web frontend now lives in this monorepo under `web/`, so the fix belongs here).

The web frontend re-establishes the authenticated context on page reload in `AuthService.initializeContext()` (`web/packages/web-runtime/src/services/auth/authService.ts`) by calling `userManager.updateContext()`, which fetches user data over HTTP (`graph.users.getMe()`, capabilities, roles). Both the page-reload token-restore path and the `addUserLoaded` handler wrapped that call in a blanket `catch` that treated **any** thrown error like a genuine authentication rejection: `handleAuthError()` → `removeUser('authError')` → redirect to `accessDenied`.

**Root cause:** the `catch` blocks did not distinguish a transient network/connectivity failure (a fast page refresh cancelling in-flight requests, a short offline period, a timeout) from a real auth rejection (401 / invalid or expired token). A temporary connectivity blip forced a full logout and showed the "trouble connecting to the login service" page.

**Fix:** a small `isNetworkError()` classifier. Connectivity failures (axios `ERR_NETWORK` / `ECONNABORTED` with no HTTP `response`, or a fetch `TypeError` such as Safari's "Load failed") now preserve the existing session and let the regular auth flow recover on the next navigation / token refresh. Errors carrying an HTTP `response` (e.g. `401`) still go through the unchanged `handleAuthError()` logout flow. Scoped to the two `catch` blocks identified in the issue analysis.

## Related Issue
- Fixes owncloud/web#12980 (cross-repo; the web repo is deprecated so this cannot use a same-repo auto-close keyword)

## Motivation and Context
Users were being logged out on transient connectivity issues and bounced to the access-denied page, losing their active session (e.g. quick reloads in Safari). Only genuine auth rejections should end the session.

## How Has This Been Tested?
- The changed files (`authService.ts`, `authService.spec.ts`) are **byte-identical** to `owncloud/web@master` before this change, and the applied diff is identical to owncloud/web#13941, which was validated there:
  - `authService.spec.ts` — **26/26 passing** (Vitest): `isNetworkError` table test across all branches; reload path (network error → no `handleAuthError`; 401 → `handleAuthError`); `addUserLoaded` handler (both cases).
  - `pnpm check:types` (vue-tsc) → passes; ESLint + Prettier on changed files → clean.
- Not separately re-run inside this repo's `web/` tree here (avoids a full monorepo install for a byte-identical change) — this repo's CI `web/` suite is the final gate. Playwright e2e not run locally (needs a running oCIS stack).

## Screenshots (if appropriate):
n/a — no UI change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added — n/a (unit-level; existing e2e auth flows unaffected)
- [ ] Documentation ticket raised — n/a (behaviour is strictly less disruptive; no admin/user-facing docs change)

---

### Notes for reviewers
- **Where it lives:** this is a change to the vendored **web frontend** (`web/…`), i.e. client-side session handling — not the oCIS backend identity/auth/proxy services.
- **Scope kept minimal:** on a network error the session is preserved and the context re-establishes on the next navigation/token-refresh; no new "offline/retry" UI state was added (kept the diff focused on the acceptance criteria). Happy to add an explicit offline indicator in a follow-up.
- **Classifier is conservative:** anything not positively recognised as a connectivity failure falls through to the existing `handleAuthError` behaviour, so unknown/real errors are no worse off than today.
- **Changelog:** added `changelog/unreleased/bugfix-web-preserve-session-on-network-error.md`.
- **CI note:** if the web e2e/unit jobs need a pipeline flag to run for a `web/`-only change, please add it on review.
- **Risk:** low — additive logic gated behind the new classifier; existing logout paths for auth rejections unchanged.

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf5p9hdg4kGRaVjjgVX5vz)_