### PR TITLE
enhancement(web): add missing main/footer regions and fix skip-to-main link

### DIFF
--- a/changelog/unreleased/enhancement-improve-landmark-regions.md
+++ b/changelog/unreleased/enhancement-improve-landmark-regions.md
@@ -1,0 +1,10 @@
+Enhancement: Improve page structure on several pages
+
+We've added missing `main` and `footer` regions to several pages (404,
+private link resolving, missing config, logout, access denied, public link
+resolving) for a more consistent page structure. We've also fixed the
+"Skip to main" link, which previously did nothing on pages using the plain
+layout (login, logout, public/private link pages) due to a missing target id
+and a stale cached DOM reference.
+
+https://github.com/owncloud/ocis/pull/12637

--- a/web/packages/web-runtime/src/components/SkipTo.vue
+++ b/web/packages/web-runtime/src/components/SkipTo.vue
@@ -14,16 +14,15 @@ export default defineComponent({
       required: true
     }
   },
-  computed: {
-    targetElement() {
-      return document.getElementById(this.target)
-    }
-  },
   methods: {
     skipToTarget() {
-      this.targetElement.setAttribute('tabindex', '-1')
-      this.targetElement.focus()
-      this.targetElement.scrollIntoView()
+      const targetElement = document.getElementById(this.target)
+      if (!targetElement) {
+        return
+      }
+      targetElement.setAttribute('tabindex', '-1')
+      targetElement.focus()
+      targetElement.scrollIntoView()
     }
   }
 })

--- a/web/packages/web-runtime/src/layouts/Plain.vue
+++ b/web/packages/web-runtime/src/layouts/Plain.vue
@@ -3,7 +3,7 @@
     class="oc-login oc-height-viewport"
     :style="{ '--oc-login-background-image': 'url(' + backgroundImg + ')' }"
   >
-    <main>
+    <main id="web-content-main">
       <h1 v-if="pageTitle" class="oc-invisible-sr" v-text="pageTitle" />
       <router-view />
     </main>

--- a/web/packages/web-runtime/src/pages/accessDenied.vue
+++ b/web/packages/web-runtime/src/pages/accessDenied.vue
@@ -14,11 +14,11 @@
           ><span v-text="$gettext('Read more')"
         /></oc-button>
       </div>
-      <div class="oc-login-card-footer oc-pt-rm">
+      <footer class="oc-login-card-footer oc-pt-rm">
         <p>
           {{ footerSlogan }}
         </p>
-      </div>
+      </footer>
     </div>
     <oc-button
       id="exitAnchor"

--- a/web/packages/web-runtime/src/pages/logout.vue
+++ b/web/packages/web-runtime/src/pages/logout.vue
@@ -6,11 +6,11 @@
         <h2 class="oc-login-card-title" v-text="cardTitle" />
         <p v-text="cardHint" />
       </div>
-      <div class="oc-login-card-footer oc-pt-rm">
+      <footer class="oc-login-card-footer oc-pt-rm">
         <p>
           {{ footerSlogan }}
         </p>
-      </div>
+      </footer>
     </div>
     <oc-button
       id="exitAnchor"

--- a/web/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
+++ b/web/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="oc-login-card oc-position-center">
+  <main class="oc-login-card oc-position-center">
     <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
     <div class="oc-login-card-body">
       <h1 v-text="$gettext('Missing or invalid config')" class="oc-login-card-title" />
       <p v-text="$gettext('Please check if the file config.json exists and is correct.')" />
       <p v-text="$gettext('Also, make sure to check the browser console for more information.')" />
     </div>
-    <div class="oc-login-card-footer">
+    <footer class="oc-login-card-footer">
       <p>
         <span v-text="$gettext('For help visit our')" />
         <a
@@ -20,8 +20,8 @@
       <p>
         {{ footerSlogan }}
       </p>
-    </div>
-  </div>
+    </footer>
+  </main>
 </template>
 
 <script lang="ts">

--- a/web/packages/web-runtime/src/pages/notFound.vue
+++ b/web/packages/web-runtime/src/pages/notFound.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="oc-flex oc-flex-center oc-flex-middle oc-flex-column page-not-found">
+  <main class="oc-flex oc-flex-center oc-flex-middle oc-flex-column page-not-found">
     <oc-icon name="emotion-normal" fill-type="line" size="xxlarge" />
     <h1 class="oc-text-muted">404</h1>
     <p
       class="oc-text-xlarge oc-m-rm oc-text-muted"
       v-text="$gettext('The page you are looking for does not exist.')"
     />
