### PR TITLE
fix(idp): announce sign-in errors and fix keyboard use

### DIFF
--- a/changelog/unreleased/bugfix-idp-error-announcements.md
+++ b/changelog/unreleased/bugfix-idp-error-announcements.md
@@ -1,0 +1,12 @@
+Bugfix: Announce IDP sign-in errors and fix keyboard use
+
+The login, consent, and account chooser pages did not announce error
+messages when they appeared, and invalid username/password fields gave no
+indication of their error state. The consent screen's scope list also had no
+programmatic link between each entry and its checkbox, and the account
+chooser's "continue as" and "use another account" entries could not be
+reached or activated with a keyboard. A visible focus outline on the login
+form's input fields had also been removed with no replacement. All of these
+have been fixed.
+
+https://github.com/owncloud/ocis/pull/12649

--- a/services/idp/assets/identifier/chooseaccount.html
+++ b/services/idp/assets/identifier/chooseaccount.html
@@ -14,16 +14,16 @@
     <div class="oc-login-form" id="chooseaccount-root">
       <img class="oc-logo" src="{{.LogoURL}}" alt="ownCloud">
       <h1 class="oc-invisible-sr">{{.Headline}}</h1>
-      <p id="oc-chooseaccount-error" class="oc-error-message" hidden></p>
+      <p id="oc-chooseaccount-error" class="oc-error-message" role="alert" aria-live="assertive" hidden></p>
       <div id="chooseaccount-body" hidden>
         <p class="oc-light oc-consent-headline" id="chooseaccount-title">{{.HeadlineSub}}</p>
         <ul class="oc-consent-scopes" id="account-list">
-          <li class="oc-chooseaccount-item" id="item-current">
-            <span class="oc-chooseaccount-avatar" id="avatar-current"></span>
+          <li class="oc-chooseaccount-item" id="item-current" role="button" tabindex="0">
+            <span class="oc-chooseaccount-avatar" id="avatar-current" aria-hidden="true"></span>
             <span class="oc-light oc-chooseaccount-label" id="label-current"></span>
           </li>
-          <li class="oc-chooseaccount-item" id="item-other">
-            <span class="oc-chooseaccount-avatar">?</span>
+          <li class="oc-chooseaccount-item" id="item-other" role="button" tabindex="0">
+            <span class="oc-chooseaccount-avatar" aria-hidden="true">?</span>
             <span class="oc-light oc-chooseaccount-label">{{.UseAnotherLabel}}</span>
           </li>
         </ul>
@@ -77,6 +77,15 @@
     catch (_) { return false; }
   }
 
+  function onKeyActivate(el, handler) {
+    el.addEventListener("keydown", function(e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handler();
+      }
+    });
+  }
+
   var helloReq = {
     state: qs("state"),
     flow: qs("flow") || "oidc",
@@ -106,7 +115,7 @@
       bodyEl.hidden = false;
 
       // "Continue as current user" — mode=0 logon (cookie re-auth, no password)
-      itemCurrent.addEventListener("click", function() {
+      function activateCurrent() {
         itemCurrent.style.opacity = "0.5";
         itemOther.style.pointerEvents = "none";
         fetchApi("/_/logon", { state: helloReq.state, params: [data.username, "", "0"], hello: helloReq })
@@ -133,14 +142,16 @@
             resetSignInState();
           })
           .catch(resetSignInState);
-      });
+      }
+      itemCurrent.addEventListener("click", activateCurrent);
+      onKeyActivate(itemCurrent, activateCurrent);
     })
     .catch(function() {
       window.location.href = pathPrefix + '/identifier' + window.location.search;
     });
 
   // "Use another account" — invalidate current session then go to login form
-  itemOther.addEventListener("click", function() {
+  function activateOther() {
     var loginParams = new URLSearchParams(window.location.search);
     loginParams.set("prompt", "login");
     loginParams.delete("flow");
@@ -148,7 +159,9 @@
     fetchApi("/_/logoff", { state: helloReq.state }).then(function() {
       window.location.href = target;
     });
-  });
+  }
+  itemOther.addEventListener("click", activateOther);
+  onKeyActivate(itemOther, activateOther);
 })();
   </script>
 </body>

--- a/services/idp/assets/identifier/consent.html
+++ b/services/idp/assets/identifier/consent.html
@@ -14,7 +14,7 @@
     <div class="oc-login-form" id="consent-root">
       <img class="oc-logo" src="{{.LogoURL}}" alt="ownCloud">
       <h1 class="oc-invisible-sr">{{.Headline}}</h1>
-      <p id="oc-consent-error-message" class="oc-error-message" hidden></p>
+      <p id="oc-consent-error-message" class="oc-error-message" role="alert" aria-live="assertive" hidden></p>
       <div id="consent-body" hidden>
         <p id="consent-display-name" class="oc-light oc-consent-headline"></p>
         <p id="consent-username" class="oc-light oc-consent-username"></p>
@@ -127,13 +127,16 @@
       if (!desc) desc = "Scope: " + scope;
       var li = document.createElement("li");
       li.className = "oc-consent-scope-item";
