### PR TITLE
fix: downgrade the trivy action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
             VERSION=${{ needs.determine-release-type.outputs.version }}
           tags: ${{ steps.tags.outputs.tags }}
       - id: trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         continue-on-error: true
         with:
           image-ref: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
Downgrade the `trivy-action` in the release build job from v0.36.0 to v0.35.0 (pinned to the allowed action hash `57a97c7`).

The v0.36.0 hash (`ed142fd`) is not on the owncloud/ocis allowed-actions list, which fails the 8.0.6 release pipeline with:

> aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 is not allowed in owncloud/ocis

This backports the relevant part of #12504 to `stable-8.0`. Minimal single-line change: `stable-8.0`'s `release.yml` only had one offending ref, so the rest of #12504 (unrelated build-push-action removal + reformatting) is intentionally not included.

Needed to unblock the v8.0.6 release tag.
