### PR TITLE
feat(web): add epub library view

### DIFF
--- a/changelog/unreleased/enhancement-add-epub-library.md
+++ b/changelog/unreleased/enhancement-add-epub-library.md
@@ -1,0 +1,12 @@
+Enhancement: Add EPUB library
+
+The EPUB reader now includes a library for discovering and organizing books
+stored across accessible personal and project spaces. The library extracts
+metadata and cover images in the browser and supports search, sorting, filters,
+favorites, custom shelves, reading statuses, grid and list views, and resuming
+from the reader's saved position.
+
+Book metadata and covers are cached locally. Library preferences are stored in
+the browser and are not synchronized between browsers or devices.
+
+https://github.com/owncloud/ocis/pull/12648

--- a/web/packages/web-app-epub-reader/README.md
+++ b/web/packages/web-app-epub-reader/README.md
@@ -1,0 +1,41 @@
+# EPUB Reader and Library
+
+The ownCloud Web EPUB app combines the built-in EPUB reader with a visual library for books
+stored across accessible personal and project spaces.
+
+## Library features
+
+- Discover EPUB files across accessible spaces
+- Extract embedded metadata and cover images in the browser
+- Search by title, author, publisher, or subject
+- Sort and filter by collection, reading status, author, subject, language, and space
+- Organize books with favorites and custom shelves
+- Switch between grid and list layouts
+- Continue from the location saved by the EPUB reader
+- Open the containing folder, download a book, or copy its private link
+- Cache metadata and covers in IndexedDB
+
+EPUB contents and metadata are not sent to an external metadata service. Favorites, shelves,
+reading-status labels, and the selected layout are stored in browser local storage and do not
+currently synchronize between browsers or devices.
+
+## Usage
+
+1. Upload EPUB files through the Files app.
+2. Open **Library** from the application switcher.
+3. Select a cover to open the book, or use its information button for metadata and file actions.
+4. Use search, sorting, and filters to organize the library.
+
+The library combines WebDAV search with a recursive scan so newly uploaded books can appear
+before search indexing completes. Metadata cache entries are invalidated when file metadata
+changes.
+
+## Development
+
+Run commands from the `web` directory:
+
+```bash
+pnpm --filter epub-reader test:unit -- --run
+pnpm check:types
+pnpm eslint 'packages/web-app-epub-reader/**/*.{ts,vue}' --max-warnings=0
+```

