### PR TITLE
fix(web): preserve focus in file versions sidebar

### DIFF
--- a/changelog/unreleased/bugfix-sidebar-versions-focus.md
+++ b/changelog/unreleased/bugfix-sidebar-versions-focus.md
@@ -1,0 +1,12 @@
+Bugfix: Preserve accessibility focus in the file versions sidebar
+
+Opening the file versions panel with a keyboard or screen reader could move
+focus to the main page, and restoring a version could briefly move focus to the
+main page before selecting the sidebar's back button. The sidebar now manages
+focus throughout panel transitions and loading states, restores focus to the
+control that opened it when closed, and returns focus to the restored version's
+Restore button after the operation completes. Version dates and action labels
+also provide clearer context for screen reader users without duplicate
+announcements or additional tab stops.
+
+https://github.com/owncloud/ocis/pull/12630

--- a/web/package.json
+++ b/web/package.json
@@ -109,9 +109,9 @@
       "@xmldom/xmldom": "0.8.13",
       "flatted": "3.4.2",
       "form-data": "4.0.6",
-      "immutable": "5.1.5",
+      "immutable": "5.1.8",
       "js-cookie": "3.0.7",
-      "linkify-it": "5.0.1",
+      "linkify-it": "5.0.2",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",
       "ws": "8.21.0"
     },

--- a/web/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/web/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-file-versions-sidebar" class="-oc-mt-s">
+  <div id="oc-file-versions-sidebar" ref="fileVersionsSidebar" class="-oc-mt-s">
     <ul v-if="versions.length" class="oc-m-rm oc-position-relative">
       <li class="spacer oc-pb-l" aria-hidden="true"></li>
       <li
@@ -13,25 +13,28 @@
             class="version-date oc-font-semibold"
             data-testid="file-versions-file-last-modified-date"
           >
-            {{ formatVersionDateRelative(item) }}
+            <span aria-hidden="true">{{ formatVersionDateRelative(item) }}</span>
+            <span class="oc-invisible-sr">
+              {{ formatVersionDateRelative(item) }}, {{ formatVersionDate(item) }}
+            </span>
           </span>
 
           -
           <span class="version-filesize" data-testid="file-versions-file-size">
             {{ formatVersionFileSize(item) }}
           </span>
-          <span tabindex="0" class="oc-invisible-sr">
-            {{ formatVersionDateRelative(item) }} {{ formatVersionDate(item) }}
-          </span>
         </div>
-        <oc-list id="oc-file-versions-sidebar-actions" class="oc-pt-xs">
+        <oc-list class="oc-pt-xs">
           <li v-if="isRevertible">
             <oc-button
               data-testid="file-versions-revert-button"
+              :data-version-name="item.name"
               appearance="raw"
-              :aria-label="$gettext('Restore')"
+              :aria-label="
+                $gettext('Restore version from %{date}', { date: formatVersionDate(item) })
+              "
               class="version-action-item oc-width-1-1 oc-rounded oc-button-justify-content-left oc-button-gap-m oc-py-s oc-px-m oc-display-block"
-              @click="revertToVersion(item)"
+              @click="revertToVersion(item, index)"
             >
               <oc-icon name="history" class="oc-icon-m oc-mr-s -oc-mt-xs" fill-type="line" />
               {{ $gettext('Restore') }}
@@ -41,7 +44,9 @@
             <oc-button
               data-testid="file-versions-download-button"
               appearance="raw"
-              :aria-label="$gettext('Download')"
+              :aria-label="
+                $gettext('Download version from %{date}', { date: formatVersionDate(item) })
+              "
               class="version-action-item oc-width-1-1 oc-rounded oc-button-justify-content-left oc-button-gap-m oc-py-s oc-px-m oc-display-block"
               @click="downloadVersion(item)"
             >
@@ -69,7 +74,7 @@ import {
   useDownloadFile,
   useResourcesStore
 } from '@ownclouders/web-pkg'
