### PR TITLE
enhancement(web): [OCISDEV-1085] add undo action to delete notification

### DIFF
--- a/changelog/unreleased/enhancement-undo-delete-toast.md
+++ b/changelog/unreleased/enhancement-undo-delete-toast.md
@@ -1,0 +1,12 @@
+Enhancement: Add "Undo" action to the delete success notification
+
+Deleting a file or folder now shows an "Undo" action alongside the
+"moved to trash bin" notification, letting users restore the deleted
+resources directly from the toast instead of navigating to the trash
+bin. The action is only shown when the resources can be resolved in
+the trash and the space supports restoring from it. The notification
+pauses its auto-dismiss timer while hovered or focused, so it does not
+disappear before the action can be used. Pressing Ctrl+Z (or Cmd+Z on
+macOS) while the notification is visible triggers the same undo.
+
+https://github.com/owncloud/ocis/pull/12650

--- a/web/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.spec.ts
+++ b/web/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.spec.ts
@@ -110,15 +110,113 @@ describe('OcNotificationMessage', () => {
     expect(wrapper.emitted('close')).toBeTruthy()
   })
 
+  describe('actions prop', () => {
+    it('should not render actions if none are provided', () => {
+      const wrapper = getWrapper()
+
+      expect(wrapper.find(selectors.actionButton).exists()).toBeFalsy()
+    })
+
+    it('should render an action button for each action', () => {
+      const actions = [
+        { label: 'Undo', ariaLabel: 'Undo delete', onClick: vi.fn() },
+        { label: 'Retry', onClick: vi.fn() }
+      ]
+      const wrapper = getWrapper({ actions })
+      const buttons = wrapper.findAll(selectors.actionButton)
+
+      expect(buttons.length).toBe(2)
+      expect(buttons[0].text()).toBe('Undo')
+      expect(buttons[0].attributes('aria-label')).toBe('Undo delete')
+      expect(buttons[1].attributes('aria-label')).toBe('Retry')
+    })
+
+    it('should call onClick when an action button is clicked', async () => {
+      const onClick = vi.fn()
+      const wrapper = getWrapper({ actions: [{ label: 'Undo', onClick }] })
+
+      await wrapper.find(selectors.actionButton).trigger('click')
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should close the notification when an action button is clicked, so it cannot be clicked twice', async () => {
+      const onClick = vi.fn()
+      const wrapper = getWrapper({ actions: [{ label: 'Undo', onClick }] })
+
+      await wrapper.find(selectors.actionButton).trigger('click')
+
+      expect(wrapper.emitted('close')).toBeTruthy()
+      expect(wrapper.emitted('close').length).toBe(1)
+    })
+
+    it('should not move focus into the notification on mount', () => {
+      const wrapper = getWrapper(
+        { actions: [{ label: 'Undo', onClick: vi.fn() }] },
+        { attachTo: document.body }
+      )
+
+      expect(document.activeElement).toBe(document.body)
+      wrapper.unmount()
+    })
+  })
+
+  describe('auto-dismiss pause/resume', () => {
+    it('should pause the dismiss timer on hover and resume on mouse leave', async () => {
+      const wrapper = getWrapper({ timeout: 10 })
+      const interactiveEl = wrapper.find(selectors.interactiveWrapper)
+
+      await interactiveEl.trigger('mouseenter')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeFalsy()
+
+      await interactiveEl.trigger('mouseleave')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('should pause the dismiss timer on focus and resume on blur', async () => {
+      const wrapper = getWrapper({ timeout: 10 })
+      const interactiveEl = wrapper.find(selectors.interactiveWrapper)
+
+      await interactiveEl.trigger('focusin')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeFalsy()
+
+      await interactiveEl.trigger('focusout')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+
+    it('should still auto-dismiss after hover and focus overlap (e.g. clicking a button)', async () => {
+      const wrapper = getWrapper({ timeout: 10 })
+      const interactiveEl = wrapper.find(selectors.interactiveWrapper)
+
+      // hover and focus both engage (as happens when clicking an action button by mouse)
+      await interactiveEl.trigger('mouseenter')
+      await interactiveEl.trigger('focusin')
+      // then only the mouse leaves, focus remains (e.g. keyboard user tabs through)
+      await interactiveEl.trigger('mouseleave')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeFalsy()
+
+      await interactiveEl.trigger('focusout')
+      vi.advanceTimersByTime(10000)
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+
   const selectors = {
     messageTitle: '.oc-notification-message-title',
     messageContent: '.oc-notification-message-content',
     messageWrapper: '.oc-notification-message div',
+    interactiveWrapper: '.oc-notification-message-interactive',
     errorLog: '.oc-error-log',
-    errorLogToggleButton: '.oc-notification-message-error-log-toggle-button'
+    errorLogToggleButton: '.oc-notification-message-error-log-toggle-button',
+    actionButton: '.oc-notification-message-action-button'
   }
 
-  function getWrapper(props = {}) {
+  function getWrapper(props = {}, mountOptions = {}) {
     return mount(OcNotificationMessage, {
       props: {
         ...props,
@@ -129,7 +227,8 @@ describe('OcNotificationMessage', () => {
           'oc-icon': true
         },
         plugins: defaultPlugins()
-      }
+      },
+      ...mountOptions
     })
   }
 })

--- a/web/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/web/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -4,16 +4,40 @@
     :class="classes"
   >
     <div class="oc-flex oc-flex-wrap oc-flex-middle oc-flex-1" :role="role" :aria-live="ariaLive">
-      <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-        <div class="oc-flex oc-flex-middle">
-          <oc-icon :variation="iconVariation" name="information" fill-type="line" class="oc-mr-s" />
-          <div class="oc-notification-message-title">
-            {{ title }}
-          </div>
+      <div class="oc-flex oc-flex-middle oc-width-1-1">
+        <oc-icon :variation="iconVariation" name="information" fill-type="line" class="oc-mr-s" />
+        <div class="oc-notification-message-title oc-flex-1">
+          {{ title }}
         </div>
-        <oc-button appearance="raw" :aria-label="$gettext('Close')" @click="close"
-          ><oc-icon name="close"
-        /></oc-button>
+        <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+        <div
+          class="oc-notification-message-interactive oc-flex oc-flex-middle oc-ml-m"
+          @mouseenter="onMouseEnter"
+          @mouseleave="onMouseLeave"
+          @focusin="onFocusIn"
+          @focusout="onFocusOut"
+        >
+          <div v-if="actions.length" class="oc-notification-message-actions oc-flex oc-flex-middle">
+            <oc-button
+              v-for="(action, index) in actions"
+              :key="index"
+              appearance="raw"
+              variation="primary"
+              class="oc-notification-message-action-button"
+              :aria-label="action.ariaLabel || action.label"
+              @click="onActionClick(action)"
+            >
+              <span class="oc-notification-message-action-button-label">{{ action.label }}</span>
+            </oc-button>
+          </div>
+          <oc-button
+            class="oc-notification-message-close-button oc-ml-s"
+            appearance="raw"
+            :aria-label="$gettext('Close')"
+            @click="close"
+            ><oc-icon name="close"
+          /></oc-button>
+        </div>
       </div>
       <div v-if="message || errorLogContent" class="oc-flex oc-flex-between oc-width-1-1 oc-mt-s">
         <span
@@ -62,6 +86,7 @@ import OcErrorLog from '../OcErrorLog/OcErrorLog.vue'
  * @props {string} [errorLogContent=null] - The error log content to display when the "Details" button is clicked.
  * @props {number} [timeout=5] - The number of seconds the notification is displayed before auto-dismiss.
  *                                If set to 0, the notification will not auto-dismiss.
+ * @props {array} [actions=[]] - Optional action buttons rendered in the notification, e.g. an "Undo" action.
  *
  * @emits {void} close - Emitted when the user clicks the close button or when the notification auto-dismisses.
  *
@@ -76,12 +101,19 @@ import OcErrorLog from '../OcErrorLog/OcErrorLog.vue'
  *
  */
 
+export interface OcNotificationMessageAction {
+  label: string
+  ariaLabel?: string
+  onClick: () => void
+}
+
 interface Props {
   status?: 'passive' | 'primary' | 'success' | 'warning' | 'danger'
   title: string
   message?: string
   errorLogContent?: string
   timeout?: number
+  actions?: OcNotificationMessageAction[]
 }
 interface Emits {
   (e: 'close'): void
@@ -97,7 +129,8 @@ const {
   title,
   message = null,
   errorLogContent = null,
-  timeout = 5
+  timeout = 5,
+  actions = []
 } = defineProps<Props>()
 
 const emit = defineEmits<Emits>()
@@ -109,6 +142,11 @@ function close() {
    * @type {void}
    */
   emit('close')
+}
+
+function onActionClick(action: OcNotificationMessageAction) {
+  action.onClick()
+  close()
 }
 
 const classes = computed(() => {
@@ -127,15 +165,57 @@ const ariaLive = computed(() => {
   return isStatusDanger.value ? 'assertive' : 'polite'
 })
 
+let remainingTime = timeout * 1000
+let timeoutStartedAt = 0
+let timeoutHandle: ReturnType<typeof setTimeout> = null
+let isHovering = false
+let isFocused = false
+
+function startTimeout() {
+  if (timeout === 0 || remainingTime <= 0 || timeoutHandle || isHovering || isFocused) {
+    return
+  }
+  timeoutStartedAt = Date.now()
+  timeoutHandle = setTimeout(() => {
+    timeoutHandle = null
+    close()
+  }, remainingTime)
+}
+
+function pauseTimeout() {
+  if (timeout === 0 || !timeoutHandle) {
+    return
+  }
+  clearTimeout(timeoutHandle)
+  timeoutHandle = null
+  remainingTime -= Date.now() - timeoutStartedAt
+}
+
+function onMouseEnter() {
+  isHovering = true
+  pauseTimeout()
+}
+
+function onMouseLeave() {
+  isHovering = false
+  startTimeout()
+}
+
+function onFocusIn() {
+  isFocused = true
+  pauseTimeout()
+}
+
+function onFocusOut() {
+  isFocused = false
+  startTimeout()
+}
+
 onMounted(() => {
   /**
    * Notification will be destroyed if timeout is set
    */
-  if (timeout !== 0) {
-    setTimeout(() => {
-      close()
-    }, timeout * 1000)
-  }
+  startTimeout()
 })
 </script>
 
@@ -148,10 +228,19 @@ onMounted(() => {
 
   &-title {
     font-size: 1.15rem;
+    min-width: 0;
   }
 
   &-error-log-toggle-button {
     word-break: keep-all;
+  }
+
+  &-interactive {
+    flex-shrink: 0;
+  }
+
+  &-action-button-label {
+    white-space: nowrap;
   }
 }
 </style>

--- a/web/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
+++ b/web/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
@@ -144,8 +144,25 @@ export const useFileActionsRestore = () => {
           originalRoute.name === unref(router.currentRoute).name &&
           originalRoute.query?.fileId === unref(router.currentRoute).query?.fileId
         ) {
-          resourcesStore.removeResources(successful)
-          resourcesStore.resetSelection()
+          if (isLocationTrashActive(router, 'files-trash-generic')) {
+            resourcesStore.removeResources(successful)
+            resourcesStore.resetSelection()
+          } else {
+            // restored items now live in the currently viewed folder, fetch their fresh info and show them.
+            // a single failing lookup must not abort the whole refresh, so upsert whatever resolves
+            const restoredResources = (
+              await Promise.allSettled(
+                successful.map((resource) =>
+                  clientService.webdav.getFileInfo(space, { path: resource.path })
+                )
+              )
+            )
+              .filter((result) => result.status === 'fulfilled')
+              .map((result) => result.value)
+            if (restoredResources.length) {
+              resourcesStore.upsertResources(restoredResources)
+            }
+          }
         }
 
         // Reload quota
@@ -237,6 +254,7 @@ export const useFileActionsRestore = () => {
 
   return {
     actions,
+    handler,
     // HACK: exported for unit tests:
     restoreResources,
     collectConflicts

--- a/web/packages/web-pkg/src/composables/actions/helpers/index.ts
+++ b/web/packages/web-pkg/src/composables/actions/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './useIsSearchActive'
 export * from './useFileActionsDeleteResources'
 export * from './useIsFilesAppActive'
+export * from './useResolveRestorableResources'

--- a/web/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/web/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -29,6 +29,8 @@ import {
 import { storeToRefs } from 'pinia'
 import { useDeleteWorker } from '../../webWorkers'
 import { captureException } from '@sentry/vue'
+import { useResolveRestorableResources } from './useResolveRestorableResources'
+import { useFileActionsRestore } from '../files/useFileActionsRestore'
 
 export const useFileActionsDeleteResources = () => {
   const configStore = useConfigStore()
@@ -44,6 +46,8 @@ export const useFileActionsDeleteResources = () => {
   const { startWorker } = useDeleteWorker({
     concurrentRequests: configStore.options.concurrentRequests.resourceBatchActions
   })
+  const { resolveRestorableResources } = useResolveRestorableResources()
+  const { handler: restoreHandler } = useFileActionsRestore()
 
   const resourcesStore = useResourcesStore()
   const { currentFolder } = storeToRefs(resourcesStore)
@@ -291,7 +295,32 @@ export const useFileActionsDeleteResources = () => {
                       { itemCount: successful.length.toString() }
                     )
 
-              messageStore.showMessage({ title })
+              const restorableResources = await resolveRestorableResources(
+                spaceForDeletion,
+                successful
+              )
+
+              messageStore.showMessage({
+                title,
+                ...(restorableResources && {
+                  timeout: 5,
+                  actions: [
+                    {
+                      label: $gettext('Undo'),
+                      ariaLabel:
+                        restorableResources.length === 1
+                          ? $gettext('Undo delete of "%{item}"', {
+                              item: restorableResources[0].name
+                            })
+                          : $gettext('Undo delete of %{itemCount} items', {
+                              itemCount: restorableResources.length.toString()
+                            }),
+                      onClick: () =>
+                        restoreHandler({ space: spaceForDeletion, resources: restorableResources })
+                    }
+                  ]
+                })
+              })
             }
 
             resourcesStore.removeResourcesFromDeleteQueue(failed.map(({ resource }) => resource.id))

--- a/web/packages/web-pkg/src/composables/actions/helpers/useResolveRestorableResources.ts
+++ b/web/packages/web-pkg/src/composables/actions/helpers/useResolveRestorableResources.ts
@@ -1,0 +1,68 @@
+import { User } from '@ownclouders/web-client/graph/generated'
+import {
+  isProjectSpaceResource,
+  Resource,
+  SpaceResource,
+  TrashResource
+} from '@ownclouders/web-client'
+import { DavProperties } from '@ownclouders/web-client/webdav'
+import { useClientService } from '../../clientService'
+import { useUserStore } from '../../piniaStores'
+
+export const useResolveRestorableResources = () => {
+  const clientService = useClientService()
+  const userStore = useUserStore()
+
+  const canRestoreDeleteForSpace = (space: SpaceResource, user: User) => {
+    if (!isProjectSpaceResource(space)) {
+      return true
+    }
+    return space.canRestoreFromTrashbin({ user })
+  }
+
+  /**
+   * Resolves the trash-bin entries for a batch of just-deleted resources within a single space.
+   * Returns null if the space doesn't support trash-restore, or if the trash listing fails.
+   */
+  const resolveRestorableResources = async (
+    space: SpaceResource,
+    deletedResources: Resource[]
+  ): Promise<TrashResource[] | null> => {
+    if (!canRestoreDeleteForSpace(space, userStore.user)) {
+      return null
+    }
+
+    let trashResources: TrashResource[]
+    try {
+      const { children } = await clientService.webdav.listFiles(
+        space,
+        {},
+        { davProperties: DavProperties.Trashbin, isTrash: true }
+      )
+      trashResources = children as TrashResource[]
+    } catch {
+      return null
+    }
+
+    const resolved: TrashResource[] = []
+    for (const deleted of deletedResources) {
+      const candidates = trashResources.filter(
+        (t) => t.name === deleted.name && t.path === deleted.path
+      )
+      if (!candidates.length) {
+        continue
+      }
+      // pick the most recently deleted match
+      candidates.sort((a, b) => new Date(b.ddate).getTime() - new Date(a.ddate).getTime())
+      resolved.push(candidates[0])
+    }
+
+    if (resolved.length !== deletedResources.length) {
+      return null
+    }
+
+    return resolved
+  }
+
+  return { resolveRestorableResources }
+}

--- a/web/packages/web-pkg/src/composables/keyboardActions/useKeyboardActions.ts
+++ b/web/packages/web-pkg/src/composables/keyboardActions/useKeyboardActions.ts
@@ -12,6 +12,7 @@ export enum Key {
   X = 'x',
   A = 'a',
   S = 's',
+  Z = 'z',
   Space = ' ',
   ArrowUp = 'ArrowUp',
   ArrowDown = 'ArrowDown',

--- a/web/packages/web-pkg/src/composables/piniaStores/messages.ts
+++ b/web/packages/web-pkg/src/composables/piniaStores/messages.ts
@@ -5,6 +5,12 @@ import { HttpError } from '@ownclouders/web-client'
 
 type MessageError = Error | HttpError
 
+export interface MessageAction {
+  label: string
+  ariaLabel?: string
+  onClick: () => void
+}
+
 export interface Message {
   id: string
   title: string
@@ -13,6 +19,7 @@ export interface Message {
   errorLogContent?: string
   timeout?: number
   status?: string
+  actions?: MessageAction[]
 }
 
 export const useMessages = defineStore('messages', () => {
@@ -53,11 +60,28 @@ export const useMessages = defineStore('messages', () => {
     messages.value = unref(messages).filter(({ id }) => message.id !== id)
   }
 
+  /**
+   * Runs the first action of the most recent message that has one (e.g. "Undo" on a
+   * delete notification) and dismisses that message. Used by the global Ctrl/Cmd+Z
+   * shortcut. Returns false if there is no message with an action to trigger.
+   */
+  const triggerLatestAction = (): boolean => {
+    const message = [...unref(messages)].reverse().find((m) => m.actions?.length)
+    if (!message) {
+      return false
+    }
+
+    message.actions[0].onClick()
+    removeMessage(message)
+    return true
+  }
+
   return {
     messages,
     showMessage,
     showErrorMessage,
-    removeMessage
+    removeMessage,
+    triggerLatestAction
   }
 })
 

--- a/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
@@ -90,6 +90,49 @@ describe('restore', () => {
       })
     })
 
+    it('should upsert restored resources into the current view when not in the trash bin', async () => {
+      const resourcesToRestore = [{ id: '1', path: '/1', name: 'file1' }] as TrashResource[]
+      const restoredResource = mock<Resource>({ id: '1', path: '/1', name: 'file1' })
+
+      const { getWorkerCallbackDone } = getWrapper({
+        invalidLocation: true,
+        setup: ({ restoreResources }, { space }) => {
+          restoreResources(space, resourcesToRestore, [])
+        },
+        restoreResult: { successful: resourcesToRestore, failed: [] },
+        getFileInfoResult: restoredResource
+      })
+      await getWorkerCallbackDone()
+
+      const { removeResources, upsertResources } = useResourcesStore()
+      expect(removeResources).toHaveBeenCalledTimes(0)
+      expect(upsertResources).toHaveBeenCalledWith([restoredResource])
+    })
+
+    it('should upsert the resolvable resources even when one lookup fails', async () => {
+      const resourcesToRestore = [
+        { id: '1', path: '/1', name: 'file1' },
+        { id: '2', path: '/2', name: 'file2' }
+      ] as TrashResource[]
+      const restoredResource = mock<Resource>({ id: '2', path: '/2', name: 'file2' })
+
+      const { getWorkerCallbackDone } = getWrapper({
+        invalidLocation: true,
+        setup: ({ restoreResources }, { space }) => {
+          restoreResources(space, resourcesToRestore, [])
+        },
+        restoreResult: { successful: resourcesToRestore, failed: [] },
+        getFileInfoImplementation: (_, { path }) =>
+          path === '/2'
+            ? Promise.resolve(restoredResource)
+            : Promise.reject(new Error('network error'))
+      })
+      await getWorkerCallbackDone()
+
+      const { upsertResources } = useResourcesStore()
+      expect(upsertResources).toHaveBeenCalledWith([restoredResource])
+    })
+
     it('should show message on error', () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const resourcesToRestore = [{ id: '1', path: '/1' }] as TrashResource[]
@@ -153,6 +196,8 @@ function getWrapper({
   invalidLocation = false,
   driveType = 'personal',
   restoreResult = { successful: [], failed: [] },
+  getFileInfoResult,
+  getFileInfoImplementation,
   setup
 }: {
   invalidLocation?: boolean
@@ -161,6 +206,8 @@ function getWrapper({
     successful: TrashResource[]
     failed: { resource: TrashResource; error: HttpError }[]
   }
+  getFileInfoResult?: Resource
+  getFileInfoImplementation?: (...args: any[]) => Promise<Resource>
   setup: (
     instance: ReturnType<typeof useFileActionsRestore>,
     {
@@ -172,9 +219,10 @@ function getWrapper({
     }
   ) => void
 }) {
+  let workerCallbackDone: Promise<unknown> = Promise.resolve()
   vi.mocked(useRestoreWorker).mockReturnValue({
     startWorker: vi.fn().mockImplementation((_, callback) => {
-      callback(restoreResult)
+      workerCallbackDone = Promise.resolve(callback(restoreResult))
     })
   })
 
@@ -189,10 +237,16 @@ function getWrapper({
   mocks.$clientService.webdav.listFiles.mockImplementation(() => {
     return Promise.resolve({ resource: mock<Resource>(), children: [] })
   })
+  if (getFileInfoImplementation) {
+    mocks.$clientService.webdav.getFileInfo.mockImplementation(getFileInfoImplementation)
+  } else {
+    mocks.$clientService.webdav.getFileInfo.mockResolvedValue(getFileInfoResult)
+  }
   mocks.$clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(mock<SpaceResource>())
 
   return {
     mocks,
+    getWorkerCallbackDone: () => workerCallbackDone,
     wrapper: getComposableWrapper(
       () => {
         const instance = useFileActionsRestore()

--- a/web/packages/web-pkg/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
@@ -1,17 +1,23 @@
 import { useFileActionsDeleteResources } from '../../../../../src/composables/actions'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { FolderResource, Resource, SpaceResource } from '@ownclouders/web-client'
+import { FolderResource, Resource, SpaceResource, TrashResource } from '@ownclouders/web-client'
 import {
   defaultComponentMocks,
   getComposableWrapper,
   useGetMatchingSpaceMock
 } from '@ownclouders/web-test-helpers'
 import { useDeleteWorker } from '../../../../../src/composables/webWorkers/deleteWorker'
+import { useRestoreWorker } from '../../../../../src/composables/webWorkers/restoreWorker'
 import { useGetMatchingSpace } from '../../../../../src/composables/spaces/useGetMatchingSpace'
-import { useResourcesStore, useSpacesStore } from '../../../../../src/composables/piniaStores'
+import {
+  useMessages,
+  useResourcesStore,
+  useSpacesStore
+} from '../../../../../src/composables/piniaStores'
 import { MockedFunction } from 'vitest'
 
 vi.mock('../../../../../src/composables/webWorkers/deleteWorker')
+vi.mock('../../../../../src/composables/webWorkers/restoreWorker')
 vi.mock('../../../../../src/composables/spaces/useGetMatchingSpace')
 
 const currentFolder = {
@@ -130,6 +136,107 @@ describe('deleteResources', () => {
         }
       })
     })
+
+    describe('undo action on the success message', () => {
+      const deletedFile = mock<Resource>({
+        id: '2',
+        name: 'fileToDelete.txt',
+        path: '/folder/fileToDelete.txt',
+        storageId: 'personal',
+        spaceId: '1'
+      })
+
+      it('is included when the space allows trash-restore and the trash entry resolves', async () => {
+        const trashEntry = mock<TrashResource>({
+          name: deletedFile.name,
+          path: deletedFile.path,
+          ddate: '2026-01-01T00:00:00Z'
+        })
+
+        const { getWorkerCallbackDone } = getWrapper({
+          currentFolder,
+          result: [deletedFile],
+          listFilesResult: { resource: mock<Resource>(), children: [trashEntry] },
+          setup: ({ filesList_delete }) => {
+            filesList_delete([deletedFile])
+          }
+        })
+        await getWorkerCallbackDone()
+
+        const { showMessage } = useMessages()
+        expect(showMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            timeout: 5,
+            actions: [expect.objectContaining({ label: 'Undo' })]
+          })
+        )
+      })
+
+      it('is omitted when the trash entry cannot be resolved', async () => {
+        const { getWorkerCallbackDone } = getWrapper({
+          currentFolder,
+          result: [deletedFile],
+          listFilesResult: { resource: mock<Resource>(), children: [] },
+          setup: ({ filesList_delete }) => {
+            filesList_delete([deletedFile])
+          }
+        })
+        await getWorkerCallbackDone()
+
+        const { showMessage } = useMessages()
+        expect(showMessage).toHaveBeenCalledWith(
+          expect.not.objectContaining({ actions: expect.anything() })
+        )
+      })
+
+      it('is omitted when the space does not allow trash-restore', async () => {
+        const { getWorkerCallbackDone } = getWrapper({
+          currentFolder,
+          result: [deletedFile],
+          spaceDriveType: 'project',
+          canRestoreFromTrashbin: false,
+          setup: ({ filesList_delete }) => {
+            filesList_delete([deletedFile])
+          }
+        })
+        await getWorkerCallbackDone()
+
+        const { showMessage } = useMessages()
+        expect(showMessage).toHaveBeenCalledWith(
+          expect.not.objectContaining({ actions: expect.anything() })
+        )
+      })
+
+      it('restores the resolved trash entry when clicked', async () => {
+        const trashEntry = mock<TrashResource>({
+          name: deletedFile.name,
+          path: deletedFile.path,
+          ddate: '2026-01-01T00:00:00Z'
+        })
+
+        let spaceUnderTest: SpaceResource
+        const { getWorkerCallbackDone } = getWrapper({
+          currentFolder,
+          result: [deletedFile],
+          listFilesResult: { resource: mock<Resource>(), children: [trashEntry] },
+          setup: ({ filesList_delete }, { space }) => {
+            spaceUnderTest = space
+            filesList_delete([deletedFile])
+          }
+        })
+        await getWorkerCallbackDone()
+
+        const { showMessage } = useMessages()
+        const call = (showMessage as MockedFunction<typeof showMessage>).mock.calls[0][0]
+        await call.actions[0].onClick()
+
+        const { startWorker } = vi.mocked(useRestoreWorker)()
+        expect(startWorker).toHaveBeenCalledWith(
+          expect.objectContaining({ space: spaceUnderTest, resources: [trashEntry] }),
+          expect.any(Function)
+        )
+      })
+    })
   })
 })
 
@@ -137,7 +244,10 @@ function getWrapper({
   currentFolder,
   setup,
   result = [],
-  getFileInfoResult
+  getFileInfoResult,
+  listFilesResult = { resource: mock<Resource>(), children: [] },
+  spaceDriveType = 'personal',
+  canRestoreFromTrashbin = true
 }: {
   currentFolder: FolderResource
   setup: (
@@ -152,17 +262,37 @@ function getWrapper({
   ) => void
   result?: Resource[]
   getFileInfoResult?: Resource
+  listFilesResult?: { resource: Resource; children: Resource[] }
+  spaceDriveType?: string
+  canRestoreFromTrashbin?: boolean
 }) {
   const mocks = {
     ...defaultComponentMocks(),
-    space: mockDeep<SpaceResource>({ id: 'personal' })
+    space: mockDeep<SpaceResource>({
+      id: 'personal',
+      driveType: spaceDriveType,
+      canRestoreFromTrashbin: () => canRestoreFromTrashbin
+    })
   }
   mocks.$clientService.webdav.deleteFile.mockResolvedValue(undefined)
   mocks.$clientService.webdav.getFileInfo.mockResolvedValue(getFileInfoResult)
+  mocks.$clientService.webdav.listFiles.mockImplementation((_, __, opts) => {
+    if (opts?.isTrash) {
+      return Promise.resolve(listFilesResult)
+    }
+    return Promise.resolve({ resource: mock<Resource>(), children: [] })
+  })
 
+  let workerCallbackDone: Promise<unknown> = Promise.resolve()
   vi.mocked(useDeleteWorker).mockReturnValue({
     startWorker: vi.fn().mockImplementation((_, callback) => {
-      callback({ successful: result, failed: [] })
+      workerCallbackDone = Promise.resolve(callback({ successful: result, failed: [] }))
+    })
+  })
+
+  vi.mocked(useRestoreWorker).mockReturnValue({
+    startWorker: vi.fn().mockImplementation((_, callback) => {
+      callback({ successful: [], failed: [] })
     })
   })
 
@@ -175,6 +305,7 @@ function getWrapper({
 
   return {
     mocks,
+    getWorkerCallbackDone: () => workerCallbackDone,
     wrapper: getComposableWrapper(
       () => {
         const instance = useFileActionsDeleteResources()

--- a/web/packages/web-pkg/tests/unit/composables/actions/helpers/useResolveRestorableResources.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/actions/helpers/useResolveRestorableResources.spec.ts
@@ -1,0 +1,133 @@
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource, TrashResource } from '@ownclouders/web-client'
+import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { useUserStore } from '../../../../../src/composables/piniaStores'
+import { useResolveRestorableResources } from '../../../../../src/composables/actions/helpers/useResolveRestorableResources'
+
+describe('resolveRestorableResources', () => {
+  it('returns null when the space does not allow trash-restore', () => {
+    const space = mock<SpaceResource>({ driveType: 'project', canRestoreFromTrashbin: () => false })
+    const deleted = [mock<Resource>({ name: 'file.txt', path: '/file.txt' })]
+
+    getWrapper({
+      setup: async ({ resolveRestorableResources }, { clientService }) => {
+        const result = await resolveRestorableResources(space, deleted)
+        expect(result).toBeNull()
+        expect(clientService.webdav.listFiles).not.toHaveBeenCalled()
+      }
+    })
+  })
+
+  it('returns null when listing the trash bin fails', () => {
+    const space = mock<SpaceResource>({ driveType: 'personal' })
+    const deleted = [mock<Resource>({ name: 'file.txt', path: '/file.txt' })]
+
+    getWrapper({
+      setup: async ({ resolveRestorableResources }) => {
+        const result = await resolveRestorableResources(space, deleted)
+        expect(result).toBeNull()
+      },
+      listFilesImplementation: () => Promise.reject(new Error('network error'))
+    })
+  })
+
+  it('returns null when not every deleted resource has a matching trash entry', () => {
+    const space = mock<SpaceResource>({ driveType: 'personal' })
+    const deleted = [
+      mock<Resource>({ name: 'file.txt', path: '/file.txt' }),
+      mock<Resource>({ name: 'other.txt', path: '/other.txt' })
+    ]
+    const trashEntry = mock<TrashResource>({
+      name: 'file.txt',
+      path: '/file.txt',
+      ddate: '2026-01-01T00:00:00Z'
+    })
+
+    getWrapper({
+      setup: async ({ resolveRestorableResources }) => {
+        const result = await resolveRestorableResources(space, deleted)
+        expect(result).toBeNull()
+      },
+      listFilesImplementation: () =>
+        Promise.resolve({ resource: mock<Resource>(), children: [trashEntry] })
+    })
+  })
+
+  it('resolves the matching trash entries for all deleted resources', () => {
+    const space = mock<SpaceResource>({ driveType: 'personal' })
+    const deleted = [mock<Resource>({ name: 'file.txt', path: '/file.txt' })]
+    const trashEntry = mock<TrashResource>({
+      name: 'file.txt',
+      path: '/file.txt',
+      ddate: '2026-01-01T00:00:00Z'
+    })
+
+    getWrapper({
+      setup: async ({ resolveRestorableResources }) => {
+        const result = await resolveRestorableResources(space, deleted)
+        expect(result).toEqual([trashEntry])
+      },
+      listFilesImplementation: () =>
+        Promise.resolve({ resource: mock<Resource>(), children: [trashEntry] })
+    })
+  })
+
+  it('picks the most recently deleted match when there are duplicates', () => {
+    const space = mock<SpaceResource>({ driveType: 'personal' })
+    const deleted = [mock<Resource>({ name: 'file.txt', path: '/file.txt' })]
+    const olderEntry = mock<TrashResource>({
+      name: 'file.txt',
+      path: '/file.txt',
+      ddate: '2025-01-01T00:00:00Z'
+    })
+    const newerEntry = mock<TrashResource>({
+      name: 'file.txt',
+      path: '/file.txt',
+      ddate: '2026-01-01T00:00:00Z'
+    })
+
+    getWrapper({
+      setup: async ({ resolveRestorableResources }) => {
+        const result = await resolveRestorableResources(space, deleted)
+        expect(result).toEqual([newerEntry])
+      },
+      listFilesImplementation: () =>
+        Promise.resolve({ resource: mock<Resource>(), children: [olderEntry, newerEntry] })
+    })
+  })
+})
+
+function getWrapper({
+  setup,
+  listFilesImplementation,
+  user
+}: {
+  setup: (
+    instance: ReturnType<typeof useResolveRestorableResources>,
+    { clientService }: { clientService: ReturnType<typeof defaultComponentMocks>['$clientService'] }
+  ) => void
+  listFilesImplementation?: () => Promise<any>
+  user?: any
+}) {
+  const mocks = defaultComponentMocks()
+  mocks.$clientService.webdav.listFiles.mockImplementation(
+    listFilesImplementation || (() => Promise.resolve({ resource: mock<Resource>(), children: [] }))
+  )
+
+  return {
+    mocks,
+    wrapper: getComposableWrapper(
+      () => {
+        if (user) {
+          useUserStore().setUser(user)
+        }
+        const instance = useResolveRestorableResources()
+        setup(instance, { clientService: mocks.$clientService })
+      },
+      {
+        mocks,
+        provide: mocks
+      }
+    )
+  }
+}

--- a/web/packages/web-pkg/tests/unit/composables/piniaStores/messages.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/piniaStores/messages.spec.ts
@@ -1,0 +1,78 @@
+import { getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { useMessages } from '../../../../src/composables/piniaStores'
+import { createPinia, setActivePinia } from 'pinia'
+
+describe('useMessages', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('method "triggerLatestAction"', () => {
+    it('returns false when there are no messages', () => {
+      getWrapper({
+        setup: (instance) => {
+          expect(instance.triggerLatestAction()).toBe(false)
+        }
+      })
+    })
+
+    it('returns false when no message has an action', () => {
+      getWrapper({
+        setup: (instance) => {
+          instance.showMessage({ title: 'plain message' })
+          expect(instance.triggerLatestAction()).toBe(false)
+        }
+      })
+    })
+
+    it('runs the action of the most recent message that has one and dismisses it', () => {
+      getWrapper({
+        setup: (instance) => {
+          const onClick = vi.fn()
+          instance.showMessage({ title: 'plain message' })
+          const withAction = instance.showMessage({
+            title: 'undoable message',
+            actions: [{ label: 'Undo', onClick }]
+          })
+
+          const triggered = instance.triggerLatestAction()
+
+          expect(triggered).toBe(true)
+          expect(onClick).toHaveBeenCalledTimes(1)
+          expect(instance.messages.find((m) => m.id === withAction.id)).toBeUndefined()
+        }
+      })
+    })
+
+    it('skips messages without an action in favor of an earlier one that has one', () => {
+      getWrapper({
+        setup: (instance) => {
+          const onClick = vi.fn()
+          const withAction = instance.showMessage({
+            title: 'undoable message',
+            actions: [{ label: 'Undo', onClick }]
+          })
+          instance.showMessage({ title: 'later plain message' })
+
+          const triggered = instance.triggerLatestAction()
+
+          expect(triggered).toBe(true)
+          expect(onClick).toHaveBeenCalledTimes(1)
+          expect(instance.messages.find((m) => m.id === withAction.id)).toBeUndefined()
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useMessages>) => void }) {
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useMessages()
+        setup(instance)
+      },
+      { pluginOptions: { pinia: false } }
+    )
+  }
+}

--- a/web/packages/web-runtime/src/components/MessageBar.vue
+++ b/web/packages/web-runtime/src/components/MessageBar.vue
@@ -8,6 +8,7 @@
       :status="item.status"
       :timeout="item.timeout"
       :error-log-content="item.errorLogContent"
+      :actions="item.actions"
       @close="deleteMessage(item)"
     />
   </oc-notifications>

--- a/web/packages/web-runtime/src/layouts/Application.vue
+++ b/web/packages/web-runtime/src/layouts/Application.vue
@@ -57,10 +57,13 @@ import {
   CustomComponentTarget,
   Extension,
   ExtensionPoint,
+  Key,
+  Modifier,
   useAppsStore,
   useAuthStore,
   useConfigStore,
   useExtensionRegistry,
+  useKeyboardActions,
   useLocalStorage
 } from '@ownclouders/web-pkg'
 import TopBar from '../components/Topbar/TopBar.vue'
@@ -110,6 +113,14 @@ export default defineComponent({
     const activeApp = useActiveApp()
     const extensionRegistry = useExtensionRegistry()
     const messageStore = useMessages()
+
+    // global shortcut so users can undo the most recent undoable action (e.g. delete)
+    // via keyboard, not just by clicking "Undo" on its notification. bypasses the
+    // default input-field guard, matching how Ctrl+S (save) is handled in AppWrapper.vue.
+    const { bindKeyAction } = useKeyboardActions({ skipDisabledKeyBindingsCheck: true })
+    bindKeyAction({ modifier: Modifier.Ctrl, primary: Key.Z }, () => {
+      messageStore.triggerLatestAction()
+    })
 
     const allMessages = ref<{ id: string; title: string; desc?: string }[]>([])
 


### PR DESCRIPTION
## Description
Adds an "Undo" action to the delete success notification toast, letting users restore deleted file(s)/folder(s) directly from the toast instead of navigating to the trash bin. The same restore can also be triggered via the Ctrl+Z (Cmd+Z on macOS) keyboard shortcut while the notification is visible.

- The "Undo" action is only shown when the deleted resources can be resolved in the trash and the space/backend supports trash-restore (e.g. hidden for project spaces without restore permission).
- Clicking "Undo" reuses the existing restore flow, including conflict resolution if a naming conflict exists at the original location.
- The current file/folder view refreshes to reflect restored item(s) without a manual page refresh.
- The notification pauses its auto-dismiss timer while hovered or keyboard-focused.
- Clicking "Undo" (or pressing Ctrl+Z) immediately dismisses the toast to prevent duplicate restore attempts.
- The action button is laid out inline with the title text, with tab order flowing title -> Undo -> Close.

## Related Issue
- Fixes [OCISDEV-1085](https://kiteworks.atlassian.net/browse/OCISDEV-1085)

## Motivation and Context
Deleting a file or folder previously showed only a passive "moved to trash bin" toast with no quick way to reverse the action, forcing users to navigate to the trash bin, find the item, and restore it manually. This adds friction for accidental deletions.

## How Has This Been Tested?
- test environment: local dev instance, unit tests (Vitest)
- test case 1: delete a single file, click "Undo" on the toast, verify it is restored and visible in the current view
- test case 2: delete multiple resources, click "Undo", verify all are restored
- test case 3: delete a file, press Ctrl+Z while the toast is visible, verify the same restore happens
- test case 4: let the toast auto-dismiss (or dismiss via close button), verify Ctrl+Z no longer restores anything
- test case 5: delete a resource in a project space without restore permission, verify no "Undo" action is shown
- test case 6: restore a file that now conflicts with an existing file at the original location, verify the conflict dialog appears
- test case 7: hover/focus the toast, verify the auto-dismiss timer pauses; verify it resumes on mouse leave/blur
- test case 8: unit tests for `useResolveRestorableResources`, `useFileActionsRestore`, `useFileActionsDeleteResources`, `useMessages.triggerLatestAction`, and `OcNotificationMessage`

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