-  </div>
+  </main>
 </template>
 <script setup lang="ts"></script>

--- a/web/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/web/packages/web-runtime/src/pages/oidcCallback.vue
@@ -9,9 +9,9 @@
       <h3 class="oc-login-card-title">{{ $gettext('Logging you in') }}</h3>
       <p>{{ $gettext('Please wait, you are being redirected.') }}</p>
     </div>
-    <div class="oc-login-card-footer oc-pt-rm">
+    <footer class="oc-login-card-footer oc-pt-rm">
       <p>{{ footerSlogan }}</p>
-    </div>
+    </footer>
   </div>
 </template>
 

--- a/web/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/web/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <main
     class="oc-link-resolve oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle"
   >
     <div class="oc-card oc-text-center oc-width-large">
@@ -35,7 +35,7 @@
     >
       <span class="text" v-text="openSharedWithMeLabel" />
     </oc-button>
-  </div>
+  </main>
 </template>
 
 <script lang="ts">

--- a/web/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/web/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -1,5 +1,6 @@
 <template>
-  <div
+  <component
+    :is="rootElement"
     class="oc-link-resolve oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle"
   >
     <div class="oc-card oc-text-center oc-width-large">
@@ -52,11 +53,11 @@
           <oc-spinner :aria-hidden="true" />
         </div>
       </template>
-      <div class="oc-card-footer oc-pt-rm">
+      <footer class="oc-card-footer oc-pt-rm">
         <p>{{ footerSlogan }}</p>
-      </div>
+      </footer>
     </div>
-  </div>
+  </component>
 </template>
 
 <script lang="ts" setup>
@@ -101,6 +102,10 @@ const spacesStore = useSpacesStore()
 
 const { currentTheme } = storeToRefs(themeStore)
 const password = ref('')
