### PR TITLE
fix: [OCISDEV-785] harden embed mode delegated authentication origin validation

### DIFF
--- a/changelog/unreleased/security-oidc-callback-delegated-auth-origin.md
+++ b/changelog/unreleased/security-oidc-callback-delegated-auth-origin.md
@@ -1,0 +1,8 @@
+Security: Harden origin validation for embed mode delegated authentication
+
+Hardened origin validation for the delegated authentication feature in Web's
+embed mode. Deployments using `WEB_OPTION_EMBED_DELEGATE_AUTHENTICATION` should
+ensure `WEB_OPTION_EMBED_DELEGATE_AUTHENTICATION_ORIGIN` is explicitly
+configured.
+
+https://github.com/owncloud/ocis/pull/12572

--- a/web/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
+++ b/web/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
@@ -61,7 +61,7 @@ export const useEmbedMode = () => {
 
   const verifyDelegatedAuthenticationOrigin = (eventOrigin: string): boolean => {
     if (!unref(delegateAuthenticationOrigin)) {
-      return true
+      return false
     }
 
     return unref(delegateAuthenticationOrigin) === eventOrigin

--- a/web/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
@@ -168,12 +168,12 @@ describe('useEmbedMode', () => {
   })
 
   describe('verifyDelegatedAuthenticationOrigin', () => {
-    it('when delegateAuthenticationOrigin is not set should return true', () => {
+    it('when delegateAuthenticationOrigin is not set should return false', () => {
       getComposableWrapper(
         () => {
           const { verifyDelegatedAuthenticationOrigin } = useEmbedMode()
 
-          expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(true)
+          expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(false)
         },
         { mocks: defaultComponentMocks() }
       )
@@ -186,7 +186,7 @@ describe('useEmbedMode', () => {
 
           expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(true)
         },
-        getWrapperOptions({ messagesOrigin: 'event-origin' })
+        getWrapperOptions({ delegateAuthenticationOrigin: 'event-origin' })
       )
     })
 

--- a/web/packages/web-runtime/src/container/bootstrap.ts
+++ b/web/packages/web-runtime/src/container/bootstrap.ts
@@ -120,12 +120,6 @@ const getEmbedConfigFromQuery = (
     config.delegateAuthentication = delegateAuthentication === 'true'
   }
 
-  const delegateAuthenticationOrigin = getQueryParam('embed-delegate-authentication-origin')
-
-  if (delegateAuthentication) {
-    config.delegateAuthenticationOrigin = delegateAuthenticationOrigin
-  }
-
   return config
 }
 

--- a/web/packages/web-runtime/src/services/auth/authService.ts
+++ b/web/packages/web-runtime/src/services/auth/authService.ts
@@ -406,10 +406,7 @@ export class AuthService implements AuthServiceInterface {
   }
 
   private handleDelegatedTokenUpdate(event: MessageEvent) {
-    if (
-      this.configStore.options.embed?.delegateAuthenticationOrigin &&
-      event.origin !== this.configStore.options.embed.delegateAuthenticationOrigin
-    ) {
+    if (event.origin !== this.configStore.options.embed?.delegateAuthenticationOrigin) {
       return
     }
 

--- a/web/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/web/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -205,6 +205,57 @@ describe('announceConfiguration', () => {
     expect(configStore.options.embed.enabled).toStrictEqual(false)
   })
 
+  it('should not allow delegateAuthenticationOrigin to be set via URL query', async () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        search:
+          '?embed=true&embed-delegate-authentication=true&embed-delegate-authentication-origin=https://attacker.example'
+      },
+      writable: true
+    })
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      mock<Response>({
+        status: 200,
+        json: () => Promise.resolve({ theme: '', server: '', options: {} })
+      })
+    )
+    const configStore = useConfigStore()
+    await announceConfiguration({ path: '/config.json', configStore })
+    expect(configStore.options.embed.delegateAuthentication).toStrictEqual(true)
+    expect(configStore.options.embed.delegateAuthenticationOrigin).toBeUndefined()
+  })
+
+  it('should keep the server-configured delegateAuthenticationOrigin even if a URL query tries to override it', async () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        search: '?embed-delegate-authentication-origin=https://attacker.example'
+      },
+      writable: true
+    })
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      mock<Response>({
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            theme: '',
+            server: '',
+            options: {
+              embed: {
+                enabled: true,
+                delegateAuthentication: true,
+                delegateAuthenticationOrigin: 'https://trusted.example'
+              }
+            }
+          })
+      })
+    )
+    const configStore = useConfigStore()
+    await announceConfiguration({ path: '/config.json', configStore })
+    expect(configStore.options.embed.delegateAuthenticationOrigin).toStrictEqual(
+      'https://trusted.example'
+    )
+  })
+
   it('should set default language to value set in URL query when it matches supported languages', async () => {
     Object.defineProperty(window, 'location', {
       value: {

--- a/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -159,6 +159,75 @@ describe('AuthService', () => {
     })
   })
 
+  describe('handleDelegatedTokenUpdate', () => {
+    const buildMessageEvent = (origin: string) =>
+      mock<MessageEvent>({
+        origin,
+        data: { name: 'owncloud-embed:update-token', data: { access_token: 'attacker-token' } }
+      })
+
+    it('when delegateAuthenticationOrigin is not configured, should reject the message regardless of its origin', () => {
+      const authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({ updateContext: mockUpdateContext })
+      })
+
+      const configStore = useConfigStore()
+      configStore.options = { embed: { enabled: true, delegateAuthentication: true } }
+      initAuthService({ authService, configStore })
+      ;(authService as any).handleDelegatedTokenUpdate(
+        buildMessageEvent('https://attacker.example')
+      )
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+
+    it('when the message origin does not match the configured delegateAuthenticationOrigin, should reject the message', () => {
+      const authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({ updateContext: mockUpdateContext })
+      })
+
+      const configStore = useConfigStore()
+      configStore.options = {
+        embed: {
+          enabled: true,
+          delegateAuthentication: true,
+          delegateAuthenticationOrigin: 'https://trusted.example'
+        }
+      }
+      initAuthService({ authService, configStore })
+      ;(authService as any).handleDelegatedTokenUpdate(
+        buildMessageEvent('https://attacker.example')
+      )
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+
+    it('when the message origin matches the configured delegateAuthenticationOrigin, should update the context', () => {
+      const authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({ updateContext: mockUpdateContext })
+      })
+
+      const configStore = useConfigStore()
+      configStore.options = {
+        embed: {
+          enabled: true,
+          delegateAuthentication: true,
+          delegateAuthenticationOrigin: 'https://trusted.example'
+        }
+      }
+      initAuthService({ authService, configStore })
+      ;(authService as any).handleDelegatedTokenUpdate(buildMessageEvent('https://trusted.example'))
+
+      expect(mockUpdateContext).toHaveBeenCalled()
+    })
+  })
+
   describe('acr', () => {
     const mockSignInRedirect = vi.fn()
 


### PR DESCRIPTION
## Description

Hardened origin validation for the delegated authentication feature in Web's embed mode.

## Related Issue

- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-785

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: delegate auth via config

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
