### PR TITLE
fix: [OCISDEV-1001] restrict group member data to authorized users

### DIFF
--- a/changelog/unreleased/security-groups-access-control.md
+++ b/changelog/unreleased/security-groups-access-control.md
@@ -1,0 +1,5 @@
+Security: Restrict group member data to authorized users
+
+The groups API could return group membership details to callers who should not have had access to it. Access to group member data is now properly restricted based on the caller's permissions.
+
+https://github.com/owncloud/ocis/pull/12573

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -262,6 +262,10 @@ func (g Graph) GetGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !g.contextUserHasFullAccountPerms(r.Context()) {
+		group.Members = nil
+	}
+
 	render.Status(r, http.StatusOK)
 	render.JSON(w, r, group)
 }

--- a/services/graph/pkg/service/v0/groups_test.go
+++ b/services/graph/pkg/service/v0/groups_test.go
@@ -303,6 +303,12 @@ var _ = Describe("Groups", func() {
 
 		Context("with an existing group", func() {
 			BeforeEach(func() {
+				permissionService.On("GetPermissionByID", mock.Anything, mock.Anything).Return(&settings.GetPermissionByIDResponse{
+					Permission: &settingsmsg.Permission{
+						Operation:  settingsmsg.Permission_OPERATION_UNKNOWN,
+						Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+					},
+				}, nil)
 				identityBackend.On("GetGroup", mock.Anything, mock.Anything, mock.Anything).Return(newGroup, nil)
 			})
 
@@ -316,6 +322,76 @@ var _ = Describe("Groups", func() {
 
 				Expect(rr.Code).To(Equal(http.StatusOK))
 			})
+		})
+
+		It("does not leak group members to unprivileged users", func() {
+			permissionService.On("GetPermissionByID", mock.Anything, mock.Anything).Return(&settings.GetPermissionByIDResponse{}, nil)
+
+			group := &libregraph.Group{}
+			group.SetId("group1")
+			group.SetDisplayName("Group Name")
+			group.SetMembers(
+				[]libregraph.User{
+					{
+						Id: libregraph.PtrString("userid"),
+					},
+				},
+			)
+			identityBackend.On("GetGroup", mock.Anything, mock.Anything, mock.Anything).Return(group, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups/group1?$expand=members", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("groupID", "group1")
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+
+			svc.GetGroup(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			data, err := io.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			respGroup := libregraph.Group{}
+			err = json.Unmarshal(data, &respGroup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(respGroup.Members).To(BeEmpty())
+		})
+
+		It("returns group members to privileged users", func() {
+			permissionService.On("GetPermissionByID", mock.Anything, mock.Anything).Return(&settings.GetPermissionByIDResponse{
+				Permission: &settingsmsg.Permission{
+					Operation:  settingsmsg.Permission_OPERATION_UNKNOWN,
+					Constraint: settingsmsg.Permission_CONSTRAINT_ALL,
+				},
+			}, nil)
+
+			group := &libregraph.Group{}
+			group.SetId("group1")
+			group.SetDisplayName("Group Name")
+			group.SetMembers(
+				[]libregraph.User{
+					{
+						Id: libregraph.PtrString("userid"),
+					},
+				},
+			)
+			identityBackend.On("GetGroup", mock.Anything, mock.Anything, mock.Anything).Return(group, nil)
+
+			r := httptest.NewRequest(http.MethodGet, "/graph/v1.0/groups/group1?$expand=members", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("groupID", "group1")
+			r = r.WithContext(context.WithValue(revactx.ContextSetUser(ctx, nil), chi.RouteCtxKey, rctx))
+
+			svc.GetGroup(rr, r)
+
+			Expect(rr.Code).To(Equal(http.StatusOK))
+			data, err := io.ReadAll(rr.Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			respGroup := libregraph.Group{}
+			err = json.Unmarshal(data, &respGroup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(respGroup.Members).To(HaveLen(1))
+			Expect(respGroup.Members[0].GetId()).To(Equal("userid"))
 		})
 	})
 


### PR DESCRIPTION
## Description

The groups API could return group membership details to callers who should not have had access to it via the single-group GET endpoint. Access to group member data is now properly restricted based on the caller's permissions.

## Related Issue

- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1001

## How Has This Been Tested?

- test environment: macos, curl
- test case 1: get group as privileged user and check members
- test case 2: get group as non-privileged user and check members

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)
