### PR TITLE
fix: restore hover feedback lost to background-highlight/default collision

### DIFF
--- a/changelog/unreleased/bugfix-restore-hover-contrast.md
+++ b/changelog/unreleased/bugfix-restore-hover-contrast.md
@@ -1,0 +1,15 @@
+Bugfix: Restore hover feedback in high-contrast and dark themes
+
+The Light and Dark High-Contrast themes set the background-highlight color
+token equal to the default page background, making hover backgrounds
+indistinguishable from the resting background wherever background-highlight
+was used for interactive feedback, such as the global search results
+dropdown. The non-high-contrast Dark theme had the same collision.
+
+background-highlight now matches background-hover in the affected theme
+definitions, and the search results dropdown and create-shortcut context
+menu now use the background-hover color directly for their hover and active
+states, since background-highlight is otherwise used for static surfaces
+like cards, modals and form fields rather than interaction feedback.
+
+https://github.com/owncloud/ocis/pull/12613

--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -147,7 +147,7 @@
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",
               "background-default": "#ffffff",
-              "background-highlight": "#ffffff",
+              "background-highlight": "oklch(87.2% 0.01 258.338)",
               "background-muted": "#ffffff",
               "background-secondary": "#ffffff",
               "background-hover": "oklch(87.2% 0.01 258.338)",
@@ -212,7 +212,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "#383838",
               "background-muted": "oklch(21% 0.034 264.665)",
               "background-secondary": "#404040",
               "background-hover": "#383838",
@@ -279,7 +279,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "oklch(21% 0.034 264.665)",
               "background-muted": "#000000",
               "background-secondary": "#000000",
               "background-hover": "oklch(21% 0.034 264.665)",
@@ -423,7 +423,7 @@
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",
               "background-default": "#ffffff",
-              "background-highlight": "#ffffff",
+              "background-highlight": "oklch(87.2% 0.01 258.338)",
               "background-muted": "#ffffff",
               "background-secondary": "#ffffff",
               "background-hover": "oklch(87.2% 0.01 258.338)",
@@ -489,7 +489,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "#383838",
               "background-muted": "oklch(21% 0.034 264.665)",
               "background-secondary": "#404040",
               "background-hover": "#383838",
@@ -563,7 +563,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "oklch(21% 0.034 264.665)",
               "background-muted": "#000000",
               "background-secondary": "#000000",
               "background-hover": "oklch(21% 0.034 264.665)",

--- a/web/packages/web-app-search/src/portals/SearchBar.vue
+++ b/web/packages/web-app-search/src/portals/SearchBar.vue
@@ -834,7 +834,7 @@ onBeforeUnmount(() => {
 
           &:hover,
           &.active {
-            background-color: var(--oc-color-background-highlight);
+            background-color: var(--oc-color-background-hover);
           }
 
           &.disabled {

--- a/web/packages/web-pkg/src/components/CreateShortcutModal.vue
+++ b/web/packages/web-pkg/src/components/CreateShortcutModal.vue
@@ -435,7 +435,7 @@ defineExpose({ onConfirm })
 
   li:hover,
   li.active {
-    background-color: var(--oc-color-background-highlight);
+    background-color: var(--oc-color-background-hover);
   }
 }
 </style>


### PR DESCRIPTION
## Description
The Light and Dark High-Contrast themes (and the non-high-contrast Dark theme) set the `background-highlight` color token equal to `background-default`. Anywhere `background-highlight` was used for hover/active feedback (e.g. the global search results dropdown, the create-shortcut context menu), the hover background was visually identical to the resting page background, so hovering showed no feedback at all.

`background-highlight` in the affected theme blocks now matches `background-hover`, and the two components that were binding a `:hover`/`.active` state to `background-highlight` (`SearchBar.vue`, `CreateShortcutModal.vue`) now read `--oc-color-background-hover` directly, since `background-highlight` is otherwise used for static surfaces (cards, modals, form fields) rather than interaction feedback.

## Related Issue
- Fixes [OCISDEV-930](https://kiteworks.atlassian.net/browse/OCISDEV-930)

##
Related PR
- https://github.com/owncloud/ocis/pull/12692/

## Motivation and Context
Switching to Light Theme – High Contrast (or Dark Theme) and hovering over search results or the create-shortcut dropdown gave no visual indication of which item was hovered — a real accessibility regression for anyone relying on hover feedback, and the root cause behind reports of "no hover effect showing" on the search bar.

## How Has This Been Tested?
- test environment: local `web/docker-compose.yml` stack, oCIS image rebuilt from this branch
- test case 1: switched to Light Theme – High Contrast on the Account page, opened the global search bar, typed a query, hovered result items — background now shows a visible grey tint instead of staying white
- test case 2: repeated the same check for Dark Theme – High Contrast, Dark Theme, and the create-shortcut modal's file-search dropdown
- test case 3: verified `theme.json` remains valid JSON after edits

## Screenshots (if appropriate):


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
