### PR TITLE
ci: exclude web when uploading generated code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
           path: |
             .
             !.git
+            !web
           retention-days: 1
 
   docker-build:


### PR DESCRIPTION
## Description

The release workflow is running out of memory when uploading the generated code. This fixes it by excluding the web directory. The web directory is not needed because the build is handled via the generation.

## Motivation and Context

Fix failing release workflow: https://github.com/owncloud/ocis/actions/runs/29113023177/job/86756419560

## How Has This Been Tested?

- test environment: GHA
- test case 1: will be tested in the next release run

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
