### PR TITLE
fix(admin-settings): prevent deleting your own account

### DIFF
--- a/changelog/unreleased/bugfix-admin-settings-prevent-self-deletion.md
+++ b/changelog/unreleased/bugfix-admin-settings-prevent-self-deletion.md
@@ -1,0 +1,15 @@
+Bugfix: Prevent deleting your own account in the user management
+
+In the admin settings user management, the account you are currently logged in
+as could be selected and included in a delete action, even though the backend
+always rejects self-deletion. Deleting a selection that included your own
+account produced a "Failed to delete 1 user" error and made your own row
+temporarily disappear from the list until the page was refreshed.
+
+The delete action now excludes the current user from the request, so all other
+selected users are deleted while your own account is left untouched. When your
+own account is part of the selection, the delete confirmation dialog shows a
+hint that it will not be deleted.
+
+https://github.com/owncloud/ocis/pull/12657
+https://github.com/owncloud/ocis/issues/12582

--- a/web/packages/web-app-admin-settings/src/components/Users/DeleteUserModal.vue
+++ b/web/packages/web-app-admin-settings/src/components/Users/DeleteUserModal.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <p class="oc-mt-rm oc-mb-rm" v-text="message" />
+    <p
+      v-if="currentUserSelected"
+      class="delete-user-own-account-hint oc-mt-s oc-mb-rm"
+      v-text="$gettext('Your own account will not be deleted.')"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { User } from '@ownclouders/web-client/graph/generated'
+import { Modal, useUserStore } from '@ownclouders/web-pkg'
+
+interface Props {
+  modal: Modal
+  users: User[]
+}
+const props = defineProps<Props>()
+const { $gettext, $ngettext } = useGettext()
+const userStore = useUserStore()
+
+const currentUserSelected = computed(() =>
+  props.users.some((user) => user.id === userStore.user.id)
+)
+
+const message = computed(() =>
+  $ngettext(
+    'Are you sure you want to delete this user?',
+    'Are you sure you want to delete the %{userCount} selected users?',
+    props.users.length,
+    { userCount: props.users.length.toString() }
+  )
+)
+</script>
+
+<style lang="scss" scoped>
+.delete-user-own-account-hint {
+  color: var(--oc-color-swatch-warning-default);
+}
+</style>

--- a/web/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
+++ b/web/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
@@ -4,13 +4,15 @@ import {
   useCapabilityStore,
   useMessages,
   useModals,
-  useRouteQuery
+  useRouteQuery,
+  useUserStore
 } from '@ownclouders/web-pkg'
 import { useClientService } from '@ownclouders/web-pkg'
 import { UserAction, UserActionOptions } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { User } from '@ownclouders/web-client/graph/generated'
 import { useUserSettingsStore } from '../../stores/userSettings'
+import DeleteUserModal from '../../../components/Users/DeleteUserModal.vue'
 
 export const useUserActionsDelete = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -18,6 +20,7 @@ export const useUserActionsDelete = () => {
   const { $gettext, $ngettext } = useGettext()
   const clientService = useClientService()
   const { dispatchModal } = useModals()
+  const userStore = useUserStore()
   const userSettingsStore = useUserSettingsStore()
 
   const currentPageQuery = useRouteQuery('page', '1')
@@ -31,15 +34,18 @@ export const useUserActionsDelete = () => {
   })
 
   const deleteUsers = async (users: User[]) => {
+    const affectedUsers = users.filter((user) => user.id !== userStore.user.id)
     const graphClient = clientService.graphAuthenticated
-    const promises = users.map((user) => graphClient.users.deleteUser(user.id))
+    const promises = affectedUsers.map((user) => graphClient.users.deleteUser(user.id))
     const results = await Promise.allSettled(promises)
 
     const succeeded = results.filter((r) => r.status === 'fulfilled')
     if (succeeded.length) {
       const title =
-        succeeded.length === 1 && users.length === 1
-          ? $gettext('User "%{user}" was deleted successfully', { user: users[0].displayName })
+        succeeded.length === 1 && affectedUsers.length === 1
+          ? $gettext('User "%{user}" was deleted successfully', {
+              user: affectedUsers[0].displayName
+            })
           : $ngettext(
               '%{userCount} user was deleted successfully',
               '%{userCount} users were deleted successfully',
@@ -54,8 +60,8 @@ export const useUserActionsDelete = () => {
       failed.forEach(console.error)
 
       const title =
-        failed.length === 1 && users.length === 1
-          ? $gettext('Failed to delete user "%{user}"', { user: users[0].displayName })
+        failed.length === 1 && affectedUsers.length === 1
+          ? $gettext('Failed to delete user "%{user}"', { user: affectedUsers[0].displayName })
           : $ngettext(
               'Failed to delete %{userCount} user',
               'Failed to delete %{userCount} users',
@@ -68,7 +74,7 @@ export const useUserActionsDelete = () => {
       })
     }
 
-    userSettingsStore.removeUsers(users)
+    userSettingsStore.removeUsers(affectedUsers)
     userSettingsStore.setSelectedUsers([])
 
     const pageCount = Math.ceil(userSettingsStore.users.length / unref(itemsPerPage))
@@ -90,14 +96,8 @@ export const useUserActionsDelete = () => {
         userCount: resources.length.toString()
       }),
       confirmText: $gettext('Delete'),
-      message: $ngettext(
-        'Are you sure you want to delete this user?',
-        'Are you sure you want to delete the %{userCount} selected users?',
-        resources.length,
-        {
-          userCount: resources.length.toString()
-        }
-      ),
+      customComponent: DeleteUserModal,
+      customComponentAttrs: () => ({ users: resources }),
       hasInput: false,
       onConfirm: () => deleteUsers(resources)
     })