+      var scopeId = "consent-scope-" + alias;
       var cb = document.createElement("input");
       cb.type = "checkbox";
+      cb.id = scopeId;
       cb.checked = true;
       cb.disabled = true;
       cb.className = "oc-consent-checkbox";
-      var label = document.createElement("span");
+      var label = document.createElement("label");
       label.className = "oc-light";
+      label.setAttribute("for", scopeId);
       label.textContent = desc;
       li.appendChild(cb);
       li.appendChild(label);

--- a/services/idp/assets/identifier/goodbye.html
+++ b/services/idp/assets/identifier/goodbye.html
@@ -14,8 +14,8 @@
       <img class="oc-logo" src="{{.LogoURL}}" alt="ownCloud">
       <h1 class="oc-invisible-sr">{{.Headline}}</h1>
       <p class="oc-message">{{.Message}}</p>
-      <footer class="oc-footer-message">ownCloud - a safe home for all your data</footer>
     </div>
   </main>
+  <footer class="oc-footer-message">ownCloud - a safe home for all your data</footer>
 </body>
 </html>

--- a/services/idp/assets/identifier/index.html
+++ b/services/idp/assets/identifier/index.html
@@ -23,12 +23,12 @@
         data-msg-sign-in="{{.ButtonSignIn}}">
         <div>
           <label class="oc-label" for="oc-login-username">{{.LabelUsername}}</label>
-          <input class="oc-input" type="text" id="oc-login-username" name="username" autocomplete="username" placeholder="{{.LabelUsername}}" required>
+          <input class="oc-input" type="text" id="oc-login-username" name="username" autocomplete="username" placeholder="{{.LabelUsername}}" aria-describedby="oc-login-error-message" required>
         </div>
         <div>
           <label class="oc-label" for="oc-login-password">{{.LabelPassword}}</label>
-          <input class="oc-input" type="password" id="oc-login-password" name="password" autocomplete="current-password" placeholder="{{.LabelPassword}}" required>
-          <p id="oc-login-error-message" class="oc-error-message" hidden></p>
+          <input class="oc-input" type="password" id="oc-login-password" name="password" autocomplete="current-password" placeholder="{{.LabelPassword}}" aria-describedby="oc-login-error-message" required>
+          <p id="oc-login-error-message" class="oc-error-message" role="alert" aria-live="assertive" hidden></p>
         </div>
         <div>
           <button class="oc-button-primary" type="submit" id="submit-btn">{{.ButtonSignIn}}</button>
@@ -103,12 +103,16 @@
     errorEl.hidden = false;
     usernameEl.classList.add("error");
     passwordEl.classList.add("error");
+    usernameEl.setAttribute("aria-invalid", "true");
+    passwordEl.setAttribute("aria-invalid", "true");
   }
 
   function hideError() {
     errorEl.hidden = true;
     usernameEl.classList.remove("error");
     passwordEl.classList.remove("error");
+    usernameEl.removeAttribute("aria-invalid");
+    passwordEl.removeAttribute("aria-invalid");
   }
 
   function setLoading(loading) {

--- a/services/idp/assets/identifier/static/theme.css
+++ b/services/idp/assets/identifier/static/theme.css
@@ -297,8 +297,17 @@ main {
 }
 
 .oc-input:focus {
-  outline: none;
+  outline: 2px solid #00b3f0;
+  outline-offset: 1px;
   border: 1px solid #fff;
+}
+
+.oc-chooseaccount-item:focus-visible,
+.oc-button-primary:focus-visible,
+.oc-button-cancel:focus-visible,
+.oc-button-consent:focus-visible {
+  outline: 2px solid #00b3f0;
+  outline-offset: 2px;
 }
 
 .oc-button-primary {

--- a/services/idp/assets/identifier/welcome.html
+++ b/services/idp/assets/identifier/welcome.html
@@ -14,8 +14,8 @@
       <img class="oc-logo" src="{{.LogoURL}}" alt="ownCloud">
       <h1 class="oc-invisible-sr">{{.Headline}}</h1>
       <p class="oc-message">{{.Message}}</p>
-      <footer class="oc-footer-message">ownCloud - a safe home for all your data</footer>
     </div>
   </main>
+  <footer class="oc-footer-message">ownCloud - a safe home for all your data</footer>
 </body>
 </html>


### PR DESCRIPTION
## Description
Error messages on the IDP login, consent, and account chooser pages were not announced when they appeared, invalid username/password fields gave no indication of their error state, the consent screen's scope checkboxes had no programmatic label association, and the account chooser's "continue as" / "use another account" entries could not be reached or activated with a keyboard. The login form's input focus outline had also been removed with no visible replacement.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1084

## Motivation and Context
Sign-in and consent errors were silent to screen reader users, and part of the account chooser flow was unusable without a mouse.

## How Has This Been Tested?
- test environment: local `ocis server` with `IDP_ASSET_PATH` pointed at `services/idp/assets`, VoiceOver on macOS
- test case 1: submit login form with invalid credentials — error is announced, inputs marked invalid
- test case 2: navigate account chooser and consent screens using keyboard only (Tab, Enter, Space)
- test case 3: verify visible focus outline appears on login inputs and buttons when tabbing

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>