### PR TITLE
fix: bump pinned vips to 8.18.4-r0

### DIFF
--- a/changelog/8.0.6_2026-07-15/security-upgrade-libvips-8.18.4.md
+++ b/changelog/8.0.6_2026-07-15/security-upgrade-libvips-8.18.4.md
@@ -1,0 +1,7 @@
+Security: Upgrade libvips to 8.18.4
+
+Bumped libvips to 8.18.4 in all Docker images. The previous pin (8.18.3-r0)
+was dropped from the Alpine edge/community repository, which broke the image
+build.
+
+https://github.com/owncloud/ocis/pull/12596

--- a/ocis/docker/Dockerfile.linux.amd64
+++ b/ocis/docker/Dockerfile.linux.amd64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree patch \
-    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.3-r0" \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.4-r0" \
     && echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \

--- a/ocis/docker/Dockerfile.linux.arm64
+++ b/ocis/docker/Dockerfile.linux.arm64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache attr bash ca-certificates curl inotify-tools libc6-compat mailcap tree patch \
-    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.3-r0" \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.4-r0" \
     && echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \

--- a/ocis/docker/Dockerfile.linux.debug.amd64
+++ b/ocis/docker/Dockerfile.linux.debug.amd64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache attr bash ca-certificates curl delve inotify-tools libc6-compat mailcap tree patch \
-    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.3-r0" \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.4-r0" \
     && echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \

--- a/ocis/docker/Dockerfile.linux.debug.arm64
+++ b/ocis/docker/Dockerfile.linux.debug.arm64
@@ -5,7 +5,7 @@ ARG REVISION=""
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache attr bash ca-certificates curl delve inotify-tools libc6-compat mailcap tree patch \
-    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.3-r0" \
+    && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "vips=8.18.4-r0" \
     && echo 'hosts: files dns' >| /etc/nsswitch.conf
 
 LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \


### PR DESCRIPTION
Bump the pinned `vips` version from `8.18.3-r0` to `8.18.4-r0` in all four release Dockerfiles.

Alpine's `edge/community` is a rolling repository that only keeps the latest build of each package. It has moved to `vips=8.18.4-r0` and dropped `8.18.3-r0`, so the exact pin is no longer satisfiable and the `docker-build` job of the v8.0.6 release pipeline fails:

> ERROR: unable to select packages:
>   vips-8.18.4-r0:
>     breaks: world[vips=8.18.3-r0]

This is the same recurring situation the 8.0.4 → 8.18.2 and 8.0.5 → 8.18.3 bumps addressed. Exact pinning is a security requirement, so the fix is to bump the pin to the currently-available (and newer) `8.18.4-r0`.

Needed to unblock the v8.0.6 release tag. Includes a `Security` changelog entry in the 8.0.6 release folder.
