### PR TITLE
fix(webdav): log unmapped thumbnail errors at error level (#12663)

### DIFF
--- a/changelog/unreleased/fix-webdav-thumbnail-error-logging.md
+++ b/changelog/unreleased/fix-webdav-thumbnail-error-logging.md
@@ -1,0 +1,18 @@
+Bugfix: Log unmapped thumbnail errors and always report a sabredav exception
+
+The webdav service logged failures of the thumbnails service at debug level only.
+Errors which are not a property of the requested file, such as the thumbnails
+service being unreachable, were therefore invisible at production log levels: a
+complete preview outage produced HTTP 500 responses without a single log line
+explaining them. Unmapped errors are now logged at error level, while expected
+per-file outcomes such as an unsupported file type or a file still being
+processed stay at debug level. Two of the four thumbnail handlers also logged
+without the request context, so their messages carried no request id.
+
+In addition, `codesEnum` only mapped four status codes, so error responses for
+all other codes were rendered with an empty `<s:exception></s:exception>`
+element. The missing entries for 403, 425 and 429 have been added and any
+remaining unmapped code now falls back to a generic exception name, so clients
+always receive a usable exception.
+
+https://github.com/owncloud/ocis/pull/12667

--- a/services/webdav/pkg/service/v0/service.go
+++ b/services/webdav/pkg/service/v0/service.go
@@ -41,7 +41,14 @@ var (
 		http.StatusUnauthorized:     "Sabre\\DAV\\Exception\\NotAuthenticated",
 		http.StatusNotFound:         "Sabre\\DAV\\Exception\\NotFound",
 		http.StatusMethodNotAllowed: "Sabre\\DAV\\Exception\\MethodNotAllowed",
+		http.StatusForbidden:        "Sabre\\DAV\\Exception\\Forbidden",
+		http.StatusTooEarly:         "Sabre\\DAV\\Exception\\TooEarly",
+		http.StatusTooManyRequests:  "Sabre\\DAV\\Exception\\TooManyRequests",
 	}
+
+	// defaultException is used for status codes which have no dedicated sabredav
+	// exception name, so that clients always receive a non-empty exception.
+	defaultException = "Sabre\\DAV\\Exception"
 )
 
 // Service defines the extension handlers.
@@ -267,7 +274,11 @@ func (g Webdav) SpacesThumbnail(w http.ResponseWriter, r *http.Request) {
 		case http.StatusForbidden:
 			renderError(w, r, errPermissionDenied(e.Detail))
 		default:
+			// an unmapped error is an infrastructure problem, not a property of the
+			// requested file: log it at error level so it is visible in production.
+			logger.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errInternalError("could not get thumbnail"))
+			return
 		}
 		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
@@ -365,9 +376,13 @@ func (g Webdav) Thumbnail(w http.ResponseWriter, r *http.Request) {
 		case http.StatusForbidden:
 			renderError(w, r, errPermissionDenied(e.Detail))
 		default:
+			// an unmapped error is an infrastructure problem, not a property of the
+			// requested file: log it at error level so it is visible in production.
+			logger.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errInternalError("could not get thumbnail"))
+			return
 		}
-		g.log.Error().Err(err).Msg("could not get thumbnail")
+		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -410,9 +425,13 @@ func (g Webdav) PublicThumbnail(w http.ResponseWriter, r *http.Request) {
 			addRetryAfterHeader(w)
 			renderError(w, r, errTooManyRequests(e.Detail))
 		default:
+			// an unmapped error is an infrastructure problem, not a property of the
+			// requested file: log it at error level so it is visible in production.
+			logger.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errInternalError("could not get thumbnail"))
+			return
 		}
-		g.log.Error().Err(err).Msg("could not get thumbnail")
+		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
 	}
 
@@ -455,7 +474,11 @@ func (g Webdav) PublicThumbnailHead(w http.ResponseWriter, r *http.Request) {
 			addRetryAfterHeader(w)
 			renderError(w, r, errTooManyRequests(e.Detail))
 		default:
+			// an unmapped error is an infrastructure problem, not a property of the
+			// requested file: log it at error level so it is visible in production.
+			logger.Error().Err(err).Msg("could not get thumbnail")
 			renderError(w, r, errInternalError("could not get thumbnail"))
+			return
 		}
 		logger.Debug().Err(err).Msg("could not get thumbnail")
 		return