-import { computed, inject, Ref, unref } from 'vue'
+import { computed, inject, nextTick, onMounted, Ref, unref, useTemplateRef } from 'vue'
 import { isShareSpaceResource, Resource, SpaceResource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 
@@ -81,6 +86,7 @@ const clientService = useClientService()
 const language = useGettext()
 const { downloadFile } = useDownloadFile({ clientService })
 const { updateResourceField } = useResourcesStore()
+const fileVersionsSidebar = useTemplateRef<HTMLElement>('fileVersionsSidebar')
 
 const space = inject<Ref<SpaceResource>>('space')
 const resource = inject<Ref<Resource>>('resource')
@@ -100,9 +106,13 @@ const isRevertible = computed(() => {
   return true
 })
 
-const revertToVersion = async (version: Resource) => {
+const revertToVersion = async (version: Resource, index: number) => {
   await clientService.webdav.restoreFileVersion(unref(space), unref(resource), version.name)
   const restoredResource = await clientService.webdav.getFileInfo(unref(space), unref(resource))
+
+  const sidebar = unref(fileVersionsSidebar)?.closest<HTMLElement>('#app-sidebar')
+  sidebar?.setAttribute('data-focus-return-version', version.name)
+  sidebar?.setAttribute('data-focus-return-index', index.toString())
 
   const fieldsToUpdate = ['size', 'mdate'] as const
   for (const field of fieldsToUpdate) {
@@ -115,6 +125,30 @@ const revertToVersion = async (version: Resource) => {
     }
   }
 }
+
+onMounted(async () => {
+  await nextTick()
+  const sidebar = unref(fileVersionsSidebar)?.closest<HTMLElement>('#app-sidebar')
+  const versionName = sidebar?.getAttribute('data-focus-return-version')
+  const versionIndex = Number.parseInt(sidebar?.getAttribute('data-focus-return-index') || '', 10)
+  if (!versionName || !sidebar) {
+    return
+  }
+
+  const restoreButtons = Array.from(
+    unref(fileVersionsSidebar)?.querySelectorAll<HTMLElement>(
+      '[data-testid="file-versions-revert-button"]'
+    ) || []
+  )
+  const restoreButton =
+    restoreButtons.find((button) => button.dataset.versionName === versionName) ||
+    restoreButtons[versionIndex] ||
+    restoreButtons[0]
+
+  restoreButton?.focus({ preventScroll: true })
+  sidebar.removeAttribute('data-focus-return-version')
+  sidebar.removeAttribute('data-focus-return-index')
+})
 const downloadVersion = (version: Resource) => {
   return downloadFile(unref(space), unref(resource), version.name)
 }

--- a/web/packages/web-app-files/tests/unit/components/SideBar/Versions/FileVersions.spec.ts
+++ b/web/packages/web-app-files/tests/unit/components/SideBar/Versions/FileVersions.spec.ts
@@ -58,8 +58,16 @@ describe('FileVersions', () => {
         const dateElement = wrapper.findAll(selectors.lastModifiedDate)
 
         expect(dateElement.length).toBe(2)
-        expect(dateElement.at(0).text()).toBe('1 day ago')
-        expect(dateElement.at(1).text()).toBe('7 days ago')
+        expect(dateElement.at(0).find('[aria-hidden="true"]').text()).toBe('1 day ago')
+        expect(dateElement.at(1).find('[aria-hidden="true"]').text()).toBe('7 days ago')
+      })
+      it('should expose the full version date without adding a keyboard stop', () => {
+        const { wrapper } = getMountedWrapper({ mountType: shallowMount })
+        const dateElement = wrapper.findAll(selectors.lastModifiedDate)
+
+        expect(dateElement.at(0).find('[tabindex]').exists()).toBe(false)
+        expect(dateElement.at(0).find('[aria-hidden="true"]').text()).toBe('1 day ago')
+        expect(dateElement.at(0).find('.oc-invisible-sr').text()).toContain('1 day ago')
       })
       it('should show content length of each version', () => {
         const { wrapper } = getMountedWrapper({ mountType: shallowMount })
@@ -70,6 +78,17 @@ describe('FileVersions', () => {
         expect(contentLengthElement.at(1).text()).toBe('11 B')
       })
       describe('row actions', () => {
+        it('should identify the version in action labels', () => {
+          const { wrapper } = getMountedWrapper()
+
+          expect(
+            wrapper.findAll(selectors.revertVersionButton).at(0).attributes('aria-label')
+          ).toContain('Restore version from')
+          expect(
+            wrapper.findAll(selectors.downloadVersionButton).at(0).attributes('aria-label')
+          ).toContain('Download version from')
+        })
+
         describe('reverting to a specific version', () => {
           it('should be possible for a non-share', () => {
             const { wrapper } = getMountedWrapper()
@@ -103,6 +122,30 @@ describe('FileVersions', () => {
 
             expect(updateResourceField).toHaveBeenCalledTimes(2)
           })
+          it('should restore focus to the activated version after the list reloads', async () => {
+            const sidebar = document.createElement('div')
+            sidebar.id = 'app-sidebar'
+            document.body.append(sidebar)
+
+            const initial = getMountedWrapper({ attachTo: sidebar })
+            await initial.wrapper.findAll(selectors.revertVersionButton).at(0).trigger('click')
+
+            expect(sidebar.getAttribute('data-focus-return-version')).toBe(defaultVersions[0].name)
+            expect(sidebar.getAttribute('data-focus-return-index')).toBe('0')
+
+            initial.wrapper.unmount()
+            const reloaded = getMountedWrapper({ attachTo: sidebar })
+            await reloaded.wrapper.vm.$nextTick()
+
+            expect(document.activeElement).toBe(
+              reloaded.wrapper.findAll(selectors.revertVersionButton).at(0).element
+            )
+            expect(sidebar.hasAttribute('data-focus-return-version')).toBe(false)
+            expect(sidebar.hasAttribute('data-focus-return-index')).toBe(false)
+
+            reloaded.wrapper.unmount()
+            sidebar.remove()
+          })
         })
 
         it('should call downloadFile method when download version button is clicked', async () => {
@@ -125,12 +168,14 @@ function getMountedWrapper({
   mountType = mount,
   space = undefined,
   versions = defaultVersions,
-  resource = mock<Resource>({ id: '1', size: 0, mdate: '' })
+  resource = mock<Resource>({ id: '1', size: 0, mdate: '' }),
+  attachTo = undefined
 }: {
   mountType?: typeof mount
   space?: SpaceResource
   versions?: Resource[]
   resource?: Resource
+  attachTo?: HTMLElement
 } = {}) {
   const downloadFile = vi.fn()
   vi.mocked(useDownloadFile).mockReturnValue({ downloadFile })
@@ -142,6 +187,7 @@ function getMountedWrapper({
 
   return {
     wrapper: mountType(FileVersions, {
+      attachTo,
       global: {
         mocks,
         renderStubDefaultSlot: true,

--- a/web/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/web/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -3,13 +3,13 @@
     id="app-sidebar"
     ref="appSideBar"
     data-testid="app-sidebar"
-    tabindex="-1"
     :class="{
       'has-active-sub-panel': hasActiveSubPanel,
       'oc-flex oc-flex-center oc-flex-middle': loading,
       'app-sidebar-full-width': fullWidthSideBar
     }"
   >
+    <span ref="focusGuard" class="sidebar-focus-guard" tabindex="-1" />
     <oc-spinner v-if="loading" :aria-label="$gettext('Loading sidebar')" />
     <template v-else>
       <div
@@ -41,7 +41,7 @@
             <oc-icon name="arrow-left-s" fill-type="line" />
           </oc-button>
 
-          <h2 class="header__title oc-my-rm">
+          <h2 class="header__title oc-my-rm" :tabindex="activePanelName === panel.name ? -1 : null">
             {{ panel.title(panelContext) }}
           </h2>
 
@@ -129,6 +129,10 @@ const { isOpen, loading, availablePanels, panelContext, activePanel = '' } = def
 const emit = defineEmits<Emits>()
 const { $gettext } = useGettext()
 const appSideBar = useTemplateRef<HTMLElement>('appSideBar')
+const focusGuard = useTemplateRef<HTMLElement>('focusGuard')
+const focusHandoffPending = ref(false)
+const previouslyFocusedElement =
+  document.activeElement instanceof HTMLElement ? document.activeElement : null
 
 const rootPanels = computed(() => {
   return availablePanels.filter((p) => p.isVisible(panelContext) && p.isRoot?.(panelContext))
@@ -199,6 +203,85 @@ const onResize = () => {
   windowWidth.value = window.innerWidth
 }
 
+const focusActivePanel = async () => {
+  if (!unref(focusHandoffPending) || !isOpen || loading) {
+    return
+  }
+
+  const focusOrigin = document.activeElement
+
+  // Let the browser apply `inert` and settle native focus before notifying
+  // assistive technology about the active panel's focus target.
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+  const activePanel = Array.from(
+    unref(appSideBar)?.querySelectorAll<HTMLElement>('.sidebar-panel') || []
+  ).find((panel) => panel.id === `sidebar-panel-${unref(activePanelName)}`)
+
+  if (
+    activePanel?.contains(document.activeElement) &&
+    document.activeElement !== unref(focusGuard)
+  ) {
+    focusHandoffPending.value = false
+    return
+  }
+
+  if (unref(hasActiveSubPanel) && activePanel) {
+    const transitionDuration = Number.parseFloat(getComputedStyle(activePanel).transitionDuration)
+    if (transitionDuration > 0) {
+      await new Promise<void>((resolve) => {
+        const finish = () => {
+          window.clearTimeout(timeout)
+          activePanel.removeEventListener('transitionend', finish)
+          resolve()
+        }
+        const timeout = window.setTimeout(finish, transitionDuration * 1000 + 50)
+        activePanel.addEventListener('transitionend', finish, { once: true })
+      })
+    }
+  }
+
+  const focusTarget = unref(hasActiveSubPanel)
+    ? activePanel?.querySelector<HTMLElement>('.header__back')
+    : activePanel?.querySelector<HTMLElement>('.header__title')
+  if (document.activeElement === unref(focusGuard) || document.activeElement === focusOrigin) {
+    focusTarget?.focus({ preventScroll: true })
+  }
+  focusHandoffPending.value = false
+}
+
+const requestPanelFocus = () => {
+  focusHandoffPending.value = true
+  void focusActivePanel()
+}
+
+watch(
+  () => activePanel,
+  () => requestPanelFocus(),
+  { flush: 'post' }
+)
+
+watch(
+  () => loading,
+  (isLoading) => {
+    if (!isLoading) {
+      void focusActivePanel()
+    }
+  },
+  { flush: 'post' }
+)
+
+watch(
+  () => loading,
+  (isLoading) => {
+    if (isLoading && unref(appSideBar)?.contains(document.activeElement)) {
+      focusHandoffPending.value = true
+      unref(focusGuard)?.focus({ preventScroll: true })
+    }
+  },
+  { flush: 'sync' }
+)
+
 watch(
   () => isOpen,
   async (isOpen) => {
@@ -227,18 +310,22 @@ function closeSidebar() {
 }
 
 function openPanel(panel: string) {
+  focusHandoffPending.value = true
+  unref(focusGuard)?.focus({ preventScroll: true })
   setOldPanelName(unref(activePanelName))
   setSidebarPanel(panel)
 }
 
 function closePanel() {
+  focusHandoffPending.value = true
   setOldPanelName(unref(activePanelName))
   resetSidebarPanel()
-  unref(appSideBar).focus()
+  unref(focusGuard)?.focus({ preventScroll: true })
 }
 
 onMounted(() => {
   window.addEventListener('resize', onResize)
+  requestPanelFocus()
 })
 
 onBeforeUnmount(() => {
@@ -247,6 +334,12 @@ onBeforeUnmount(() => {
   if (unref(backgroundContentEl)) {
     unref(backgroundContentEl).style.visibility = 'visible'
   }
+
+  nextTick(() => {
+    if (previouslyFocusedElement?.isConnected) {
+      previouslyFocusedElement.focus()
+    }
+  })
 })
 </script>
 
@@ -257,12 +350,14 @@ onBeforeUnmount(() => {
   overflow: hidden;
   min-width: 440px;
   width: 440px;
+}
 
-  &:focus,
-  &:focus-visible {
-    box-shadow: none;
-    outline: none;
-  }
+.sidebar-focus-guard {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
 }
 .app-sidebar-full-width {
   min-width: 100% !important;

--- a/web/packages/web-pkg/src/composables/sideBar/useSideBar.ts
+++ b/web/packages/web-pkg/src/composables/sideBar/useSideBar.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, onBeforeUnmount, readonly, ref, Ref, unref } from 'vue'
+import { computed, onBeforeUnmount, readonly, ref, Ref, unref } from 'vue'
 import { EventBus, eventBus as defaultEventBus } from '../../services/eventBus'
 import { SideBarEventTopics } from './eventTopics'
 import { useLocalStorage } from '../localStorage'
@@ -39,21 +39,9 @@ export const useSideBar = (options?: SideBarOptions): SideBarResult => {
     }
   })
 
-  const focusSidebar = async () => {
-    await nextTick()
-    const appSideBar = document.getElementById('app-sidebar')
-    if (!appSideBar) {
-      return
-    }
-    appSideBar.focus()
-  }
-
   const sideBarActivePanel = ref(null)
   const toggleSideBarToken = eventBus.subscribe(SideBarEventTopics.toggle, () => {
     isSideBarOpen.value = !unref(isSideBarOpen)
-    if (unref(isSideBarOpen)) {
-      focusSidebar()
-    }
   })
   const closeSideBarToken = eventBus.subscribe(SideBarEventTopics.close, () => {
     isSideBarOpen.value = false
@@ -62,14 +50,12 @@ export const useSideBar = (options?: SideBarOptions): SideBarResult => {
   const openSideBarToken = eventBus.subscribe(SideBarEventTopics.open, () => {
     isSideBarOpen.value = true
     sideBarActivePanel.value = null
-    focusSidebar()
   })
   const openSideBarWithPanelToken = eventBus.subscribe(
     SideBarEventTopics.openWithPanel,
     (panelName: string) => {
       isSideBarOpen.value = true
       sideBarActivePanel.value = panelName
-      focusSidebar()
     }
   )
   const setActiveSideBarPanelToken = eventBus.subscribe(

--- a/web/packages/web-pkg/tests/unit/components/sidebar/SideBar.spec.ts
+++ b/web/packages/web-pkg/tests/unit/components/sidebar/SideBar.spec.ts
@@ -1,0 +1,140 @@
+import { defineComponent, nextTick } from 'vue'
+import { defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+import SideBar from '../../../../src/components/SideBar/SideBar.vue'
+import { SideBarPanel } from '../../../../src/components/SideBar/types'
+
+const panelComponent = defineComponent({ template: '<div>Panel content</div>' })
+const rootPanel = {
+  name: 'details',
+  icon: 'information',
+  title: () => 'Details',
+  isVisible: () => true,
+  isRoot: () => true,
+  component: panelComponent
+} as SideBarPanel<any, any, any>
+const versionsPanel = {
+  name: 'versions',
+  icon: 'history',
+  title: () => 'Versions',
+  isVisible: () => true,
+  component: panelComponent
+} as SideBarPanel<any, any, any>
+
+const waitForAnimationFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+describe('SideBar', () => {
+  it('moves focus into the active panel and restores it when closed', async () => {
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+
+    const wrapper = mount(SideBar, {
+      attachTo: document.body,
+      global: { plugins: defaultPlugins() },
+      props: {
+        isOpen: true,
+        loading: false,
+        availablePanels: [rootPanel],
+        panelContext: {}
+      }
+    })
+
+    await nextTick()
+    await waitForAnimationFrame()
+    expect(document.activeElement).toBe(
+      wrapper.find('#sidebar-panel-details .header__title').element
+    )
+
+    wrapper.unmount()
+    await nextTick()
+    expect(document.activeElement).toBe(trigger)
+
+    trigger.remove()
+  })
+
+  it('moves focus into the active panel when loading finishes', async () => {
+    const wrapper = mount(SideBar, {
+      attachTo: document.body,
+      global: { plugins: defaultPlugins() },
+      props: {
+        isOpen: true,
+        loading: true,
+        availablePanels: [rootPanel],
+        panelContext: {}
+      }
+    })
+
+    await wrapper.setProps({ loading: false })
+    await nextTick()
+    await waitForAnimationFrame()
+    expect(document.activeElement).toBe(
+      wrapper.find('#sidebar-panel-details .header__title').element
+    )
+
+    wrapper.unmount()
+  })
+
+  it('does not move external focus into the sidebar after a background reload', async () => {
+    const wrapper = mount(SideBar, {
+      attachTo: document.body,
+      global: { plugins: defaultPlugins() },
+      props: {
+        isOpen: true,
+        loading: false,
+        availablePanels: [rootPanel],
+        panelContext: {}
+      }
+    })
+
+    await nextTick()
+    await waitForAnimationFrame()
+
+    const filterOption = document.createElement('button')
+    document.body.append(filterOption)
+    filterOption.focus()
+
+    await wrapper.setProps({ loading: true })
+    await wrapper.setProps({ loading: false })
+    await nextTick()
+    await waitForAnimationFrame()
+
+    expect(document.activeElement).toBe(filterOption)
+
+    wrapper.unmount()
+    filterOption.remove()
+  })
+
+  it('moves focus to the back button when the versions panel opens', async () => {
+    const wrapper = mount(SideBar, {
+      attachTo: document.body,
+      global: { plugins: defaultPlugins() },
+      props: {
+        isOpen: true,
+        loading: false,
+        availablePanels: [rootPanel, versionsPanel],
+        panelContext: {},
+        onSelectPanel: (panel: string) => wrapper.setProps({ activePanel: panel })
+      }
+    })
+
+    const versionsSelect = wrapper.find('#sidebar-panel-versions-select')
+    ;(versionsSelect.element as HTMLElement).focus()
+    expect(document.activeElement).toBe(versionsSelect.element)
+
+    await versionsSelect.trigger('click')
+    await nextTick()
+    expect(document.activeElement).toBe(wrapper.find('.sidebar-focus-guard').element)
+
+    await waitForAnimationFrame()
+
+    expect(document.activeElement).toBe(
+      wrapper.find('#sidebar-panel-versions .header__back').element
+    )
+
+    await wrapper.setProps({ loading: true })
+    expect(document.activeElement).toBe(wrapper.find('.sidebar-focus-guard').element)
+
+    wrapper.unmount()
+  })
+})

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -12,9 +12,9 @@ overrides:
   '@xmldom/xmldom': 0.8.13
   flatted: 3.4.2
   form-data: 4.0.6
-  immutable: 5.1.5
+  immutable: 5.1.8
   js-cookie: 3.0.7
-  linkify-it: 5.0.1
+  linkify-it: 5.0.2
   minimatch@>=9.0.0 <9.0.7: 9.0.7
   ws: 8.21.0
 
@@ -5167,8 +5167,8 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  immutable@5.1.5:
-    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+  immutable@5.1.8:
+    resolution: {integrity: sha512-TM5YqrGeTsVIPPpILzeqZ8D2Zc2TvNgSDi88zPF2a4cyqQdWV/wVWBDRDbNzzrLeRWScrFcOX9lW2iX6GOtUDw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5483,8 +5483,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
@@ -12090,7 +12090,7 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.8: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -12417,7 +12417,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -12543,7 +12543,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -13446,7 +13446,7 @@ snapshots:
   sass@1.94.1:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.5
+      immutable: 5.1.8
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.6.0


### PR DESCRIPTION
- Keep keyboard and screen-reader focus inside the versions sidebar while panels transition or reload.
- Restore focus to the opening control when the sidebar closes and to the matching Restore action after a version is restored.
- Improve version date and action announcements without introducing duplicate announcements or additional tab stops.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes (https://kiteworks.atlassian.net/browse/OCISDEV-935)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
