### PR TITLE
fix: upgrade Go to 1.25.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 env:
   NODE_VERSION: '24'
   PNPM_VERSION: '10.28.1'
-  GOLANG_BUILD_IMAGE: 'golang:1.25.11-alpine3.23@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931'
+  GOLANG_BUILD_IMAGE: 'golang:1.25.12-alpine3.23@sha256:cc985ef6f9c3bf9ece7488129c9abe0a150388ccdfa428d886fc709dca0b230a'
 
 jobs:
   determine-release-type:

--- a/changelog/8.0.6_2026-07-15/security-upgrade-go-1.25.12.md
+++ b/changelog/8.0.6_2026-07-15/security-upgrade-go-1.25.12.md
@@ -1,0 +1,8 @@
+Security: Upgrade Go to 1.25.12
+
+Bumped the Go toolchain used to build the release binaries and Docker images
+from 1.25.11 to 1.25.12. Go 1.25.11 is affected by CVE-2026-39822 (os.Root
+symlink following allows directory traversal), which is fixed in 1.25.12 and
+was blocking the release image security scan.
+
+https://github.com/owncloud/ocis/pull/12602

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/owncloud/ocis/v2
 
-go 1.25.11
+go 1.25.12
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION

Fix: bump the Go toolchain from 1.25.11 to 1.25.12.
- `go.mod`: `go 1.25.11` → `go 1.25.12`. The `docker-build` job derives its `golang:<ver>-alpine` build image from `go.mod` via `setup-go`, so this is what actually rebuilds the binary with the patched stdlib.
- `release.yml`: update the pinned `GOLANG_BUILD_IMAGE` to `golang:1.25.12-alpine3.23` with its matching digest, to keep it consistent.

Includes a `Security` changelog entry in the 8.0.6 release folder. Needed to unblock the v8.0.6 release tag.