+
+// the "resolvePublicLink" route already renders inside the Plain layout's own
+// <main>, so avoid nesting a second <main> landmark for that route only
+const rootElement = computed(() => (unref(route).name === 'resolvePublicLink' ? 'div' : 'main'))
 
 const isOcmLink = computed(() => {
   const split = unref(route).path.split('/')?.[1]

--- a/web/packages/web-runtime/tests/unit/components/SkipTo.spec.ts
+++ b/web/packages/web-runtime/tests/unit/components/SkipTo.spec.ts
@@ -1,33 +1,80 @@
 import { DOMWrapper } from '@vue/test-utils'
 import SkipTo from '../../../src/components/SkipTo.vue'
 import { shallowMount } from '@ownclouders/web-test-helpers'
-;(document as any).getElementById = vi.fn(() => ({
-  setAttribute: vi.fn(),
-  focus: vi.fn(),
-  scrollIntoView: vi.fn()
-}))
 
 const selectors = {
   skipButton: '.skip-button'
 }
 
 describe('SkipTo component', () => {
-  const spySkipToTarget = vi.spyOn(SkipTo.methods, 'skipToTarget')
-
-  let wrapper: ReturnType<typeof getShallowWrapper>['wrapper']
-  let skipButton: DOMWrapper<Element>
-  beforeEach(() => {
-    wrapper = getShallowWrapper().wrapper
-    skipButton = wrapper.find(selectors.skipButton)
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should render provided text in the slot', () => {
+    const targetElement = {
+      setAttribute: vi.fn(),
+      focus: vi.fn(),
+      scrollIntoView: vi.fn()
+    }
+    vi.spyOn(document, 'getElementById').mockReturnValue(targetElement as unknown as HTMLElement)
+
+    const { wrapper } = getShallowWrapper()
+    const skipButton: DOMWrapper<Element> = wrapper.find(selectors.skipButton)
+
     expect(skipButton.text()).toEqual('Skip to main')
   })
-  it('should call "skipToTarget" method on click', async () => {
-    await skipButton.trigger('click')
 
-    expect(spySkipToTarget).toHaveBeenCalledTimes(1)
+  it('should look up the target element at click time and focus it', async () => {
+    const targetElement = {
+      setAttribute: vi.fn(),
+      focus: vi.fn(),
+      scrollIntoView: vi.fn()
+    }
+    const getElementByIdSpy = vi
+      .spyOn(document, 'getElementById')
+      .mockReturnValue(targetElement as unknown as HTMLElement)
+
+    const { wrapper } = getShallowWrapper()
+
+    // the target element is not looked up before the button is clicked
+    expect(getElementByIdSpy).not.toHaveBeenCalled()
+
+    await wrapper.find(selectors.skipButton).trigger('click')
+
+    expect(getElementByIdSpy).toHaveBeenCalledWith('main-content')
+    expect(targetElement.setAttribute).toHaveBeenCalledWith('tabindex', '-1')
+    expect(targetElement.focus).toHaveBeenCalledTimes(1)
+    expect(targetElement.scrollIntoView).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-resolves the target on every click, picking up a target added after mount', async () => {
+    const getElementByIdSpy = vi.spyOn(document, 'getElementById').mockReturnValue(null)
+
+    const { wrapper } = getShallowWrapper()
+
+    await wrapper.find(selectors.skipButton).trigger('click')
+    expect(getElementByIdSpy).toHaveBeenCalledTimes(1)
+
+    const targetElement = {
+      setAttribute: vi.fn(),
+      focus: vi.fn(),
+      scrollIntoView: vi.fn()
+    }
+    getElementByIdSpy.mockReturnValue(targetElement as unknown as HTMLElement)
+
+    await wrapper.find(selectors.skipButton).trigger('click')
+
+    expect(getElementByIdSpy).toHaveBeenCalledTimes(2)
+    expect(targetElement.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('should do nothing when the target element does not exist', async () => {
+    vi.spyOn(document, 'getElementById').mockReturnValue(null)
+
+    const { wrapper } = getShallowWrapper()
+
+    await expect(wrapper.find(selectors.skipButton).trigger('click')).resolves.not.toThrow()
   })
 })
 
@@ -35,7 +82,7 @@ function getShallowWrapper() {
   return {
     wrapper: shallowMount(SkipTo, {
       props: {
-        target: ''
+        target: 'main-content'
       },
       slots: {
         default: 'Skip to main'

--- a/web/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
+++ b/web/packages/web-runtime/tests/unit/pages/__snapshots__/accessDenied.spec.ts.snap
@@ -8,9 +8,9 @@ exports[`access denied page > renders component 1`] = `
       <p>This could be because of a routine safety log out, or because your account is either inactive or not yet authorized for use. Please try logging in after a while or seek help from your Administrator.</p>
       <!--v-if-->
     </div>
-    <div class="oc-login-card-footer oc-pt-rm">
+    <footer class="oc-login-card-footer oc-pt-rm">
       <p>ownCloud – A safe home for all your data</p>
-    </div>
+    </footer>
   </div> <a attrs="[object Object]" class="oc-button oc-rounded oc-button-l oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled oc-mt-m oc-width-medium" id="exitAnchor"></a>
 </div>"
 `;

--- a/web/packages/web-runtime/tests/unit/pages/__snapshots__/resolvePublicLink.spec.ts.snap
+++ b/web/packages/web-runtime/tests/unit/pages/__snapshots__/resolvePublicLink.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`resolvePublicLink > password required form > should display if password
 `;
 
 exports[`resolvePublicLink > should display the configuration theme general slogan as the login card footer 1`] = `
-"<div class="oc-card-footer oc-pt-rm">
+"<footer class="oc-card-footer oc-pt-rm">
   <p>ownCloud – A safe home for all your data</p>
-</div>"
+</footer>"
 `;


### PR DESCRIPTION
## Description
Adds missing `main` and `footer` landmark regions to several pages (404, private/public link resolving, missing-config, logout, access-denied) for a more consistent, accessible page structure. Also fixes the "Skip to main" link, which silently did nothing on pages using the plain layout (login, logout, public/private link pages) because the target element had no id and the component cached a stale DOM reference.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1068

## Motivation and Context
Several standalone pages lacked proper `main`/`footer` landmark elements, hurting screen-reader navigation and semantic structure. The "Skip to main" accessibility shortcut was also broken on plain-layout pages since `Plain.vue`'s `<main>` had no `id` to target, and `SkipTo.vue` computed the target element once and cached it instead of looking it up at click time.

## How Has This Been Tested?
- test environment:
- test case 1: Navigate to a page using the plain layout (e.g. login, logout, public/private link resolving) and verify the "Skip to main" link moves focus into the main content.
- test case 2: Verify 404, missing-config, logout, and access-denied pages expose `main`/`footer` landmarks (e.g. via browser dev tools or a screen reader).
- ...

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