--- a/web/packages/web-app-epub-reader/package.json
+++ b/web/packages/web-app-epub-reader/package.json
@@ -8,7 +8,9 @@
     "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest"
   },
   "dependencies": {
-    "epubjs": "^0.3.93"
+    "@zip.js/zip.js": "2.8.33",
+    "epubjs": "^0.3.93",
+    "focus-trap-vue": "^4.1.0"
   },
   "devDependencies": {
     "@ownclouders/web-test-helpers": "workspace:*"

--- a/web/packages/web-app-epub-reader/src/components/BookDetails.vue
+++ b/web/packages/web-app-epub-reader/src/components/BookDetails.vue
@@ -1,0 +1,535 @@
+<template>
+  <div class="book-details-backdrop">
+    <button
+      type="button"
+      class="backdrop-dismiss"
+      tabindex="-1"
+      :aria-label="$gettext('Close book details')"
+      @click="emit('close')"
+    />
+    <!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
+    <focus-trap :active="true">
+      <aside
+        class="book-details oc-background-default oc-box-shadow-large"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="book-details-title"
+        tabindex="-1"
+        @keydown.esc="emit('close')"
+      >
+        <header class="details-header oc-flex oc-flex-between oc-flex-middle oc-p-m">
+          <h2 id="book-details-title" class="oc-m-rm">{{ $gettext('Book details') }}</h2>
+          <oc-button appearance="raw" :aria-label="$gettext('Close')" @click="emit('close')">
+            <oc-icon name="close" />
+          </oc-button>
+        </header>
+
+        <div class="details-content oc-p-m">
+          <div class="details-hero">
+            <div class="details-cover">
+              <img v-if="book.coverUrl" :src="book.coverUrl" :alt="''" />
+              <div v-else class="details-cover-fallback">
+                <oc-icon name="book" size="xlarge" />
+                <span>{{ book.title }}</span>
+              </div>
+            </div>
+            <div class="details-hero-copy">
+              <button
+                type="button"
+                class="favorite-button"
+                :class="{ 'favorite-button-active': book.favorite }"
+                :aria-label="book.favorite ? $gettext('Remove favorite') : $gettext('Add favorite')"
+                :aria-pressed="book.favorite"
+                @click="emit('toggle-favorite')"
+              >
+                <oc-icon name="star" size="small" variation="inherit" />
+                <span>{{ book.favorite ? $gettext('Favorited') : $gettext('Favorite') }}</span>
+              </button>
+              <h3 class="oc-mb-xs">{{ book.title }}</h3>
+              <p class="oc-text-muted oc-m-rm">
+                {{ book.authors.join(', ') || $gettext('Unknown author') }}
+              </p>
+              <p v-if="book.published" class="oc-text-muted oc-mt-xs">
+                {{ book.published }}
+              </p>
+              <span class="status-badge oc-mt-s">{{ currentStatusLabel }}</span>
+            </div>
+          </div>
+
+          <div class="primary-action oc-mt-l">
+            <oc-button class="reading-action" @click="emit('open')">
+              <oc-icon name="book" size="small" />
+              {{ openActionLabel }}
+            </oc-button>
+          </div>
+          <div class="secondary-actions oc-flex oc-mt-s oc-mb-l">
+            <oc-button appearance="outline" @click="emit('show-in-files')">
+              <oc-icon name="folder" size="small" />
+              {{ $gettext('Show in folder') }}
+            </oc-button>
+            <oc-button appearance="outline" @click="emit('download')">
+              <oc-icon name="download" size="small" />
+              {{ $gettext('Download') }}
+            </oc-button>
+            <oc-button appearance="outline" @click="emit('copy-link')">
+              <oc-icon name="link" size="small" />
+              <span aria-live="polite">{{
+                copied ? $gettext('Copied') : $gettext('Copy link')
+              }}</span>
+            </oc-button>
+          </div>
+
+          <section v-if="book.description" class="details-section description-section">
+            <h3>{{ $gettext('About this book') }}</h3>
+            <p class="details-description">{{ book.description }}</p>
+          </section>
+
+          <section class="organization-card oc-mt-l">
+            <div class="organization-block">
+              <fieldset class="status-fieldset">
+                <legend>{{ $gettext('Reading status') }}</legend>
+                <div class="status-options">
+                  <label
+                    v-for="option in statusOptions"
+                    :key="option.value"
+                    class="status-option"
+                    :class="{ 'status-option-selected': book.readingStatus === option.value }"
+                  >
+                    <input
+                      type="radio"
+                      name="epub-reading-status"
+                      :value="option.value"
+                      :checked="book.readingStatus === option.value"
+                      @change="emit('set-status', option.value)"
+                    />
+                    <span>{{ option.label }}</span>
+                  </label>
+                </div>
+              </fieldset>
+            </div>
+            <div class="organization-block shelves-block">
+              <h3>{{ $gettext('Shelves') }}</h3>
+              <p v-if="!shelves.length" class="oc-text-muted">
+                {{ $gettext('Create a shelf to organize this book.') }}
+              </p>
+              <div v-else class="shelf-options oc-flex oc-flex-wrap">
+                <label v-for="shelf in shelves" :key="shelf.id" class="shelf-option">
+                  <input
+                    type="checkbox"
+                    :checked="book.shelfIds.includes(shelf.id)"
+                    @change="emit('toggle-shelf', shelf.id)"
+                  />
+                  <span>{{ shelf.name }}</span>
+                </label>
+              </div>
+              <div class="new-shelf oc-flex oc-mt-m">
+                <oc-text-input
+                  v-model="newShelfName"
+                  :label="$gettext('New shelf')"
+                  :placeholder="$gettext('Shelf name')"
+                  @keydown.enter="createShelf"
+                />
+                <oc-button
+                  class="add-shelf-button"
+                  size="small"
+                  variant="primary"
+                  :disabled="!newShelfName.trim()"
+                  @click="createShelf"
+                >
+                  {{ $gettext('Add shelf') }}
+                </oc-button>
+              </div>
+            </div>
+          </section>
+
+          <section v-if="hasPublicationMetadata" class="details-section oc-mt-l">
+            <h3>{{ $gettext('Publication') }}</h3>
+            <dl class="book-metadata">
+              <template v-if="book.publisher">
+                <dt>{{ $gettext('Publisher') }}</dt>
+                <dd>{{ book.publisher }}</dd>
+              </template>
+              <template v-if="book.language">
+                <dt>{{ $gettext('Language') }}</dt>
+                <dd>{{ book.language }}</dd>
+              </template>
+              <template v-if="book.subjects.length">
+                <dt>{{ $gettext('Subjects') }}</dt>
+                <dd>{{ book.subjects.join(', ') }}</dd>
+              </template>
+            </dl>
+          </section>
+
+          <details class="file-details oc-mt-l">
+            <summary>{{ $gettext('File details') }}</summary>
+            <dl class="file-metadata">
+              <dt>{{ $gettext('File name') }}</dt>
+              <dd>{{ book.resource.name }}</dd>
+              <dt>{{ $gettext('Location') }}</dt>
+              <dd>{{ locationLabel }}</dd>
+              <dt v-if="book.resource.size">{{ $gettext('Size') }}</dt>
+              <dd v-if="book.resource.size">{{ formattedSize }}</dd>
+            </dl>
+          </details>
+        </div>
+      </aside>
+    </focus-trap>
+    <!-- eslint-enable vuejs-accessibility/no-static-element-interactions -->
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { FocusTrap } from 'focus-trap-vue'
+import type { LibraryBook, LibraryShelf, ReadingStatus } from '../types'
+
+const props = defineProps<{ book: LibraryBook; copied?: boolean; shelves: LibraryShelf[] }>()
+const emit = defineEmits<{
+  (event: 'close' | 'open' | 'show-in-files' | 'download' | 'copy-link'): void
+  (event: 'toggle-favorite'): void
+  (event: 'set-status', status: ReadingStatus): void
+  (event: 'toggle-shelf', shelfId: string): void
+  (event: 'create-shelf', name: string): void
+}>()
+const { $gettext } = useGettext()
+const newShelfName = ref('')
+const statusOptions: { label: string; value: ReadingStatus }[] = [
+  { label: $gettext('Unread'), value: 'unread' },
+  { label: $gettext('Reading'), value: 'reading' },
+  { label: $gettext('Finished'), value: 'finished' }
+]
+const currentStatusLabel = computed(
+  () => statusOptions.find(({ value }) => value === props.book.readingStatus)?.label ?? ''
+)
+const hasPublicationMetadata = computed(() =>
+  Boolean(props.book.publisher || props.book.language || props.book.subjects.length)
+)
+const openActionLabel = computed(() => {
+  if (props.book.readingProgress === 100) return $gettext('Open finished book')
+  if (!props.book.hasReadingPosition) return $gettext('Start reading')
+  if (props.book.readingProgress === undefined) return $gettext('Continue reading')
+  return $gettext('Continue reading · %{progress}%', {
+    progress: String(props.book.readingProgress)
+  })
+})
+const locationLabel = computed(() => {
+  const path = props.book.resource.path.replace(/^\/+/, '')
+  return path ? `${props.book.space.name} / ${path}` : props.book.space.name
+})
+
+const formattedSize = computed(() => {
+  const bytes = Number(props.book.resource.size || 0)
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+})
+
+function createShelf(): void {
+  const name = newShelfName.value.trim()
+  if (!name) return
+  emit('create-shelf', name)
+  newShelfName.value = ''
+}
+</script>
+
+<style scoped>
+.book-details-backdrop {
+  backdrop-filter: blur(2px);
+  background: rgb(0 0 0 / 32%);
+  display: flex;
+  inset: 0;
+  justify-content: flex-end;
+  position: fixed;
+  z-index: 1000;
+}
+
+.book-details {
+  border-radius: 14px 0 0 14px;
+  height: 100%;
+  max-width: 100%;
+  overflow-y: auto;
+  position: relative;
+  width: 34rem;
+  z-index: 1;
+}
+
+.backdrop-dismiss {
+  background: transparent;
+  border: 0;
+  cursor: default;
+  inset: 0;
+  padding: 0;
+  position: absolute;
+}
+
+.details-header {
+  background: var(--oc-color-background-default);
+  border-bottom: 1px solid var(--oc-color-background-muted);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.details-hero {
+  align-items: start;
+  display: grid;
+  gap: var(--oc-space-medium);
+  grid-template-columns: 8rem minmax(0, 1fr);
+  padding: var(--oc-space-medium);
+  background: var(--oc-color-background-muted);
+  border-radius: 12px;
+  position: relative;
+}
+
+.details-hero-copy h3 {
+  padding-right: 7rem;
+}
+
+.favorite-button {
+  align-items: center;
+  background: var(--oc-color-background-default);
+  border: 1px solid var(--oc-color-swatch-passive-default);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  gap: var(--oc-space-xsmall);
+  min-height: 2rem;
+  padding: 0 var(--oc-space-small);
+  position: absolute;
+  right: var(--oc-space-small);
+  top: var(--oc-space-small);
+}
+
+.favorite-button-active {
+  background: var(--oc-color-swatch-primary-default);
+  border-color: var(--oc-color-swatch-primary-default);
+  color: var(--oc-color-swatch-primary-contrast);
+}
+
+.favorite-button:focus-visible {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.favorite-button:hover {
+  border-color: var(--oc-color-swatch-primary-default);
+  box-shadow: 0 0 0 2px var(--oc-color-background-highlight);
+}
+
+.details-cover {
+  aspect-ratio: 2 / 3;
+  background: var(--oc-color-background-muted);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 3px 8px 1px rgb(0 0 0 / 14%);
+}
+
+.details-cover img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.details-cover-fallback {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--oc-space-small);
+  height: 100%;
+  justify-content: center;
+  padding: var(--oc-space-small);
+  text-align: center;
+}
+
+.secondary-actions {
+  gap: var(--oc-space-small);
+}
+
+.reading-action {
+  justify-content: center;
+  width: 100%;
+}
+
+.secondary-actions > * {
+  flex: 1;
+}
+
+.status-badge {
+  background: var(--oc-color-swatch-primary-default);
+  border-radius: 999px;
+  color: var(--oc-color-swatch-primary-contrast);
+  display: inline-flex;
+  font-size: var(--oc-font-size-small);
+  font-weight: 600;
+  padding: var(--oc-space-xsmall) var(--oc-space-small);
+}
+
+.new-shelf {
+  gap: var(--oc-space-small);
+}
+
+.organization-card {
+  background: var(--oc-color-background-muted);
+  border-radius: 10px;
+  padding: var(--oc-space-medium);
+}
+
+.status-fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.status-fieldset legend {
+  font-weight: 600;
+  margin-bottom: var(--oc-space-small);
+}
+
+.status-options {
+  display: grid;
+  gap: var(--oc-space-small);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.status-option {
+  align-items: center;
+  background: var(--oc-color-background-default);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  display: grid;
+  gap: var(--oc-space-small);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  min-height: 2.75rem;
+  padding: 0 var(--oc-space-small);
+}
+
+.status-option:hover {
+  border-color: var(--oc-color-swatch-primary-default);
+  box-shadow: 0 0 0 2px var(--oc-color-background-highlight);
+}
+
+.status-option:focus-within {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.status-option-selected {
+  background: var(--oc-color-background-highlight);
+  border-color: var(--oc-color-swatch-primary-default);
+  font-weight: 600;
+}
+
+.organization-block + .organization-block {
+  border-top: 1px solid var(--oc-color-background-default);
+  margin-top: var(--oc-space-medium);
+  padding-top: var(--oc-space-medium);
+}
+
+.new-shelf {
+  align-items: end;
+}
+
+.new-shelf > :first-child {
+  flex: 1;
+}
+
+.add-shelf-button {
+  min-height: 2.5rem;
+}
+
+.add-shelf-button:hover:not(:disabled) {
+  box-shadow: 0 0 0 3px var(--oc-color-background-highlight);
+  filter: brightness(0.88);
+}
+
+.add-shelf-button:focus-visible {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.shelf-options {
+  gap: var(--oc-space-small);
+}
+
+.shelf-option {
+  align-items: center;
+  display: flex;
+  gap: var(--oc-space-small);
+  background: var(--oc-color-background-default);
+  border-radius: 999px;
+  cursor: pointer;
+  padding: var(--oc-space-xsmall) var(--oc-space-small);
+}
+
+.shelf-option:hover {
+  box-shadow: inset 0 0 0 2px var(--oc-color-swatch-primary-default);
+}
+
+.shelf-option:focus-within {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.details-description {
+  line-height: 1.6;
+  white-space: pre-line;
+}
+
+.book-metadata,
+.file-metadata {
+  display: grid;
+  gap: var(--oc-space-small) var(--oc-space-medium);
+  grid-template-columns: max-content minmax(0, 1fr);
+}
+
+.book-metadata {
+  margin: 0;
+}
+
+.file-details {
+  background: var(--oc-color-background-muted);
+  border-radius: 10px;
+  padding: var(--oc-space-medium);
+}
+
+.file-details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.file-metadata {
+  margin: var(--oc-space-medium) 0 0;
+}
+
+.book-metadata dt,
+.file-metadata dt {
+  font-weight: 600;
+}
+
+.book-metadata dd,
+.file-metadata dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 520px) {
+  .book-details {
+    width: 100%;
+  }
+
+  .status-options {
+    grid-template-columns: 1fr;
+  }
+
+  .secondary-actions {
+    flex-wrap: wrap;
+  }
+
+  .secondary-actions > * {
+    flex: 1 0 45%;
+  }
+}
+</style>

--- a/web/packages/web-app-epub-reader/src/composables/useLibrary.ts
+++ b/web/packages/web-app-epub-reader/src/composables/useLibrary.ts
@@ -1,0 +1,334 @@
+import type { Resource, SpaceResource } from '@ownclouders/web-client'
+import { DavProperties } from '@ownclouders/web-client/webdav'
+import {
+  encodePath,
+  useCapabilityStore,
+  useClientService,
+  useClipboard,
+  useDownloadFile,
+  useFolderLink,
+  useMessages,
+  useRouter,
+  useSpacesStore
+} from '@ownclouders/web-pkg'
+import { computed, onUnmounted, ref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import type { LibraryBook, LibraryShelf, LibrarySort, ReadingStatus } from '../types'
+import { getCachedMetadata, setCachedMetadata } from '../utils/cache'
+import { extractEpubMetadata, titleFromFileName } from '../utils/epub'
+import {
+  getBookPreferences,
+  loadShelves,
+  saveBookPreferences,
+  saveShelves
+} from '../utils/preferences'
+import { getReaderProgress } from '../utils/readerProgress'
+
+const SEARCH_LIMIT = 500
+const METADATA_WORKERS = 4
+const MAX_SCANNED_FOLDERS = 2000
+const EPUB_SEARCH_PATTERN = 'name:*.epub'
+
+export function useLibrary() {
+  const { $gettext } = useGettext()
+  const { showErrorMessage } = useMessages()
+  const clientService = useClientService()
+  const capabilityStore = useCapabilityStore()
+  const spacesStore = useSpacesStore()
+  const router = useRouter()
+  const { downloadFile } = useDownloadFile()
+  const { copyToClipboard } = useClipboard()
+  const { getParentFolderLink } = useFolderLink()
+
+  const searchAvailable = computed(() => !!capabilityStore.davReports?.includes('search-files'))
+
+  const books = ref<LibraryBook[]>([])
+  const loading = ref(false)
+  const error = ref('')
+  const query = ref('')
+  const sort = ref<LibrarySort>('recent')
+  const shelves = ref<LibraryShelf[]>(loadShelves())
+
+  const visibleBooks = computed(() => {
+    const needle = query.value.trim().toLocaleLowerCase()
+    const filtered = needle
+      ? books.value.filter((book) =>
+          [book.title, ...book.authors, book.publisher, ...book.subjects]
+            .join(' ')
+            .toLocaleLowerCase()
+            .includes(needle)
+        )
+      : [...books.value]
+
+    return filtered.sort((left, right) => {
+      if (sort.value === 'title') return left.title.localeCompare(right.title)
+      if (sort.value === 'author') {
+        return (left.authors[0] ?? '').localeCompare(right.authors[0] ?? '')
+      }
+      return (
+        new Date(right.resource.mdate ?? 0).getTime() - new Date(left.resource.mdate ?? 0).getTime()
+      )
+    })
+  })
+
+  async function searchBooks(): Promise<Resource[]> {
+    const { resources } = await clientService.webdav.search(EPUB_SEARCH_PATTERN, {
+      searchLimit: SEARCH_LIMIT,
+      davProperties: DavProperties.Default
+    })
+    return resources.filter((resource) => resource.name.toLowerCase().endsWith('.epub'))
+  }
+
+  async function scanSpace(space: SpaceResource): Promise<Resource[]> {
+    const pendingPaths = [space.path || '/']
+    const visitedPaths = new Set<string>()
+    const epubs: Resource[] = []
+
+    while (pendingPaths.length && visitedPaths.size < MAX_SCANNED_FOLDERS) {
+      const path = pendingPaths.shift()!
+      if (visitedPaths.has(path)) continue
+      visitedPaths.add(path)
+
+      const { children } = await clientService.webdav.listFiles(space, { path }, { depth: 1 })
+
+      for (const resource of children ?? []) {
+        if (resource.isFolder || resource.type === 'folder') {
+          if (resource.path && !visitedPaths.has(resource.path)) pendingPaths.push(resource.path)
+          continue
+        }
+        if (!resource.name.toLowerCase().endsWith('.epub')) continue
+        epubs.push({
+          ...resource,
+          mimeType: resource.mimeType || 'application/epub+zip',
+          spaceId: resource.spaceId || space.id,
+          storageId: resource.storageId || space.id
+        })
+      }
+    }
+
+    if (visitedPaths.size >= MAX_SCANNED_FOLDERS && pendingPaths.length) {
+      console.warn(
+        `EPUB library scan reached the ${MAX_SCANNED_FOLDERS} folder limit in "${space.name}"; results may be incomplete.`
+      )
+    }
+
+    return epubs
+  }
+
+  async function scanSpaces(spaces: SpaceResource[]): Promise<Resource[]> {
+    const results = await Promise.allSettled(spaces.map(scanSpace))
+    const discovered = results.flatMap((result) =>
+      result.status === 'fulfilled' ? result.value : []
+    )
+    if (!discovered.length && results.every((result) => result.status === 'rejected')) {
+      throw (results[0] as PromiseRejectedResult).reason
+    }
+    return discovered
+  }
+
+  async function discoverBooks(spaces: SpaceResource[]): Promise<Resource[]> {
+    // Prefer the server-side search REPORT (fast, one request). Only walk every
+    // folder as a fallback when the server lacks search-files support or the
+    // search request fails, rather than always paying for both.
+    if (searchAvailable.value) {
+      try {
+        return await searchBooks()
+      } catch (cause) {
+        console.warn('EPUB library search failed, falling back to folder scan', cause)
+      }
+    }
+
+    return scanSpaces(spaces)
+  }
+
+  async function hydrateBook(book: LibraryBook): Promise<void> {
+    try {
+      const cachedMetadata = await getCachedMetadata(book.resource)
+      if (cachedMetadata) {
+        Object.assign(book, cachedMetadata)
+        updateReaderProgress(book)
+        return
+      }
+
+      const { response } = await clientService.webdav.getFileContents(
+        book.space,
+        { path: book.resource.path },
+        { responseType: 'blob' }
+      )
+      const metadata = await extractEpubMetadata(response.data as Blob, book.title)
+      Object.assign(book, metadata)
+      updateReaderProgress(book)
+      await setCachedMetadata(book.resource, metadata)
+    } catch (cause) {
+      console.warn(`Could not read EPUB metadata for ${book.resource.name}`, cause)
+      book.metadataError = $gettext('Metadata could not be read')
+    } finally {
+      book.loadingMetadata = false
+    }
+  }
+
+  function updateReaderProgress(book: LibraryBook): void {
+    const readerProgress = getReaderProgress(book.resource, book.spineItemCount)
+    book.hasReadingPosition = readerProgress.hasPosition
+    book.readingProgress = readerProgress.percentage
+    if (readerProgress.finished && book.readingStatus !== 'finished') {
+      book.readingStatus = 'finished'
+      persistBook(book)
+    }
+  }
+
+  async function hydrateBooks(items: LibraryBook[]): Promise<void> {
+    let next = 0
+    async function worker() {
+      while (next < items.length) {
+        const book = items[next++]
+        await hydrateBook(book)
+      }
+    }
+    await Promise.all(Array.from({ length: Math.min(METADATA_WORKERS, items.length) }, worker))
+  }
+
+  async function loadBooks(): Promise<void> {
+    if (loading.value) return
+    loading.value = true
+    error.value = ''
+    books.value.forEach((book) => book.coverUrl && URL.revokeObjectURL(book.coverUrl))
+    books.value = []
+
+    try {
+      const spaces = (spacesStore.spaces as SpaceResource[]).filter((space) => space.id)
+      if (!spaces.length) throw new Error($gettext('No file spaces are available'))
+      const spaceById = new Map(spaces.map((space) => [space.id, space]))
+      const discovered = await discoverBooks(spaces)
+      const resources = [
+        ...new Map(
+          discovered
+            .filter((resource) => spaceById.has(resource.spaceId || resource.storageId || ''))
+            .map((resource) => [resource.id, resource])
+        ).values()
+      ]
+
+      books.value = resources.map((resource) => {
+        const preferences = getBookPreferences(resource)
+        const readerProgress = getReaderProgress(resource)
+        return {
+          id: resource.fileId || resource.id,
+          resource,
+          space: spaceById.get(resource.spaceId || resource.storageId || '')!,
+          title: titleFromFileName(resource.name),
+          authors: [],
+          description: '',
+          language: '',
+          publisher: '',
+          published: '',
+          subjects: [],
+          spineItemCount: 0,
+          loadingMetadata: true,
+          hasReadingPosition: readerProgress.hasPosition,
+          readingProgress: readerProgress.percentage,
+          ...preferences
+        }
+      })
+
+      await hydrateBooks(books.value)
+    } catch (cause) {
+      error.value =
+        cause instanceof Error ? cause.message : $gettext('The library could not be loaded')
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function openBook(book: LibraryBook): void {
+    const driveAliasAndItem = book.space.getDriveAliasAndItem(book.resource)
+    router.push(`/epub-reader/read/${encodePath(driveAliasAndItem)}`)
+  }
+
+  function showBookInFiles(book: LibraryBook): void {
+    router.push(getParentFolderLink(book.resource))
+  }
+
+  function downloadBook(book: LibraryBook): Promise<void> {
+    return downloadFile(book.space, book.resource)
+  }
+
+  async function copyBookLink(book: LibraryBook): Promise<boolean> {
+    const privateLink = book.resource.privateLink
+    if (!privateLink) {
+      showErrorMessage({ title: $gettext('The link could not be copied') })
+      return false
+    }
+    try {
+      await copyToClipboard(privateLink)
+      return true
+    } catch (cause) {
+      console.error(cause)
+      showErrorMessage({ title: $gettext('The link could not be copied'), errors: [cause] })
+      return false
+    }
+  }
+
+  function persistBook(book: LibraryBook): void {
+    saveBookPreferences(book.resource, {
+      favorite: book.favorite,
+      readingStatus: book.readingStatus,
+      shelfIds: book.shelfIds
+    })
+  }
+
+  function toggleFavorite(book: LibraryBook): void {
+    book.favorite = !book.favorite
+    persistBook(book)
+  }
+
+  function setReadingStatus(book: LibraryBook, status: ReadingStatus): void {
+    book.readingStatus = status
+    persistBook(book)
+  }
+
+  function toggleBookShelf(book: LibraryBook, shelfId: string): void {
+    book.shelfIds = book.shelfIds.includes(shelfId)
+      ? book.shelfIds.filter((id) => id !== shelfId)
+      : [...book.shelfIds, shelfId]
+    persistBook(book)
+  }
+
+  function createShelf(name: string): LibraryShelf | null {
+    const trimmedName = name.trim()
+    if (!trimmedName) return null
+    const existing = shelves.value.find(
+      (shelf) => shelf.name.toLocaleLowerCase() === trimmedName.toLocaleLowerCase()
+    )
+    if (existing) return existing
+    const shelf = {
+      id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`,
+      name: trimmedName
+    }
+    shelves.value = [...shelves.value, shelf]
+    saveShelves(shelves.value)
+    return shelf
+  }
+
+  onUnmounted(() => {
+    books.value.forEach((book) => book.coverUrl && URL.revokeObjectURL(book.coverUrl))
+  })
+
+  return {
+    books,
+    copyBookLink,
+    downloadBook,
+    error,
+    loadBooks,
+    loading,
+    openBook,
+    query,
+    createShelf,
+    shelves,
+    showBookInFiles,
+    sort,
+    setReadingStatus,
+    toggleBookShelf,
+    toggleFavorite,
+    visibleBooks
+  }
+}

--- a/web/packages/web-app-epub-reader/src/composables/useLibraryFilters.ts
+++ b/web/packages/web-app-epub-reader/src/composables/useLibraryFilters.ts
@@ -1,0 +1,157 @@
+import { computed, reactive, type Ref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import type { LibraryBook, LibraryShelf } from '../types'
+
+export type LibraryFilterKey = 'collection' | 'author' | 'subject' | 'language' | 'space' | 'status'
+
+interface FilterOption {
+  label: string
+  value: string
+}
+
+export interface LibraryFilter {
+  key: LibraryFilterKey
+  label: string
+  options: FilterOption[]
+}
+
+export interface ActiveLibraryFilter {
+  key: LibraryFilterKey
+  label: string
+  valueLabel: string
+}
+
+interface UseLibraryFiltersOptions {
+  books: Ref<LibraryBook[]>
+  visibleBooks: Ref<LibraryBook[]>
+  shelves: Ref<LibraryShelf[]>
+  query: Ref<string>
+}
+
+function uniqueOptions(values: string[]): FilterOption[] {
+  return [...new Set(values.filter(Boolean))]
+    .sort((left, right) => left.localeCompare(right))
+    .map((value) => ({ label: value, value }))
+}
+
+export function useLibraryFilters({
+  books,
+  visibleBooks,
+  shelves,
+  query
+}: UseLibraryFiltersOptions) {
+  const { $gettext } = useGettext()
+  const filterValues = reactive<Record<LibraryFilterKey, string>>({
+    collection: 'all',
+    author: 'all',
+    subject: 'all',
+    language: 'all',
+    space: 'all',
+    status: 'all'
+  })
+
+  const filters = computed<LibraryFilter[]>(() => [
+    {
+      key: 'collection',
+      label: $gettext('Collection'),
+      options: [
+        { label: $gettext('All books'), value: 'all' },
+        { label: $gettext('Favorites'), value: 'favorites' },
+        ...shelves.value.map(({ id, name }) => ({ label: name, value: `shelf:${id}` }))
+      ]
+    },
+    {
+      key: 'author',
+      label: $gettext('Author'),
+      options: [
+        { label: $gettext('All authors'), value: 'all' },
+        ...uniqueOptions(books.value.flatMap(({ authors }) => authors))
+      ]
+    },
+    {
+      key: 'subject',
+      label: $gettext('Subject'),
+      options: [
+        { label: $gettext('All subjects'), value: 'all' },
+        ...uniqueOptions(books.value.flatMap(({ subjects }) => subjects))
+      ]
+    },
+    {
+      key: 'language',
+      label: $gettext('Language'),
+      options: [
+        { label: $gettext('All languages'), value: 'all' },
+        ...uniqueOptions(books.value.map(({ language }) => language))
+      ]
+    },
+    {
+      key: 'space',
+      label: $gettext('Space'),
+      options: [
+        { label: $gettext('All spaces'), value: 'all' },
+        ...uniqueOptions(books.value.map(({ space }) => space.name))
+      ]
+    },
+    {
+      key: 'status',
+      label: $gettext('Status'),
+      options: [
+        { label: $gettext('All statuses'), value: 'all' },
+        { label: $gettext('Unread'), value: 'unread' },
+        { label: $gettext('Reading'), value: 'reading' },
+        { label: $gettext('Finished'), value: 'finished' }
+      ]
+    }
+  ])
+
+  const filteredBooks = computed(() =>
+    visibleBooks.value.filter((book) => {
+      const collection = filterValues.collection
+      if (collection === 'favorites' && !book.favorite) return false
+      if (collection.startsWith('shelf:') && !book.shelfIds.includes(collection.slice(6))) {
+        return false
+      }
+      if (filterValues.author !== 'all' && !book.authors.includes(filterValues.author)) return false
+      if (filterValues.subject !== 'all' && !book.subjects.includes(filterValues.subject)) {
+        return false
+      }
+      if (filterValues.language !== 'all' && book.language !== filterValues.language) return false
+      if (filterValues.space !== 'all' && book.space.name !== filterValues.space) return false
+      return filterValues.status === 'all' || book.readingStatus === filterValues.status
+    })
+  )
+
+  const hasActiveFilters = computed(
+    () =>
+      Boolean(query.value.trim()) || Object.values(filterValues).some((value) => value !== 'all')
+  )
+
+  const activeFilters = computed<ActiveLibraryFilter[]>(() =>
+    filters.value.flatMap((filter) => {
+      const selectedValue = filterValues[filter.key]
+      if (selectedValue === 'all') return []
+      const selectedOption = filter.options.find(({ value }) => value === selectedValue)
+      return selectedOption
+        ? [{ key: filter.key, label: filter.label, valueLabel: selectedOption.label }]
+        : []
+    })
+  )
+
+  function clearFilter(key: LibraryFilterKey): void {
+    filterValues[key] = 'all'
+  }
+
+  function resetFilters(): void {
+    Object.keys(filterValues).forEach((key) => (filterValues[key as LibraryFilterKey] = 'all'))
+  }
+
+  return {
+    activeFilters,
+    clearFilter,
+    filteredBooks,
+    filters,
+    filterValues,
+    hasActiveFilters,
+    resetFilters
+  }
+}

--- a/web/packages/web-app-epub-reader/src/index.ts
+++ b/web/packages/web-app-epub-reader/src/index.ts
@@ -1,6 +1,7 @@
+import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import translations from '../l10n/translations.json'
-import { AppWrapperRoute, defineWebApplication } from '@ownclouders/web-pkg'
+import { AppMenuItemExtension, AppWrapperRoute, defineWebApplication } from '@ownclouders/web-pkg'
 
 export default defineWebApplication({
   setup() {
@@ -10,7 +11,16 @@ export default defineWebApplication({
 
     const routes = [
       {
-        path: '/:driveAliasAndItem(.*)?',
+        path: '/',
+        component: () => import('./views/LibraryView.vue'),
+        name: 'epub-library',
+        meta: {
+          authContext: 'user',
+          title: $gettext('Library')
+        }
+      },
+      {
+        path: '/read/:driveAliasAndItem(.*)?',
         component: async () => {
           // lazy loading to avoid loading the epubjs package on page load
           const EpubReader = (await import('./App.vue')).default
@@ -30,20 +40,36 @@ export default defineWebApplication({
       }
     ]
 
+    const appInfo = {
+      name: $gettext('Epub Reader'),
+      id: appId,
+      icon: 'book-read',
+      color: '#4f46e5',
+      extensions: [
+        {
+          extension: 'epub',
+          routeName: 'epub-reader'
+        }
+      ]
+    }
+
+    const extensions = computed<AppMenuItemExtension[]>(() => [
+      {
+        id: `app.${appId}.menuItem`,
+        type: 'appMenuItem',
+        label: () => $gettext('Library'),
+        color: appInfo.color,
+        icon: 'book',
+        priority: 50,
+        path: `/${appId}`
+      }
+    ])
+
     return {
-      appInfo: {
-        name: $gettext('Epub Reader'),
-        id: appId,
-        icon: 'book-read',
-        extensions: [
-          {
-            extension: 'epub',
-            routeName: 'epub-reader'
-          }
-        ]
-      },
+      appInfo,
       routes,
-      translations
+      translations,
+      extensions
     }
   }
 })

--- a/web/packages/web-app-epub-reader/src/types.ts
+++ b/web/packages/web-app-epub-reader/src/types.ts
@@ -1,0 +1,42 @@
+import type { Resource, SpaceResource } from '@ownclouders/web-client'
+
+export interface EpubMetadata {
+  title: string
+  authors: string[]
+  description: string
+  language: string
+  publisher: string
+  published: string
+  subjects: string[]
+  spineItemCount: number
+  coverUrl?: string
+  coverBlob?: Blob
+}
+
+export interface LibraryBook extends EpubMetadata {
+  id: string
+  resource: Resource
+  space: SpaceResource
+  loadingMetadata: boolean
+  metadataError?: string
+  favorite: boolean
+  readingStatus: ReadingStatus
+  shelfIds: string[]
+  readingProgress?: number
+  hasReadingPosition: boolean
+}
+
+export type LibrarySort = 'recent' | 'title' | 'author'
+export type ReadingStatus = 'unread' | 'reading' | 'finished'
+export type LibraryViewMode = 'grid' | 'list'
+
+export interface LibraryShelf {
+  id: string
+  name: string
+}
+
+export interface BookPreferences {
+  favorite: boolean
+  readingStatus: ReadingStatus
+  shelfIds: string[]
+}

--- a/web/packages/web-app-epub-reader/src/utils/cache.ts
+++ b/web/packages/web-app-epub-reader/src/utils/cache.ts
@@ -1,0 +1,96 @@
+import type { Resource } from '@ownclouders/web-client'
+import type { EpubMetadata } from '../types'
+
+const DATABASE_NAME = 'ocis-epub-library'
+const DATABASE_VERSION = 1
+const STORE_NAME = 'metadata'
+
+interface CachedMetadataRecord {
+  id: string
+  fingerprint: string
+  metadata: Omit<EpubMetadata, 'coverBlob' | 'coverUrl'>
+  coverBlob?: Blob
+}
+
+export function resourceCacheId(resource: Resource): string {
+  return resource.fileId || resource.id || `${resource.spaceId}:${resource.path}`
+}
+
+export function resourceFingerprint(resource: Resource): string {
+  return [resource.etag || '', resource.mdate || '', String(resource.size || 0)].join(':')
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION)
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function getCachedMetadata(resource: Resource): Promise<EpubMetadata | null> {
+  if (typeof indexedDB === 'undefined') return null
+  try {
+    const database = await openDatabase()
+    const record = await new Promise<CachedMetadataRecord | undefined>((resolve, reject) => {
+      const request = database
+        .transaction(STORE_NAME, 'readonly')
+        .objectStore(STORE_NAME)
+        .get(resourceCacheId(resource))
+      request.onsuccess = () => resolve(request.result as CachedMetadataRecord | undefined)
+      request.onerror = () => reject(request.error)
+    })
+    database.close()
+    if (
+      !record ||
+      record.fingerprint !== resourceFingerprint(resource) ||
+      typeof record.metadata.spineItemCount !== 'number'
+    ) {
+      return null
+    }
+    return {
+      ...record.metadata,
+      coverBlob: record.coverBlob,
+      coverUrl: record.coverBlob ? URL.createObjectURL(record.coverBlob) : undefined
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function setCachedMetadata(resource: Resource, metadata: EpubMetadata): Promise<void> {
+  if (typeof indexedDB === 'undefined') return
+  try {
+    const database = await openDatabase()
+    const persistedMetadata: CachedMetadataRecord['metadata'] = {
+      authors: metadata.authors,
+      description: metadata.description,
+      language: metadata.language,
+      published: metadata.published,
+      publisher: metadata.publisher,
+      subjects: metadata.subjects,
+      spineItemCount: metadata.spineItemCount,
+      title: metadata.title
+    }
+    const record: CachedMetadataRecord = {
+      id: resourceCacheId(resource),
+      fingerprint: resourceFingerprint(resource),
+      metadata: persistedMetadata,
+      coverBlob: metadata.coverBlob
+    }
+    await new Promise<void>((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, 'readwrite')
+      transaction.objectStore(STORE_NAME).put(record)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+    database.close()
+  } catch (e) {
+    console.error('Failed to set cached metadata', e)
+  }
+}

--- a/web/packages/web-app-epub-reader/src/utils/epub.ts
+++ b/web/packages/web-app-epub-reader/src/utils/epub.ts
@@ -1,0 +1,144 @@
+import * as zip from '@zip.js/zip.js'
+import type { EpubMetadata } from '../types'
+
+const textDecoder = new TextDecoder()
+
+function normalizedPath(path: string): string {
+  const parts: string[] = []
+  for (const segment of path.split('/')) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') parts.pop()
+    else parts.push(segment)
+  }
+  return parts.join('/')
+}
+
+function resolvePath(baseFile: string, relativePath: string): string {
+  const base = baseFile.includes('/') ? baseFile.slice(0, baseFile.lastIndexOf('/') + 1) : ''
+  return normalizedPath(`${base}${relativePath}`)
+}
+
+function elementsByLocalName(root: ParentNode, localName: string): Element[] {
+  return [...root.querySelectorAll('*')].filter(
+    (element) => element.localName === localName || element.tagName.split(':').pop() === localName
+  )
+}
+
+function firstText(document: Document, localName: string): string {
+  return elementsByLocalName(document, localName)[0]?.textContent?.trim() ?? ''
+}
+
+function allText(document: Document, localName: string): string[] {
+  return elementsByLocalName(document, localName)
+    .map((element) => element.textContent?.trim() ?? '')
+    .filter(Boolean)
+}
+
+export function metadataFromPackageDocument(
+  packageXml: string,
+  fallbackTitle: string
+): EpubMetadata & { coverHref?: string; coverMediaType?: string } {
+  const document = new DOMParser().parseFromString(packageXml, 'application/xml')
+  if (document.querySelector('parsererror')) {
+    throw new Error('Invalid EPUB package document')
+  }
+
+  const metadataElements = elementsByLocalName(document, 'meta')
+  const manifestItems = elementsByLocalName(document, 'item')
+  const coverImageItem = manifestItems.find((element) =>
+    element.getAttribute('properties')?.split(/\s+/).includes('cover-image')
+  )
+  const coverId =
+    metadataElements
+      .find((element) => element.getAttribute('name') === 'cover')
+      ?.getAttribute('content') ??
+    coverImageItem?.getAttribute('id') ??
+    ''
+  const coverItem =
+    manifestItems.find((element) => element.getAttribute('id') === coverId) ?? coverImageItem
+
+  return {
+    title: firstText(document, 'title') || fallbackTitle,
+    authors: allText(document, 'creator'),
+    description: firstText(document, 'description'),
+    language: firstText(document, 'language'),
+    publisher: firstText(document, 'publisher'),
+    published: firstText(document, 'date'),
+    subjects: allText(document, 'subject'),
+    spineItemCount: elementsByLocalName(document, 'itemref').length,
+    coverHref: coverItem?.getAttribute('href') ?? undefined,
+    coverMediaType: coverItem?.getAttribute('media-type') ?? undefined
+  }
+}
+
+async function entryText(entry: zip.FileEntry): Promise<string> {
+  const data = await entry.getData(new zip.Uint8ArrayWriter())
+  return textDecoder.decode(data)
+}
+
+export async function extractEpubMetadata(
+  data: Blob,
+  fallbackTitle: string
+): Promise<EpubMetadata> {
+  // Extensions are loaded as standalone bundles from oCIS. ZIP.js cannot
+  // reliably resolve its worker script from that runtime location, which can
+  // leave metadata extraction pending indefinitely. EPUB metadata is small
+  // enough to process on the main thread.
+  const reader = new zip.ZipReader(new zip.BlobReader(data), {
+    useWebWorkers: false
+  })
+  try {
+    const entries = (await reader.getEntries()).filter(
+      (entry): entry is zip.FileEntry => !entry.directory
+    )
+    const byName = new Map(entries.map((entry) => [normalizedPath(entry.filename), entry]))
+    const containerEntry = byName.get('META-INF/container.xml')
+    if (!containerEntry) throw new Error('EPUB container.xml is missing')
+
+    const container = new DOMParser().parseFromString(
+      await entryText(containerEntry),
+      'application/xml'
+    )
+    const packagePath = container.querySelector('rootfile')?.getAttribute('full-path')
+    if (!packagePath) throw new Error('EPUB package path is missing')
+
+    const normalizedPackagePath = normalizedPath(packagePath)
+    const packageEntry = byName.get(normalizedPackagePath)
+    if (!packageEntry) throw new Error('EPUB package document is missing')
+
+    const parsed = metadataFromPackageDocument(await entryText(packageEntry), fallbackTitle)
+    let coverUrl: string | undefined
+    let coverBlob: Blob | undefined
+
+    if (parsed.coverHref) {
+      const coverEntry = byName.get(resolvePath(normalizedPackagePath, parsed.coverHref))
+      if (coverEntry) {
+        coverBlob = await coverEntry.getData(new zip.BlobWriter(parsed.coverMediaType))
+        coverUrl = URL.createObjectURL(coverBlob)
+      }
+    }
+
+    return {
+      title: parsed.title,
+      authors: parsed.authors,
+      description: parsed.description,
+      language: parsed.language,
+      publisher: parsed.publisher,
+      published: parsed.published,
+      subjects: parsed.subjects,
+      spineItemCount: parsed.spineItemCount,
+      coverUrl,
+      coverBlob
+    }
+  } finally {
+    await reader.close()
+  }
+}
+
+export function titleFromFileName(name: string): string {
+  return name
+    .replace(/\.epub$/i, '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/web/packages/web-app-epub-reader/src/utils/preferences.ts
+++ b/web/packages/web-app-epub-reader/src/utils/preferences.ts
@@ -1,0 +1,66 @@
+import type { Resource } from '@ownclouders/web-client'
+import type { BookPreferences, LibraryShelf, LibraryViewMode } from '../types'
+import { resourceCacheId } from './cache'
+
+const STORAGE_KEY = 'ocis-epub-library-preferences-v1'
+
+interface StoredPreferences {
+  books: Record<string, BookPreferences>
+  shelves: LibraryShelf[]
+  viewMode: LibraryViewMode
+}
+
+const defaults = (): StoredPreferences => ({ books: {}, shelves: [], viewMode: 'grid' })
+
+function read(): StoredPreferences {
+  if (typeof localStorage === 'undefined') return defaults()
+  try {
+    return { ...defaults(), ...JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') }
+  } catch {
+    return defaults()
+  }
+}
+
+function write(value: StoredPreferences): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+  } catch {
+    // Preferences remain available for this session when browser storage is disabled.
+  }
+}
+
+export function getBookPreferences(resource: Resource): BookPreferences {
+  return {
+    favorite: false,
+    readingStatus: 'unread',
+    shelfIds: [],
+    ...read().books[resourceCacheId(resource)]
+  }
+}
+
+export function saveBookPreferences(resource: Resource, preferences: BookPreferences): void {
+  const stored = read()
+  stored.books[resourceCacheId(resource)] = preferences
+  write(stored)
+}
+
+export function loadShelves(): LibraryShelf[] {
+  return read().shelves
+}
+
+export function saveShelves(shelves: LibraryShelf[]): void {
+  const stored = read()
+  stored.shelves = shelves
+  write(stored)
+}
+
+export function loadViewMode(): LibraryViewMode {
+  return read().viewMode
+}
+
+export function saveViewMode(viewMode: LibraryViewMode): void {
+  const stored = read()
+  stored.viewMode = viewMode
+  write(stored)
+}

--- a/web/packages/web-app-epub-reader/src/utils/readerProgress.ts
+++ b/web/packages/web-app-epub-reader/src/utils/readerProgress.ts
@@ -1,0 +1,59 @@
+import type { Resource } from '@ownclouders/web-client'
+
+interface ReaderLocation {
+  atEnd?: boolean
+  atStart?: boolean
+  start?: {
+    cfi?: string
+    displayed?: { page?: number; total?: number }
+    index?: number
+    percentage?: number
+  }
+}
+
+export interface ReaderProgress {
+  finished: boolean
+  hasPosition: boolean
+  percentage?: number
+}
+
+function fallbackPercentage(location: ReaderLocation, spineItemCount: number): number | undefined {
+  const { displayed, index } = location.start ?? {}
+  if (!spineItemCount || typeof index !== 'number') return undefined
+
+  const page = displayed?.page ?? 1
+  const totalPages = displayed?.total ?? 1
+  const chapterProgress = totalPages > 0 ? (page - 1) / totalPages : 0
+  const percentage = Math.round(((index + chapterProgress) / spineItemCount) * 100)
+
+  if (location.atEnd) return 100
+  if (location.atStart) return 0
+  return Math.max(1, Math.min(99, percentage))
+}
+
+export function getReaderProgress(resource: Resource, spineItemCount = 0): ReaderProgress {
+  if (typeof localStorage === 'undefined') return { finished: false, hasPosition: false }
+
+  try {
+    const storedValue = localStorage.getItem(`oc_epubReader_resource_${resource.id}`)
+    if (!storedValue) return { finished: false, hasPosition: false }
+
+    const location = (JSON.parse(storedValue) as { currentLocation?: ReaderLocation })
+      .currentLocation
+    if (!location?.start?.cfi) return { finished: false, hasPosition: false }
+
+    const savedPercentage = location.start.percentage
+    const percentage =
+      typeof savedPercentage === 'number' && savedPercentage > 0
+        ? Math.round(savedPercentage * 100)
+        : fallbackPercentage(location, spineItemCount)
+    return {
+      finished: location.atEnd === true || percentage === 100,
+      hasPosition: true,
+      percentage:
+        typeof percentage === 'number' ? Math.max(0, Math.min(100, percentage)) : undefined
+    }
+  } catch {
+    return { finished: false, hasPosition: false }
+  }
+}

--- a/web/packages/web-app-epub-reader/src/views/LibraryView.vue
+++ b/web/packages/web-app-epub-reader/src/views/LibraryView.vue
@@ -1,0 +1,872 @@
+<template>
+  <main class="library oc-p-m" :aria-label="$gettext('Library')">
+    <header class="library-header oc-flex oc-flex-between oc-flex-middle oc-mb-l">
+      <div>
+        <h1 class="oc-m-rm">{{ $gettext('Library') }}</h1>
+        <p class="oc-text-muted oc-m-rm">
+          {{ $gettext('Browse EPUB books stored in your ownCloud spaces.') }}
+        </p>
+      </div>
+      <oc-button appearance="outline" :disabled="loading" @click="loadBooks">
+        <oc-icon name="refresh" size="small" />
+        {{ $gettext('Refresh') }}
+      </oc-button>
+    </header>
+
+    <div class="library-controls oc-flex oc-flex-between oc-flex-middle oc-mb-l">
+      <oc-text-input
+        v-model="query"
+        class="library-search"
+        :label="$gettext('Search books')"
+        :placeholder="$gettext('Title, author, publisher or subject')"
+      />
+      <oc-select
+        :model-value="selectedSortOption"
+        class="library-sort"
+        :label="$gettext('Sort by')"
+        :options="sortOptions"
+        option-label="label"
+        @update:model-value="onSortUpdate"
+      />
+    </div>
+
+    <section
+      v-if="showContinueReading"
+      class="continue-section oc-mb-xl"
+      aria-labelledby="continue-reading-heading"
+    >
+      <div class="continue-section-heading oc-flex oc-flex-between oc-flex-middle oc-mb-m">
+        <div>
+          <h2 id="continue-reading-heading" class="oc-m-rm">
+            {{ $gettext('Continue reading') }}
+          </h2>
+          <p class="oc-text-muted oc-m-rm">{{ $gettext('Pick up where you left off.') }}</p>
+        </div>
+      </div>
+      <div class="continue-list">
+        <button
+          v-for="book in continueReadingBooks"
+          :key="book.id"
+          type="button"
+          class="continue-card"
+          :aria-label="$gettext('Continue reading %{title}', { title: book.title })"
+          @click="openBook(book)"
+        >
+          <span class="continue-cover">
+            <img v-if="book.coverUrl" :src="book.coverUrl" :alt="''" />
+            <oc-icon v-else name="book" size="large" />
+          </span>
+          <span class="continue-card-content">
+            <strong>{{ book.title }}</strong>
+            <span class="oc-text-muted">
+              {{ book.authors.join(', ') || $gettext('Unknown author') }}
+            </span>
+            <span class="continue-card-progress">
+              {{
+                book.readingProgress === undefined
+                  ? $gettext('Resume')
+                  : $gettext('%{progress}% complete', { progress: String(book.readingProgress) })
+              }}
+            </span>
+            <span
+              v-if="book.readingProgress !== undefined"
+              class="reading-progress"
+              role="progressbar"
+              :aria-label="$gettext('Reading progress for %{title}', { title: book.title })"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              :aria-valuenow="book.readingProgress"
+            >
+              <span :style="{ width: `${book.readingProgress}%` }" />
+            </span>
+          </span>
+        </button>
+      </div>
+    </section>
+
+    <div class="library-toolbar oc-flex oc-flex-between oc-flex-middle oc-mb-l">
+      <div class="library-filters">
+        <label v-for="filter in primaryFilters" :key="filter.key" class="library-filter">
+          <span>{{ filter.label }}</span>
+          <select v-model="filterValues[filter.key]">
+            <option v-for="option in filter.options" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
+          </select>
+        </label>
+        <oc-button
+          appearance="outline"
+          class="advanced-filter-toggle"
+          aria-controls="advanced-library-filters"
+          :aria-expanded="showAdvancedFilters"
+          @click="showAdvancedFilters = !showAdvancedFilters"
+        >
+          <oc-icon name="filter" size="small" />
+          {{ $gettext('More filters') }}
+          <span v-if="advancedFilterCount">({{ advancedFilterCount }})</span>
+        </oc-button>
+      </div>
+      <div class="view-toggle oc-flex" role="group" :aria-label="$gettext('View mode')">
+        <button
+          type="button"
+          class="view-toggle-button"
+          :class="{ 'view-toggle-button-selected': viewMode === 'grid' }"
+          :aria-pressed="viewMode === 'grid'"
+          @click="setViewMode('grid')"
+        >
+          {{ $gettext('Grid') }}
+        </button>
+        <button
+          type="button"
+          class="view-toggle-button"
+          :class="{ 'view-toggle-button-selected': viewMode === 'list' }"
+          :aria-pressed="viewMode === 'list'"
+          @click="setViewMode('list')"
+        >
+          {{ $gettext('List') }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="showAdvancedFilters"
+      id="advanced-library-filters"
+      class="advanced-filters oc-mb-m oc-p-m"
+    >
+      <label v-for="filter in advancedFilters" :key="filter.key" class="library-filter">
+        <span>{{ filter.label }}</span>
+        <select v-model="filterValues[filter.key]">
+          <option v-for="option in filter.options" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
+    </div>
+
+    <div v-if="activeFilters.length" class="active-filters oc-flex oc-flex-wrap oc-mb-l">
+      <oc-button
+        v-for="filter in activeFilters"
+        :key="filter.key"
+        appearance="raw"
+        class="filter-chip"
+        :aria-label="
+          $gettext('Remove %{label} filter: %{value}', {
+            label: filter.label,
+            value: filter.valueLabel
+          })
+        "
+        @click="clearFilter(filter.key)"
+      >
+        <span>{{ filter.label }}: {{ filter.valueLabel }}</span>
+        <oc-icon name="close" size="small" />
+      </oc-button>
+      <oc-button appearance="raw" @click="resetFilters">{{ $gettext('Clear all') }}</oc-button>
+    </div>
+
+    <div v-if="loading && !books.length" class="library-state" role="status">
+      <oc-spinner size="large" />
+      <p>{{ $gettext('Finding EPUB books…') }}</p>
+    </div>
+
+    <div v-else-if="error" class="library-state" role="alert">
+      <oc-icon name="error-warning" size="xlarge" />
+      <h2>{{ $gettext('Library unavailable') }}</h2>
+      <p>{{ error }}</p>
+      <oc-button @click="loadBooks">{{ $gettext('Try again') }}</oc-button>
+    </div>
+
+    <div v-else-if="!filteredBooks.length" class="library-state">
+      <oc-icon name="book" size="xlarge" />
+      <h2>
+        {{ hasActiveFilters ? $gettext('No matching books') : $gettext('No EPUB books found') }}
+      </h2>
+      <p v-if="!hasActiveFilters">
+        {{ $gettext('Upload EPUB files to an accessible ownCloud space and refresh the library.') }}
+      </p>
+    </div>
+
+    <template v-else>
+      <p class="oc-text-muted oc-mb-m" role="status">
+        {{ $gettext('%{count} books', { count: String(filteredBooks.length) }) }}
+        <span v-if="loading"> · {{ $gettext('Reading metadata…') }}</span>
+      </p>
+      <div class="bookshelf" :class="`bookshelf-${viewMode}`">
+        <article v-for="book in filteredBooks" :key="book.id" class="book-card">
+          <oc-button
+            appearance="raw"
+            class="book-details-button"
+            :aria-label="$gettext('View details for %{title}', { title: book.title })"
+            @click="showDetails(book, $event)"
+          >
+            <oc-icon name="information" size="small" />
+          </oc-button>
+          <button
+            type="button"
+            class="book-open"
+            :aria-label="$gettext('Open %{title}', { title: book.title })"
+            @click="openBook(book)"
+          >
+            <span class="book-cover">
+              <img v-if="book.coverUrl" :src="book.coverUrl" :alt="''" />
+              <span v-else class="book-cover-fallback">
+                <oc-icon name="book" size="xlarge" />
+                <span>{{ book.title }}</span>
+              </span>
+            </span>
+            <span class="book-title">{{ book.title }}</span>
+            <span class="book-author">
+              {{ book.authors.join(', ') || $gettext('Unknown author') }}
+            </span>
+            <span v-if="book.hasReadingPosition" class="continue-reading">
+              <template v-if="book.readingProgress === 100">{{ $gettext('Finished') }}</template>
+              <template v-else>
+                {{ $gettext('Continue reading') }}
+                <span v-if="book.readingProgress !== undefined">
+                  · {{ book.readingProgress }}%</span
+                >
+              </template>
+            </span>
+            <span
+              v-if="book.readingProgress !== undefined"
+              class="reading-progress"
+              role="progressbar"
+              :aria-label="$gettext('Reading progress for %{title}', { title: book.title })"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              :aria-valuenow="book.readingProgress"
+            >
+              <span :style="{ width: `${book.readingProgress}%` }" />
+            </span>
+            <span v-if="book.loadingMetadata" class="book-status oc-text-muted">
+              {{ $gettext('Reading metadata…') }}
+            </span>
+            <span v-else-if="book.metadataError" class="book-status oc-text-muted">
+              {{ book.metadataError }}
+            </span>
+            <span v-else-if="book.published" class="book-status oc-text-muted">
+              {{ book.published.slice(0, 4) }}
+            </span>
+          </button>
+          <div class="book-card-meta">
+            <div
+              v-if="book.favorite || book.readingStatus !== 'unread'"
+              class="book-labels oc-flex oc-flex-wrap oc-mt-xs"
+            >
+              <span v-if="book.favorite" class="book-label">{{ $gettext('Favorite') }}</span>
+              <span v-if="book.readingStatus !== 'unread'" class="book-label">
+                {{ readingStatusLabel(book.readingStatus) }}
+              </span>
+            </div>
+          </div>
+        </article>
+      </div>
+    </template>
+
+    <book-details
+      v-if="selectedBook"
+      :book="selectedBook"
+      :copied="copied"
+      :shelves="shelves"
+      @close="closeDetails"
+      @open="openBook(selectedBook)"
+      @show-in-files="showBookInFiles(selectedBook)"
+      @download="downloadBook(selectedBook)"
+      @copy-link="copySelectedBookLink"
+      @toggle-favorite="toggleFavorite(selectedBook)"
+      @set-status="setReadingStatus(selectedBook, $event)"
+      @toggle-shelf="toggleBookShelf(selectedBook, $event)"
+      @create-shelf="createAndAssignShelf"
+    />
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import BookDetails from '../components/BookDetails.vue'
+import { useLibrary } from '../composables/useLibrary'
+import { useLibraryFilters } from '../composables/useLibraryFilters'
+import type { LibraryBook, LibrarySort, LibraryViewMode, ReadingStatus } from '../types'
+import { loadViewMode, saveViewMode } from '../utils/preferences'
+
+const { $gettext } = useGettext()
+const {
+  books,
+  copyBookLink,
+  createShelf,
+  downloadBook,
+  error,
+  loadBooks,
+  loading,
+  openBook,
+  query,
+  shelves,
+  setReadingStatus,
+  showBookInFiles,
+  sort,
+  toggleBookShelf,
+  toggleFavorite,
+  visibleBooks
+} = useLibrary()
+const selectedBook = ref<LibraryBook | null>(null)
+const copied = ref(false)
+const viewMode = ref<LibraryViewMode>(loadViewMode())
+const showAdvancedFilters = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | undefined
+let detailsTrigger: HTMLElement | null = null
+const {
+  activeFilters,
+  clearFilter,
+  filteredBooks,
+  filters,
+  filterValues,
+  hasActiveFilters,
+  resetFilters
+} = useLibraryFilters({ books, query, shelves, visibleBooks })
+
+const primaryFilters = computed(() =>
+  filters.value.filter(({ key }) => ['collection', 'status'].includes(key))
+)
+const advancedFilters = computed(() =>
+  filters.value.filter(({ key }) => !['collection', 'status'].includes(key))
+)
+const advancedFilterCount = computed(
+  () => advancedFilters.value.filter(({ key }) => filterValues[key] !== 'all').length
+)
+const continueReadingBooks = computed(() =>
+  books.value
+    .filter(
+      ({ hasReadingPosition, readingProgress, readingStatus }) =>
+        hasReadingPosition && readingProgress !== 100 && readingStatus !== 'finished'
+    )
+    .sort((left, right) => (right.readingProgress ?? 0) - (left.readingProgress ?? 0))
+    .slice(0, 6)
+)
+const showContinueReading = computed(
+  () =>
+    !loading.value &&
+    !error.value &&
+    !hasActiveFilters.value &&
+    continueReadingBooks.value.length > 0
+)
+
+const sortOptions = [
+  { label: $gettext('Recently added'), value: 'recent' },
+  { label: $gettext('Title'), value: 'title' },
+  { label: $gettext('Author'), value: 'author' }
+]
+
+const selectedSortOption = computed(
+  () => sortOptions.find((option) => option.value === sort.value) ?? sortOptions[0]
+)
+
+function onSortUpdate(option: { value: LibrarySort } | null): void {
+  if (option) sort.value = option.value
+}
+
+async function closeDetails(): Promise<void> {
+  selectedBook.value = null
+  copied.value = false
+  if (copiedTimer) clearTimeout(copiedTimer)
+  await nextTick()
+  detailsTrigger?.focus()
+  detailsTrigger = null
+}
+
+function showDetails(book: LibraryBook, event: MouseEvent): void {
+  detailsTrigger = event.currentTarget as HTMLElement
+  copied.value = false
+  selectedBook.value = book
+}
+
+function setViewMode(mode: LibraryViewMode): void {
+  viewMode.value = mode
+  saveViewMode(mode)
+}
+
+function readingStatusLabel(status: ReadingStatus): string {
+  return {
+    unread: $gettext('Unread'),
+    reading: $gettext('Reading'),
+    finished: $gettext('Finished')
+  }[status]
+}
+
+function createAndAssignShelf(name: string): void {
+  if (!selectedBook.value) return
+  const shelf = createShelf(name)
+  if (shelf && !selectedBook.value.shelfIds.includes(shelf.id)) {
+    toggleBookShelf(selectedBook.value, shelf.id)
+  }
+}
+
+async function copySelectedBookLink(): Promise<void> {
+  if (!selectedBook.value) return
+  const success = await copyBookLink(selectedBook.value)
+  if (!success) return
+  copied.value = true
+  if (copiedTimer) clearTimeout(copiedTimer)
+  copiedTimer = setTimeout(() => (copied.value = false), 2000)
+}
+
+onMounted(loadBooks)
+</script>
+
+<style scoped>
+.library {
+  box-sizing: border-box;
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  width: 100%;
+}
+
+.library-header,
+.library-controls {
+  gap: var(--oc-space-medium);
+}
+
+.library-toolbar {
+  align-items: end;
+  gap: var(--oc-space-medium);
+}
+
+.continue-section {
+  background: var(--oc-color-background-muted);
+  border-radius: 12px;
+  padding: var(--oc-space-medium);
+}
+
+.continue-list {
+  display: grid;
+  gap: var(--oc-space-medium);
+  grid-auto-columns: minmax(17rem, 21rem);
+  grid-auto-flow: column;
+  overflow-x: auto;
+  padding: var(--oc-space-xsmall) var(--oc-space-xsmall) var(--oc-space-small);
+  scroll-snap-type: x proximity;
+}
+
+.continue-card {
+  align-items: center;
+  background: var(--oc-color-background-default);
+  border: 0;
+  border-radius: 10px;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 12%);
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  gap: var(--oc-space-medium);
+  grid-template-columns: 4.5rem minmax(0, 1fr);
+  padding: var(--oc-space-small);
+  scroll-snap-align: start;
+  text-align: left;
+}
+
+.continue-card:focus-visible {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.continue-cover {
+  align-items: center;
+  aspect-ratio: 2 / 3;
+  background: var(--oc-color-background-muted);
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.continue-cover img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.continue-card-content,
+.continue-card-content > span {
+  display: block;
+  min-width: 0;
+}
+
+.continue-card-content {
+  overflow: hidden;
+}
+
+.continue-card-content strong,
+.continue-card-content > span:not(.reading-progress) {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.continue-card-progress {
+  color: var(--oc-color-swatch-primary-default);
+  font-size: var(--oc-font-size-small);
+  font-weight: 600;
+  margin-top: var(--oc-space-small);
+}
+
+.library-filters {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  gap: var(--oc-space-small);
+}
+
+.advanced-filter-toggle {
+  align-self: end;
+}
+
+.advanced-filters {
+  background: var(--oc-color-background-muted);
+  border-radius: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--oc-space-medium);
+}
+
+.active-filters {
+  align-items: center;
+  gap: var(--oc-space-small);
+}
+
+.filter-chip {
+  background: var(--oc-color-background-muted);
+  border-radius: 999px;
+  gap: var(--oc-space-xsmall);
+  padding: var(--oc-space-xsmall) var(--oc-space-small);
+}
+
+.library-filter {
+  display: grid;
+  font-size: var(--oc-font-size-small);
+  gap: var(--oc-space-xsmall);
+}
+
+.library-filter select {
+  background: var(--oc-color-background-default);
+  border: 1px solid var(--oc-color-background-muted);
+  border-radius: 5px;
+  color: inherit;
+  min-height: 2.5rem;
+  padding: 0 var(--oc-space-small);
+}
+
+.view-toggle {
+  background: var(--oc-color-background-muted);
+  border-radius: 8px;
+  gap: var(--oc-space-xsmall);
+  padding: var(--oc-space-xsmall);
+}
+
+.view-toggle-button {
+  background: var(--oc-color-background-default);
+  border: 2px solid var(--oc-color-swatch-passive-default);
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  min-height: 2.5rem;
+  padding: 0 var(--oc-space-medium);
+}
+
+.view-toggle-button:hover {
+  border-color: var(--oc-color-swatch-primary-default);
+  box-shadow: 0 0 0 2px var(--oc-color-background-highlight);
+}
+
+.view-toggle-button:focus-visible {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 2px;
+}
+
+.view-toggle-button-selected {
+  background: var(--oc-color-swatch-primary-default);
+  border-color: var(--oc-color-swatch-primary-default);
+  color: var(--oc-color-swatch-primary-contrast);
+}
+
+.library-controls {
+  align-items: end;
+}
+
+.library-search {
+  max-width: 32rem;
+  width: 100%;
+}
+
+.library-sort {
+  min-width: 12rem;
+}
+
+.library-state {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 20rem;
+  text-align: center;
+}
+
+.bookshelf {
+  display: grid;
+  gap: var(--oc-space-large) var(--oc-space-medium);
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+}
+
+.book-card {
+  min-width: 0;
+  position: relative;
+}
+
+.book-labels {
+  gap: var(--oc-space-xsmall);
+}
+
+.book-label {
+  background: var(--oc-color-background-muted);
+  border-radius: 5px;
+  font-size: var(--oc-font-size-xsmall);
+  padding: 0 var(--oc-space-xsmall);
+}
+
+.bookshelf-list {
+  display: block;
+}
+
+.bookshelf-list .book-card {
+  align-items: stretch;
+  border-bottom: 1px solid var(--oc-color-background-muted);
+  display: grid;
+  gap: var(--oc-space-medium);
+  grid-template-columns: minmax(0, 1fr) minmax(10rem, 14rem);
+  padding: var(--oc-space-small) 0;
+}
+
+.bookshelf-list .book-open {
+  align-items: center;
+  column-gap: var(--oc-space-medium);
+  display: grid;
+  grid-template-areas:
+    'cover title continue'
+    'cover author progress'
+    'cover status status';
+  grid-template-columns: 3.5rem minmax(8rem, 2fr) minmax(7rem, 1fr);
+  row-gap: var(--oc-space-xsmall);
+}
+
+.bookshelf-list .book-cover {
+  grid-area: cover;
+}
+
+.bookshelf-list .book-title {
+  grid-area: title;
+}
+
+.bookshelf-list .book-author {
+  grid-area: author;
+}
+
+.bookshelf-list .book-status {
+  grid-area: status;
+  margin-top: 0;
+}
+
+.bookshelf-list .continue-reading {
+  grid-area: continue;
+}
+
+.bookshelf-list .reading-progress {
+  align-self: center;
+  grid-area: progress;
+  margin-top: 0;
+  width: 100%;
+}
+
+.bookshelf-list .book-card-meta {
+  align-items: center;
+  align-self: end;
+  display: flex;
+  gap: var(--oc-space-small);
+  justify-content: flex-end;
+  min-height: 1.5rem;
+  white-space: nowrap;
+}
+
+.bookshelf-list .book-labels {
+  margin-top: 0;
+}
+
+.bookshelf-list .book-labels {
+  flex-wrap: nowrap;
+}
+
+.bookshelf-list .book-title,
+.bookshelf-list .book-author {
+  margin-top: 0;
+}
+
+.book-open {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.book-open:focus-visible .book-cover {
+  outline: 3px solid var(--oc-color-swatch-primary-default);
+  outline-offset: 3px;
+}
+
+.book-cover {
+  aspect-ratio: 2 / 3;
+  background: var(--oc-color-background-muted);
+  border-radius: 8px;
+  box-shadow: 0 3px 8px 1px rgb(0 0 0 / 14%);
+  display: block;
+  overflow: hidden;
+  width: 100%;
+}
+
+.book-cover img {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.book-cover-fallback {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--oc-space-medium);
+  height: 100%;
+  justify-content: center;
+  padding: var(--oc-space-medium);
+  text-align: center;
+}
+
+.book-title,
+.book-author,
+.book-status {
+  display: block;
+}
+
+.book-details-button {
+  background: var(--oc-color-background-default);
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgb(0 0 0 / 18%);
+  min-height: 2rem;
+  min-width: 2rem;
+  padding: 0;
+  position: absolute;
+  right: var(--oc-space-small);
+  top: var(--oc-space-small);
+  z-index: 2;
+}
+
+.book-title {
+  font-weight: 600;
+  margin-top: var(--oc-space-small);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.book-author,
+.book-status,
+.continue-reading {
+  font-size: var(--oc-font-size-small);
+  margin-top: var(--oc-space-xsmall);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.continue-reading {
+  color: var(--oc-color-swatch-primary-default);
+  display: block;
+  font-size: var(--oc-font-size-small);
+  font-weight: 600;
+  margin-top: var(--oc-space-small);
+}
+
+.reading-progress {
+  background: var(--oc-color-background-muted);
+  border-radius: 999px;
+  display: block;
+  height: 0.25rem;
+  margin-top: var(--oc-space-xsmall);
+  overflow: hidden;
+}
+
+.reading-progress > span {
+  background: var(--oc-color-swatch-primary-default);
+  display: block;
+  height: 100%;
+}
+
+@media (max-width: 640px) {
+  .library-header,
+  .library-controls,
+  .library-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .library-sort {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .library-filters,
+  .library-filter,
+  .advanced-filter-toggle {
+    width: 100%;
+  }
+
+  .advanced-filters {
+    display: grid;
+  }
+
+  .view-toggle {
+    align-self: flex-end;
+    width: fit-content;
+  }
+
+  .continue-list {
+    grid-auto-columns: minmax(15rem, 85%);
+  }
+
+  .bookshelf-list .book-card {
+    grid-template-columns: 1fr;
+  }
+
+  .bookshelf-list .book-open {
+    grid-template-areas:
+      'cover title'
+      'cover author'
+      'cover status'
+      'cover continue'
+      'cover progress';
+    grid-template-columns: 3.5rem minmax(0, 1fr);
+  }
+
+  .bookshelf-list .book-title {
+    padding-right: 2.75rem;
+  }
+
+  .bookshelf-list .book-card-meta {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/web/packages/web-app-epub-reader/tests/unit/BookDetails.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/BookDetails.spec.ts
@@ -1,0 +1,78 @@
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { defaultPlugins, mount, PartialComponentProps } from '@ownclouders/web-test-helpers'
+import BookDetails from '../../src/components/BookDetails.vue'
+import type { LibraryBook } from '../../src/types'
+
+function libraryBook(overrides: Partial<LibraryBook> = {}): LibraryBook {
+  return {
+    id: 'file-1',
+    resource: mock<Resource>({ name: 'Book.epub', path: '/Books/Book.epub', size: '2048' }),
+    space: mock<SpaceResource>({ name: 'Personal' }),
+    title: 'A Book',
+    authors: ['Ada Lovelace'],
+    description: '',
+    language: '',
+    publisher: '',
+    published: '',
+    subjects: [],
+    spineItemCount: 1,
+    loadingMetadata: false,
+    favorite: false,
+    readingStatus: 'unread',
+    shelfIds: [],
+    hasReadingPosition: false,
+    ...overrides
+  }
+}
+
+describe('BookDetails', () => {
+  it('renders the book title and author', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find('#book-details-title').exists()).toBe(true)
+    expect(wrapper.html()).toContain('A Book')
+    expect(wrapper.html()).toContain('Ada Lovelace')
+  })
+
+  it('emits "close" when Escape is pressed on the dialog', async () => {
+    const { wrapper } = getWrapper()
+    await wrapper.get('[role="dialog"]').trigger('keydown.esc')
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('emits action events from the secondary actions', async () => {
+    const { wrapper } = getWrapper()
+    const buttons = wrapper.findAll('.secondary-actions button')
+    await buttons[0].trigger('click')
+    await buttons[1].trigger('click')
+    await buttons[2].trigger('click')
+    expect(wrapper.emitted('show-in-files')).toBeTruthy()
+    expect(wrapper.emitted('download')).toBeTruthy()
+    expect(wrapper.emitted('copy-link')).toBeTruthy()
+  })
+
+  it('shows the copied state when the copied prop is set', () => {
+    const { wrapper } = getWrapper({ copied: true })
+    expect(wrapper.html()).toContain('Copied')
+  })
+})
+
+function getWrapper(props: PartialComponentProps<typeof BookDetails> = {}) {
+  return {
+    wrapper: mount(BookDetails, {
+      props: {
+        book: libraryBook(),
+        shelves: [],
+        ...props
+      },
+      global: {
+        plugins: [...defaultPlugins()],
+        stubs: {
+          'focus-trap': {
+            template: '<slot />'
+          }
+        }
+      }
+    })
+  }
+}

--- a/web/packages/web-app-epub-reader/tests/unit/LibraryView.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/LibraryView.spec.ts
@@ -1,0 +1,130 @@
+import { ref } from 'vue'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+import LibraryView from '../../src/views/LibraryView.vue'
+import type { LibraryBook } from '../../src/types'
+
+const { libraryState, loadBooks, openBook } = vi.hoisted(() => ({
+  libraryState: {
+    books: undefined as never,
+    visibleBooks: undefined as never,
+    shelves: undefined as never,
+    query: undefined as never,
+    sort: undefined as never,
+    loading: undefined as never,
+    error: undefined as never
+  },
+  loadBooks: vi.fn(),
+  openBook: vi.fn()
+}))
+
+vi.mock('../../src/composables/useLibrary', () => ({
+  useLibrary: () => ({
+    books: libraryState.books,
+    visibleBooks: libraryState.visibleBooks,
+    shelves: libraryState.shelves,
+    query: libraryState.query,
+    sort: libraryState.sort,
+    loading: libraryState.loading,
+    error: libraryState.error,
+    loadBooks,
+    openBook,
+    copyBookLink: vi.fn(),
+    createShelf: vi.fn(),
+    downloadBook: vi.fn(),
+    setReadingStatus: vi.fn(),
+    showBookInFiles: vi.fn(),
+    toggleBookShelf: vi.fn(),
+    toggleFavorite: vi.fn()
+  })
+}))
+
+function libraryBook(overrides: Partial<LibraryBook> = {}): LibraryBook {
+  return {
+    id: 'file-1',
+    resource: mock<Resource>({ name: 'Book.epub', path: '/Books/Book.epub' }),
+    space: mock<SpaceResource>({ name: 'Personal' }),
+    title: 'A Book',
+    authors: ['Ada Lovelace'],
+    description: '',
+    language: '',
+    publisher: '',
+    published: '',
+    subjects: [],
+    spineItemCount: 1,
+    loadingMetadata: false,
+    favorite: false,
+    readingStatus: 'unread',
+    shelfIds: [],
+    hasReadingPosition: false,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('LibraryView', () => {
+  it('loads books on mount', () => {
+    getWrapper()
+    expect(loadBooks).toHaveBeenCalled()
+  })
+
+  it('shows a loading state while loading with no books', () => {
+    const { wrapper } = getWrapper({ loading: true, books: [] })
+    expect(wrapper.find('.library-state[role="status"]').exists()).toBe(true)
+  })
+
+  it('shows an error state when loading fails', () => {
+    const { wrapper } = getWrapper({ error: 'Boom' })
+    const alert = wrapper.find('.library-state[role="alert"]')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toContain('Boom')
+  })
+
+  it('shows the empty state when there are no books', () => {
+    const { wrapper } = getWrapper({ books: [], visibleBooks: [] })
+    expect(wrapper.html()).toContain('No EPUB books found')
+  })
+
+  it('renders a card per visible book', () => {
+    const books = [libraryBook(), libraryBook({ id: 'file-2', title: 'Second' })]
+    const { wrapper } = getWrapper({ books, visibleBooks: books })
+    expect(wrapper.findAll('.book-card')).toHaveLength(2)
+  })
+
+  it('opens a book when its open button is clicked', async () => {
+    const books = [libraryBook()]
+    const { wrapper } = getWrapper({ books, visibleBooks: books })
+    await wrapper.find('.book-open').trigger('click')
+    expect(openBook).toHaveBeenCalledWith(books[0])
+  })
+})
+
+function getWrapper(
+  state: {
+    books?: LibraryBook[]
+    visibleBooks?: LibraryBook[]
+    loading?: boolean
+    error?: string
+  } = {}
+) {
+  libraryState.books = ref(state.books ?? []) as never
+  libraryState.visibleBooks = ref(state.visibleBooks ?? state.books ?? []) as never
+  libraryState.shelves = ref([]) as never
+  libraryState.query = ref('') as never
+  libraryState.sort = ref('recent') as never
+  libraryState.loading = ref(state.loading ?? false) as never
+  libraryState.error = ref(state.error ?? '') as never
+
+  return {
+    wrapper: mount(LibraryView, {
+      global: {
+        plugins: [...defaultPlugins()],
+        stubs: { 'oc-select': true, 'oc-spinner': true, BookDetails: true }
+      }
+    })
+  }
+}

--- a/web/packages/web-app-epub-reader/tests/unit/cache.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/cache.spec.ts
@@ -1,0 +1,26 @@
+import type { Resource } from '@ownclouders/web-client'
+import { describe, expect, it } from 'vitest'
+import { resourceCacheId, resourceFingerprint } from '../../src/utils/cache'
+
+function resource(overrides: Partial<Resource> = {}): Resource {
+  return {
+    id: 'resource-id',
+    name: 'book.epub',
+    path: '/Books/book.epub',
+    type: 'file',
+    ...overrides
+  } as Resource
+}
+
+describe('EPUB metadata cache keys', () => {
+  it('prefers the stable file id', () => {
+    expect(resourceCacheId(resource({ fileId: 'file-id' }))).toBe('file-id')
+  })
+
+  it('changes the fingerprint when file metadata changes', () => {
+    const original = resourceFingerprint(resource({ etag: 'one', size: 100 }))
+    const changed = resourceFingerprint(resource({ etag: 'two', size: 100 }))
+
+    expect(changed).not.toBe(original)
+  })
+})

--- a/web/packages/web-app-epub-reader/tests/unit/epub.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/epub.spec.ts
@@ -1,0 +1,65 @@
+import * as zip from '@zip.js/zip.js'
+import { describe, expect, it } from 'vitest'
+import {
+  extractEpubMetadata,
+  metadataFromPackageDocument,
+  titleFromFileName
+} from '../../src/utils/epub'
+
+describe('EPUB metadata utilities', () => {
+  it('extracts Dublin Core metadata and cover information', () => {
+    const metadata = metadataFromPackageDocument(
+      `<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <metadata>
+          <dc:title>A Wizard of Earthsea</dc:title>
+          <dc:creator>Ursula K. Le Guin</dc:creator>
+          <dc:language>en</dc:language>
+          <dc:publisher>Parnassus Press</dc:publisher>
+          <dc:subject>Fantasy</dc:subject>
+          <meta name="cover" content="cover-image" />
+        </metadata>
+        <manifest><item id="cover-image" href="images/cover.jpg" media-type="image/jpeg" /></manifest>
+        <spine><itemref idref="chapter-1" /><itemref idref="chapter-2" /></spine>
+      </package>`,
+      'Fallback title'
+    )
+
+    expect(metadata).toMatchObject({
+      title: 'A Wizard of Earthsea',
+      authors: ['Ursula K. Le Guin'],
+      language: 'en',
+      publisher: 'Parnassus Press',
+      subjects: ['Fantasy'],
+      spineItemCount: 2,
+      coverHref: 'images/cover.jpg'
+    })
+  })
+
+  it('creates a readable title from a filename', () => {
+    expect(titleFromFileName('the_left-hand.of-earthsea.epub')).toBe('the left hand of earthsea')
+  })
+
+  it('reads metadata from an EPUB archive without a web worker', async () => {
+    zip.configure({ useWebWorkers: false })
+    const writer = new zip.ZipWriter(new zip.BlobWriter('application/epub+zip'))
+    await writer.add(
+      'META-INF/container.xml',
+      new zip.TextReader(
+        '<container><rootfiles><rootfile full-path="OEBPS/content.opf" /></rootfiles></container>'
+      )
+    )
+    await writer.add(
+      'OEBPS/content.opf',
+      new zip.TextReader(
+        '<package><metadata><title>Frankenstein</title><creator>Mary Shelley</creator></metadata><manifest /></package>'
+      )
+    )
+    const epub = await writer.close()
+
+    await expect(extractEpubMetadata(epub, 'Fallback')).resolves.toMatchObject({
+      title: 'Frankenstein',
+      authors: ['Mary Shelley']
+    })
+  })
+})

--- a/web/packages/web-app-epub-reader/tests/unit/preferences.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/preferences.spec.ts
@@ -1,0 +1,46 @@
+import type { Resource } from '@ownclouders/web-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getBookPreferences,
+  loadShelves,
+  loadViewMode,
+  saveBookPreferences,
+  saveShelves,
+  saveViewMode
+} from '../../src/utils/preferences'
+
+const values = new Map<string, string>()
+
+beforeEach(() => {
+  values.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value)
+  })
+})
+
+describe('library preferences', () => {
+  const resource = { id: 'book-1', path: '/Books/book.epub' } as Resource
+
+  it('persists per-book organization state', () => {
+    saveBookPreferences(resource, {
+      favorite: true,
+      readingStatus: 'reading',
+      shelfIds: ['classics']
+    })
+
+    expect(getBookPreferences(resource)).toEqual({
+      favorite: true,
+      readingStatus: 'reading',
+      shelfIds: ['classics']
+    })
+  })
+
+  it('persists shelves and view mode', () => {
+    saveShelves([{ id: 'classics', name: 'Classics' }])
+    saveViewMode('list')
+
+    expect(loadShelves()).toEqual([{ id: 'classics', name: 'Classics' }])
+    expect(loadViewMode()).toBe('list')
+  })
+})

--- a/web/packages/web-app-epub-reader/tests/unit/readerProgress.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/readerProgress.spec.ts
@@ -1,0 +1,77 @@
+import type { Resource } from '@ownclouders/web-client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getReaderProgress } from '../../src/utils/readerProgress'
+
+const values = new Map<string, string>()
+const resource = { id: 'book-id' } as Resource
+
+beforeEach(() => {
+  values.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => values.get(key) ?? null
+  })
+})
+
+describe('EPUB reader progress', () => {
+  it('reads the location saved by the built-in EPUB reader', () => {
+    values.set(
+      'oc_epubReader_resource_book-id',
+      JSON.stringify({
+        currentLocation: {
+          start: { cfi: 'epubcfi(/6/4!/4/2)', percentage: 0.42 }
+        }
+      })
+    )
+
+    expect(getReaderProgress(resource)).toEqual({
+      finished: false,
+      hasPosition: true,
+      percentage: 42
+    })
+  })
+
+  it('returns an empty state for books that have not been opened', () => {
+    expect(getReaderProgress(resource)).toEqual({ finished: false, hasPosition: false })
+  })
+
+  it('estimates progress when EPUB.js leaves its percentage at zero', () => {
+    values.set(
+      'oc_epubReader_resource_book-id',
+      JSON.stringify({
+        currentLocation: {
+          atStart: false,
+          start: {
+            cfi: 'epubcfi(/6/8!/4/2)',
+            index: 2,
+            percentage: 0,
+            displayed: { page: 3, total: 10 }
+          }
+        }
+      })
+    )
+
+    expect(getReaderProgress(resource, 10)).toEqual({
+      finished: false,
+      hasPosition: true,
+      percentage: 22
+    })
+  })
+
+  it('marks a location at the end as finished', () => {
+    values.set(
+      'oc_epubReader_resource_book-id',
+      JSON.stringify({
+        currentLocation: {
+          atEnd: true,
+          start: { cfi: 'epubcfi(/6/20!/4/2)', index: 9, percentage: 0 }
+        }
+      })
+    )
+
+    expect(getReaderProgress(resource, 10)).toEqual({
+      finished: true,
+      hasPosition: true,
+      percentage: 100
+    })
+  })
+})

--- a/web/packages/web-app-epub-reader/tests/unit/useLibrary.spec.ts
+++ b/web/packages/web-app-epub-reader/tests/unit/useLibrary.spec.ts
@@ -1,0 +1,287 @@
+import { mock } from 'vitest-mock-extended'
+import { Resource, SearchResource, SpaceResource } from '@ownclouders/web-client'
+import {
+  defaultComponentMocks,
+  getComposableWrapper,
+  nextTicks,
+  RouteLocation
+} from '@ownclouders/web-test-helpers'
+import { useLibrary } from '../../src/composables/useLibrary'
+import * as cache from '../../src/utils/cache'
+import * as epub from '../../src/utils/epub'
+import * as preferences from '../../src/utils/preferences'
+import * as readerProgress from '../../src/utils/readerProgress'
+
+const { copyToClipboard, downloadFile, showErrorMessage } = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(),
+  downloadFile: vi.fn(),
+  showErrorMessage: vi.fn()
+}))
+
+vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@ownclouders/web-pkg')>()),
+  useClipboard: () => ({ copyToClipboard }),
+  useDownloadFile: () => ({ downloadFile }),
+  useMessages: () => ({ showErrorMessage, showMessage: vi.fn() })
+}))
+vi.mock('../../src/utils/cache')
+vi.mock('../../src/utils/epub')
+vi.mock('../../src/utils/preferences')
+vi.mock('../../src/utils/readerProgress')
+
+const personalSpace = mock<SpaceResource>({ id: 'space-1', name: 'Personal', path: '/' })
+const projectSpace = mock<SpaceResource>({ id: 'space-2', name: 'Project', path: '/' })
+
+function epubResource(overrides: Partial<Resource> = {}): Resource {
+  return {
+    id: 'file-1',
+    fileId: 'file-1',
+    name: 'Book.epub',
+    path: '/Books/Book.epub',
+    spaceId: 'space-1',
+    storageId: 'space-1',
+    isFolder: false,
+    type: 'file',
+    mdate: 'Wed, 15 Jul 2026 10:00:00 GMT',
+    privateLink: 'https://cloud.example/f/file-1',
+    ...overrides
+  } as Resource
+}
+
+function searchResult(resources: Resource[]) {
+  return {
+    resources: resources.map((resource) => ({ ...resource, highlights: '' })) as SearchResource[],
+    totalResults: resources.length
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  copyToClipboard.mockResolvedValue(undefined)
+  downloadFile.mockResolvedValue(undefined)
+  vi.mocked(cache.getCachedMetadata).mockResolvedValue(null)
+  vi.mocked(cache.setCachedMetadata).mockResolvedValue()
+  vi.mocked(epub.extractEpubMetadata).mockResolvedValue({
+    title: 'Book',
+    authors: ['Author'],
+    description: '',
+    language: '',
+    publisher: '',
+    published: '',
+    subjects: [],
+    spineItemCount: 1
+  })
+  vi.mocked(epub.titleFromFileName).mockImplementation((name: string) =>
+    name.replace(/\.epub$/, '')
+  )
+  vi.mocked(preferences.getBookPreferences).mockReturnValue({
+    favorite: false,
+    readingStatus: 'unread',
+    shelfIds: []
+  })
+  vi.mocked(preferences.loadShelves).mockReturnValue([])
+  vi.mocked(readerProgress.getReaderProgress).mockReturnValue({
+    finished: false,
+    hasPosition: false
+  })
+})
+
+describe('useLibrary', () => {
+  describe('discovery', () => {
+    it('uses webdav.search when search-files is available and skips the folder scan', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockResolvedValue(searchResult([epubResource()]))
+
+        await library.loadBooks()
+
+        expect(clientService.webdav.search).toHaveBeenCalledWith(
+          'name:*.epub',
+          expect.objectContaining({ searchLimit: expect.any(Number) })
+        )
+        expect(clientService.webdav.listFiles).not.toHaveBeenCalled()
+        expect(library.books.value).toHaveLength(1)
+      })
+    })
+
+    it('falls back to scanning folders when search-files is not supported', async () => {
+      await withLibrary({ searchAvailable: false }, async ({ library, clientService }) => {
+        clientService.webdav.listFiles.mockResolvedValue({
+          resource: mock<Resource>(),
+          children: [epubResource()]
+        })
+
+        await library.loadBooks()
+
+        expect(clientService.webdav.search).not.toHaveBeenCalled()
+        expect(clientService.webdav.listFiles).toHaveBeenCalled()
+        expect(library.books.value).toHaveLength(1)
+      })
+    })
+
+    it('falls back to scanning folders when the search request fails', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockRejectedValue(new Error('boom'))
+        clientService.webdav.listFiles.mockResolvedValue({
+          resource: mock<Resource>(),
+          children: [epubResource()]
+        })
+
+        await library.loadBooks()
+
+        expect(clientService.webdav.listFiles).toHaveBeenCalled()
+        expect(library.books.value).toHaveLength(1)
+      })
+    })
+
+    it('deduplicates books discovered under the same id', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockResolvedValue(
+          searchResult([epubResource(), epubResource({ path: '/Other/Book.epub' })])
+        )
+
+        await library.loadBooks()
+
+        expect(library.books.value).toHaveLength(1)
+      })
+    })
+
+    it('drops results whose space is not available', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockResolvedValue(
+          searchResult([
+            epubResource({ id: 'x', fileId: 'x', spaceId: 'unknown', storageId: 'unknown' })
+          ])
+        )
+
+        await library.loadBooks()
+
+        expect(library.books.value).toHaveLength(0)
+      })
+    })
+
+    it('surfaces an error when all discovery fails', async () => {
+      await withLibrary({ searchAvailable: false }, async ({ library, clientService }) => {
+        clientService.webdav.listFiles.mockRejectedValue(new Error('unreachable'))
+
+        await library.loadBooks()
+
+        expect(library.error.value).toBe('unreachable')
+        expect(library.books.value).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('hydration', () => {
+    it('reads metadata for every discovered book', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockResolvedValue(
+          searchResult([
+            epubResource(),
+            epubResource({ id: 'file-2', fileId: 'file-2', path: '/Books/Second.epub' })
+          ])
+        )
+        clientService.webdav.getFileContents.mockResolvedValue({
+          response: { data: new Blob() }
+        } as never)
+
+        await library.loadBooks()
+
+        expect(epub.extractEpubMetadata).toHaveBeenCalledTimes(2)
+        expect(library.books.value.every((book) => !book.loadingMetadata)).toBe(true)
+      })
+    })
+
+    it('records a metadata error without failing the whole load', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library, clientService }) => {
+        clientService.webdav.search.mockResolvedValue(searchResult([epubResource()]))
+        clientService.webdav.getFileContents.mockRejectedValue(new Error('no bytes'))
+
+        await library.loadBooks()
+
+        expect(library.books.value[0].metadataError).toBeTruthy()
+        expect(library.books.value[0].loadingMetadata).toBe(false)
+      })
+    })
+  })
+
+  describe('actions', () => {
+    it('copies the resource private link to the clipboard', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library }) => {
+        const book = { resource: epubResource(), space: personalSpace } as never
+
+        const success = await library.copyBookLink(book)
+
+        expect(success).toBe(true)
+        expect(copyToClipboard).toHaveBeenCalledWith('https://cloud.example/f/file-1')
+      })
+    })
+
+    it('reports an error when no private link is available', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library }) => {
+        const book = {
+          resource: epubResource({ privateLink: undefined }),
+          space: personalSpace
+        } as never
+
+        const success = await library.copyBookLink(book)
+
+        expect(success).toBe(false)
+        expect(copyToClipboard).not.toHaveBeenCalled()
+        expect(showErrorMessage).toHaveBeenCalled()
+      })
+    })
+
+    it('delegates downloads to useDownloadFile', async () => {
+      await withLibrary({ searchAvailable: true }, async ({ library }) => {
+        const resource = epubResource()
+        const book = { resource, space: personalSpace } as never
+
+        await library.downloadBook(book)
+
+        expect(downloadFile).toHaveBeenCalledWith(personalSpace, resource)
+      })
+    })
+  })
+})
+
+type LibraryInstance = ReturnType<typeof useLibrary>
+
+async function withLibrary(
+  { searchAvailable }: { searchAvailable: boolean },
+  scenario: (ctx: {
+    library: LibraryInstance
+    clientService: ReturnType<typeof defaultComponentMocks>['$clientService']
+  }) => Promise<void>
+) {
+  const componentMocks = defaultComponentMocks({
+    currentRoute: mock<RouteLocation>({ name: 'epub-library' })
+  })
+
+  let library!: LibraryInstance
+  const wrapper = getComposableWrapper(
+    () => {
+      library = useLibrary()
+    },
+    {
+      mocks: componentMocks,
+      provide: componentMocks,
+      pluginOptions: {
+        piniaOptions: {
+          spacesState: { spaces: [personalSpace, projectSpace] },
+          capabilityState: {
+            capabilities: {
+              dav: { reports: searchAvailable ? ['search-files'] : [] }
+            } as never
+          }
+        }
+      }
+    }
+  )
+
+  try {
+    await scenario({ library, clientService: componentMocks.$clientService })
+    await nextTicks(2)
+  } finally {
+    wrapper.unmount()
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -577,9 +577,15 @@ importers:
       '@ownclouders/web-pkg':
         specifier: workspace:*
         version: link:../web-pkg
+      '@zip.js/zip.js':
+        specifier: 2.8.33
+        version: 2.8.33
       epubjs:
         specifier: ^0.3.93
         version: 0.3.93
+      focus-trap-vue:
+        specifier: ^4.1.0
+        version: 4.1.0(focus-trap@8.2.0)(vue@3.5.29(typescript@5.9.3))
       vue3-gettext:
         specifier: ^4.0.1
         version: 4.0.1(vue@3.5.29(typescript@5.9.3))


### PR DESCRIPTION
## Description

Adds a visual library to the existing EPUB reader application.

The library:

- discovers EPUB files across accessible personal and project spaces
- extracts embedded metadata and cover images locally in the browser
- provides search, sorting, filters, favorites, custom shelves, and reading statuses
- supports grid and list layouts
- resumes books from the reader's saved position
- provides actions to open the containing folder, download a book, or copy its private link
- caches metadata and covers in IndexedDB and stores library preferences in local storage
- adds the Library entry to the application switcher while preserving direct EPUB file routing

## Related Issue

- Fixes <issue_link>

## Motivation and Context

The EPUB app previously opened individual books but did not provide a dedicated place to discover and organize EPUB files stored in oCIS. This change turns the app's root route into a library while keeping the reader available under `/read/:driveAliasAndItem`.

EPUB content and metadata stay in the browser. Library preferences are local to the current browser and are not synchronized between browsers or devices.

## How Has This Been Tested?

- test environment: local development checkout
- `pnpm --filter epub-reader test:unit -- --run` (6 files, 31 tests)
- `pnpm check:types`
- `pnpm eslint 'packages/web-app-epub-reader/**/*.{ts,vue}' --max-warnings=0`

## Screenshots (if appropriate):

<!-- Add a screenshot of the EPUB library grid/list view. -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
