### PR TITLE
fix(web): stop breadcrumb items from being announced twice

### DIFF
--- a/changelog/unreleased/bugfix-breadcrumb-duplicate-announcement.md
+++ b/changelog/unreleased/bugfix-breadcrumb-duplicate-announcement.md
@@ -1,0 +1,10 @@
+Bugfix: Stop breadcrumb items from being announced twice
+
+Each breadcrumb list item had `tabindex="0"`, putting the item itself in the
+keyboard/screen reader focus order in addition to the link or button nested
+inside it. This caused every breadcrumb segment to be announced twice in a
+row. The list item is no longer a separate focus stop; only its inner link
+or button is, while the item remains focusable enough for existing
+drag-and-drop styling to keep working.
+
+https://github.com/owncloud/ocis/pull/12643

--- a/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.spec.ts
+++ b/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.spec.ts
@@ -22,6 +22,13 @@ describe('OcBreadcrumb', () => {
     )
     expect(wrapper.html()).toMatchSnapshot()
   })
+  it('does not make list items focusable to avoid duplicate screen reader announcements', () => {
+    const { wrapper } = getWrapper()
+    const listItems = wrapper.findAll('.oc-breadcrumb-list-item:not(.oc-invisible-sr)')
+    listItems.forEach((li) => {
+      expect(li.attributes('tabindex')).not.toBe('0')
+    })
+  })
   it('displays context menu trigger if enabled via property', () => {
     const { wrapper } = getWrapper({ showContextActions: true })
     expect(wrapper.find('#oc-breadcrumb-contextmenu-trigger').exists()).toBe(true)

--- a/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
+++ b/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
@@ -13,7 +13,7 @@
         :data-item-id="item.id"
         :aria-hidden="item.isTruncationPlaceholder"
         :inert="item.isTruncationPlaceholder || undefined"
-        :tabindex="item.isTruncationPlaceholder ? -1 : 0"
+        tabindex="-1"
         :class="[
           'oc-breadcrumb-list-item',
           'oc-flex',

--- a/web/packages/design-system/src/components/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.ts.snap
+++ b/web/packages/design-system/src/components/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`OcBreadcrumb > displays all items 1`] = `
 "<nav id="oc-breadcrumbs-2" class="oc-breadcrumb oc-breadcrumb-default" aria-label="Breadcrumbs">
   <ol class="oc-breadcrumb-list oc-flex oc-m-rm oc-p-rm">
-    <li data-key="0" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="0" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">First folder</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
@@ -13,17 +13,17 @@ exports[`OcBreadcrumb > displays all items 1`] = `
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="2" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="2" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-flex"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Subfolder</span></oc-button-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="3" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="3" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]" aria-current="page"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Deep</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="4" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
+    <li data-key="4" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
       <!--v-if-->
       <!--v-if-->
     </li>
@@ -39,7 +39,7 @@ exports[`OcBreadcrumb > displays all items 1`] = `
 exports[`OcBreadcrumb > sets correct variation 1`] = `
 "<nav id="oc-breadcrumbs-1" class="oc-breadcrumb oc-breadcrumb-lead" aria-label="Breadcrumbs">
   <ol class="oc-breadcrumb-list oc-flex oc-m-rm oc-p-rm">
-    <li data-key="0" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="0" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">First folder</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
@@ -49,17 +49,17 @@ exports[`OcBreadcrumb > sets correct variation 1`] = `
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="2" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="2" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-flex"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Subfolder</span></oc-button-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="3" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="3" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]" aria-current="page"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Deep</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="4" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
+    <li data-key="4" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
       <!--v-if-->
       <!--v-if-->
     </li>


### PR DESCRIPTION
## Description
Each breadcrumb `<li>` in `OcBreadcrumb.vue` had `tabindex="0"`, which put the list item itself into the keyboard/screen reader focus order in addition to the `<a>`/`<button>` nested inside it. As a result, every breadcrumb segment
was announced twice by screen readers (once for the `<li>`, once for its inner link/button).

The `<li>` tabindex is now a static `-1`, removing it from the Tab/AT focus order while keeping it focusable enough for the existing drag-and-drop `@blur` cleanup handler to keep working. The inner link/button remains the single, correctly announced focus stop.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1082

## Motivation and Context
Screen reader users navigating the breadcrumb trail (e.g. Files > Folder >Subfolder) heard each folder name read out twice, which is confusing and adds unnecessary noise to an already repetitive UI element.

## How Has This Been Tested?
- test case 1: manually verified breadcrumb keyboard navigation/tab order still lands correctly on each link/button

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