@@ -527,11 +550,15 @@ type errResponse struct {
 }
 
 func newErrResponse(statusCode int, msg string) *errResponse {
+	exception, ok := codesEnum[statusCode]
+	if !ok {
+		exception = defaultException
+	}
 	rsp := &errResponse{
 		HTTPStatusCode: statusCode,
 		Xmlnsd:         "DAV",
 		Xmlnss:         "http://sabredav.org/ns",
-		Exception:      codesEnum[statusCode],
+		Exception:      exception,
 	}
 	if msg != "" {
 		rsp.Message = msg

--- a/services/webdav/pkg/service/v0/service_test.go
+++ b/services/webdav/pkg/service/v0/service_test.go
@@ -1,0 +1,50 @@
+package svc
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewErrResponseException(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		expected   string
+	}{
+		{"bad request", http.StatusBadRequest, "Sabre\\DAV\\Exception\\BadRequest"},
+		{"unauthorized", http.StatusUnauthorized, "Sabre\\DAV\\Exception\\NotAuthenticated"},
+		{"not found", http.StatusNotFound, "Sabre\\DAV\\Exception\\NotFound"},
+		{"method not allowed", http.StatusMethodNotAllowed, "Sabre\\DAV\\Exception\\MethodNotAllowed"},
+		{"forbidden", http.StatusForbidden, "Sabre\\DAV\\Exception\\Forbidden"},
+		{"too early", http.StatusTooEarly, "Sabre\\DAV\\Exception\\TooEarly"},
+		{"too many requests", http.StatusTooManyRequests, "Sabre\\DAV\\Exception\\TooManyRequests"},
+		// unmapped codes must still yield a non-empty exception
+		{"internal server error", http.StatusInternalServerError, defaultException},
+		{"not implemented", http.StatusNotImplemented, defaultException},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rsp := newErrResponse(tt.statusCode, "some message")
+			if rsp.Exception != tt.expected {
+				t.Errorf("expected exception %q, got %q", tt.expected, rsp.Exception)
+			}
+			if rsp.HTTPStatusCode != tt.statusCode {
+				t.Errorf("expected status code %d, got %d", tt.statusCode, rsp.HTTPStatusCode)
+			}
+			if rsp.Message != "some message" {
+				t.Errorf("expected message to be set, got %q", rsp.Message)
+			}
+		})
+	}
+}
+
+func TestNewErrResponseEmptyMessage(t *testing.T) {
+	rsp := newErrResponse(http.StatusNotFound, "")
+	if rsp.Message != "" {
+		t.Errorf("expected empty message, got %q", rsp.Message)
+	}
+	if rsp.Exception != "Sabre\\DAV\\Exception\\NotFound" {
+		t.Errorf("unexpected exception %q", rsp.Exception)
+	}
+}


### PR DESCRIPTION
Forward port of #12663 to `stable-8.2`. Companion to #12666 (`stable-8.1`).

Failures of the thumbnails service were logged at debug level only, so errors which are not a property of the requested file — such as the thumbnails service being unreachable — were invisible at production log levels. A complete preview outage produced HTTP 500 responses without a single log line explaining them.

Unmapped errors are now logged at error level, while expected per-file outcomes such as an unsupported file type or a file still being processed stay at debug level. `Thumbnail` and `PublicThumbnail` previously logged at error level for *every* failure, including expected 404s for unsupported file types, and did so via `g.log` so the message carried no request id — both now log only in the `default:` branch, using the request-scoped logger.

Also adds the missing `codesEnum` entries for 403, 425 and 429 and falls back to a generic exception name for any remaining unmapped status code, so error responses no longer render an empty `<s:exception></s:exception>`.

**Conflict resolution:** the cherry-pick needed manual resolution because this branch already renders the sanitized message `errInternalError("could not get thumbnail")` instead of `err.Error()`. That line is context directly below the insertion point, so git could not place the hunk. This branch's sanitized message is kept unchanged; the added and removed lines are byte-identical to #12666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)