--- a/web/packages/web-app-admin-settings/tests/unit/components/Users/DeleteUserModal.spec.ts
+++ b/web/packages/web-app-admin-settings/tests/unit/components/Users/DeleteUserModal.spec.ts
@@ -1,0 +1,35 @@
+import DeleteUserModal from '../../../../src/components/Users/DeleteUserModal.vue'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { User } from '@ownclouders/web-client/graph/generated'
+import { Modal } from '@ownclouders/web-pkg'
+
+describe('DeleteUserModal', () => {
+  it('shows a hint when the current user is part of the selection', () => {
+    // the default mocked user store uses id '1'
+    const { wrapper } = getWrapper([mock<User>({ id: '1' }), mock<User>({ id: '2' })])
+    expect(wrapper.find('.delete-user-own-account-hint').exists()).toBe(true)
+  })
+  it('does not show a hint when the current user is not part of the selection', () => {
+    const { wrapper } = getWrapper([mock<User>({ id: '2' })])
+    expect(wrapper.find('.delete-user-own-account-hint').exists()).toBe(false)
+  })
+})
+
+function getWrapper(users = [mock<User>()]) {
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: shallowMount(DeleteUserModal, {
+      props: {
+        modal: mock<Modal>(),
+        users
+      },
+      global: {
+        provide: mocks,
+        plugins: [...defaultPlugins()]
+      }
+    })
+  }
+}

--- a/web/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
+++ b/web/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
@@ -1,8 +1,10 @@
 import { useUserActionsDelete } from '../../../../../src/composables/actions/users/useUserActionsDelete'
+import DeleteUserModal from '../../../../../src/components/Users/DeleteUserModal.vue'
 import { mock } from 'vitest-mock-extended'
+import { Mock } from 'vitest'
 import { unref } from 'vue'
 import { User } from '@ownclouders/web-client/graph/generated'
-import { useCapabilityStore } from '@ownclouders/web-pkg'
+import { useCapabilityStore, useModals } from '@ownclouders/web-pkg'
 import {
   defaultComponentMocks,
   getComposableWrapper,
@@ -55,11 +57,58 @@ describe('useUserActionsDelete', () => {
         }
       })
     })
+    it('should not delete the current user when included in the selection', () => {
+      getWrapper({
+        currentUserId: 'self',
+        setup: async ({ deleteUsers }, { clientService }) => {
+          const currentUser = mock<User>({ id: 'self' })
+          const otherUser = mock<User>({ id: 'other' })
+          await deleteUsers([currentUser, otherUser])
+          expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(
+            otherUser.id
+          )
+          expect(clientService.graphAuthenticated.users.deleteUser).not.toHaveBeenCalledWith(
+            currentUser.id
+          )
+        }
+      })
+    })
+    it('should do nothing when the current user is the only selected user', () => {
+      getWrapper({
+        currentUserId: 'self',
+        setup: async ({ deleteUsers }, { clientService }) => {
+          const currentUser = mock<User>({ id: 'self' })
+          await deleteUsers([currentUser])
+          expect(clientService.graphAuthenticated.users.deleteUser).not.toHaveBeenCalled()
+        }
+      })
+    })
+  })
+  describe('method "handler"', () => {
+    it('dispatches the delete modal with the selected users', () => {
+      getWrapper({
+        setup: ({ actions }) => {
+          const { dispatchModal } = useModals()
+          const resources = [mock<User>({ id: 'self' }), mock<User>({ id: 'other' })]
+          unref(actions)[0].handler({ resources })
+          expect(dispatchModal).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variation: 'danger',
+              customComponent: DeleteUserModal,
+              customComponentAttrs: expect.any(Function)
+            })
+          )
+          const attrs = (dispatchModal as unknown as Mock).mock.calls[0][0].customComponentAttrs()
+          expect(attrs.users).toEqual(resources)
+        }
+      })
+    })
   })
 })
 
 function getWrapper({
-  setup
+  setup,
+  currentUserId = '0'
 }: {
   setup: (
     instance: ReturnType<typeof useUserActionsDelete>,
@@ -69,6 +118,7 @@ function getWrapper({
       clientService: ReturnType<typeof defaultComponentMocks>['$clientService']
     }
   ) => void
+  currentUserId?: string
 }) {
   const mocks = defaultComponentMocks()
   return {
@@ -77,7 +127,15 @@ function getWrapper({
         const instance = useUserActionsDelete()
         setup(instance, { clientService: mocks.$clientService })
       },
-      { mocks, provide: mocks }
+      {
+        mocks,
+        provide: mocks,
+        pluginOptions: {
+          piniaOptions: {
+            userState: { user: { id: currentUserId } as User }
+          }
+        }
+      }
     )
   }
 }


### PR DESCRIPTION
In the user management, the account you are currently logged in as could be selected and included in a delete action, even though the backend always rejects self-deletion. Deleting a selection that included your own account produced a "Failed to delete 1 user" error and made your own row temporarily disappear from the list until the page was refreshed.

The delete action now excludes the current user from the request, so all other selected users are deleted while your own account is left untouched. When your own account is part of the selection, the delete confirmation dialog shows a hint that it will not be deleted.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes OCISDEV-1044, #12582 

## Motivation and Context
N.A
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N.A

## Screenshots (if appropriate):
N.A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
