### PR TITLE
enhancement(web): show select-all checkbox label in tile view

### DIFF
--- a/changelog/unreleased/enhancement-show-select-all-checkbox-in-tile-view.md
+++ b/changelog/unreleased/enhancement-show-select-all-checkbox-in-tile-view.md
@@ -1,0 +1,7 @@
+Enhancement: Show the select-all checkbox label in tile view
+
+The label of the select-all checkbox in the resource tiles view is now
+visible, improving the user experience by making it clear what the
+checkbox is for.
+
+https://github.com/owncloud/ocis/pull/12640

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -7,7 +7,7 @@
         class="oc-ml-s"
         size="large"
         :label="selectAllCheckboxLabel"
-        :label-hidden="true"
+        :label-hidden="false"
         :disabled="resources.length === disabledResourceIds.length"
         :model-value="areAllResourcesSelected"
         @click.stop="toggleSelectionAll"

--- a/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`ResourceTiles component > renders a footer slot 1`] = `
 "<div id="tiles-view" class="oc-px-m oc-pt-l">
-  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" disabled="" aria-label="Select all"> <!--v-if--></span>
+  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" disabled=""> <label for="tiles-view-select-all" class="">Select all</label></span>
     <!--v-if-->
   </div>
   <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles"> </ul>
@@ -13,7 +13,7 @@ exports[`ResourceTiles component > renders a footer slot 1`] = `
 
 exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
 "<div id="tiles-view" class="oc-px-m oc-pt-l">
-  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all"> <!--v-if--></span>
+  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l"> <label for="tiles-view-select-all" class="oc-cursor-pointer">Select all</label></span>
     <!--v-if-->
   </div>
   <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles">


### PR DESCRIPTION
## Description
Show the select-all checkbox label in the tile view of the file list, matching the existing behavior in the list view.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-933

## Motivation and Context
The select-all checkbox label was visually hidden in the tile view, which made it unclear what the checkbox was for. Showing the label improves the user experience and makes the checkbox's purpose clear, consistent with the list view.

## How Has This Been Tested?
- test environment: local web dev build
- test case 1: Open the files list in tile view and confirm the select-all checkbox now shows a visible label
- test case 2: Confirm the list view's select-all checkbox is unchanged

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
