### PR TITLE
fix(graph): [OCISDEV-1088] fix concurrent map access in share listing (#12670)

### DIFF
--- a/changelog/unreleased/fix-graph-concurrent-map-access-share-listing.md
+++ b/changelog/unreleased/fix-graph-concurrent-map-access-share-listing.md
@@ -1,0 +1,18 @@
+Bugfix: Fix concurrent map access when listing shares
+
+Listing shares could abort the whole oCIS process with the Go runtime error
+"fatal error: concurrent map read and map write". This is an unrecoverable
+runtime fault, so it could not be caught and recovered from, and it dropped all
+connections that were in flight at that moment.
+
+When converting CS3 shares into Graph DriveItems, the worker goroutines read
+from the shared driveItems map while the collecting loop was already writing
+results into the very same map. The results channel is buffered, so the workers
+never blocked when handing over an item and the collecting loop started writing
+while workers were still running. The results are now collected after all
+workers have finished, which removes the overlapping access.
+
+Note that lowering the maximum concurrency did not avoid this, as a single
+worker could still run concurrently with the collecting loop.
+
+https://github.com/owncloud/ocis/pull/12674

--- a/services/graph/pkg/service/v0/base.go
+++ b/services/graph/pkg/service/v0/base.go
@@ -435,18 +435,18 @@ func (g BaseGraphService) cs3UserSharesToDriveItems(ctx context.Context, shares 
 			return nil
 		})
 	}
-	// Wait for things to settle down, then close results chan
-	go func() {
-		_ = errg.Wait() // error is checked later
-		close(results)
-	}()
+
+	// Wait for all workers to finish before collecting the results. The workers
+	// read from driveItems, so writing to it below must not overlap with them.
+	// The results channel is buffered with len(shares), which is at least the
+	// number of items the workers can send, so they never block on the handover.
+	if err := errg.Wait(); err != nil {
+		return nil, err
+	}
+	close(results)
 
 	for item := range results {
 		driveItems[item.GetId()] = *item
-	}
-
-	if err := errg.Wait(); err != nil {
-		return nil, err
 	}
 
 	return driveItems, nil
@@ -535,18 +535,18 @@ func (g BaseGraphService) cs3OCMSharesToDriveItems(ctx context.Context, shares [
 			return nil
 		})
 	}
-	// Wait for things to settle down, then close results chan
-	go func() {
-		_ = errg.Wait() // error is checked later
-		close(results)
-	}()
+
+	// Wait for all workers to finish before collecting the results. The workers
+	// read from driveItems, so writing to it below must not overlap with them.
+	// The results channel is buffered with len(shares), which is at least the
+	// number of items the workers can send, so they never block on the handover.
+	if err := errg.Wait(); err != nil {
+		return nil, err
+	}
+	close(results)
 
 	for item := range results {
 		driveItems[item.GetId()] = *item
-	}
-
-	if err := errg.Wait(); err != nil {
-		return nil, err
 	}
 
 	return driveItems, nil
@@ -797,18 +797,18 @@ func (g BaseGraphService) cs3PublicSharesToDriveItems(ctx context.Context, share
 			return nil
 		})
 	}
-	// Wait for things to settle down, then close results chan
-	go func() {
-		_ = errg.Wait() // error is checked later
-		close(results)
-	}()
+
+	// Wait for all workers to finish before collecting the results. The workers
+	// read from driveItems, so writing to it below must not overlap with them.
+	// The results channel is buffered with len(shares), which is at least the
+	// number of items the workers can send, so they never block on the handover.
+	if err := errg.Wait(); err != nil {
+		return nil, err
+	}
+	close(results)
 
 	for item := range results {
 		driveItems[item.GetId()] = *item
-	}
-
-	if err := errg.Wait(); err != nil {
-		return nil, err
 	}
 
 	return driveItems, nil

--- a/services/graph/pkg/service/v0/base_race_test.go
+++ b/services/graph/pkg/service/v0/base_race_test.go
@@ -1,0 +1,159 @@
+package svc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	libregraph "github.com/owncloud/libre-graph-api-go"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/config/defaults"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/identity"
+	"github.com/owncloud/reva/v2/pkg/conversions"
+	"github.com/owncloud/reva/v2/pkg/rgrpc/status"
+	"github.com/owncloud/reva/v2/pkg/rgrpc/todo/pool"
+	cs3mocks "github.com/owncloud/reva/v2/tests/cs3mocks/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+)
+
+// numRaceTestResources needs to be comfortably larger than the number of
+// workers so that some workers are still reading from the driveItems map while
+// the collecting loop has already started writing to it.
+const numRaceTestResources = 200
+
+// newRaceTestService builds a BaseGraphService with a mocked gateway that can
+// stat any resource and resolve any user.
+func newRaceTestService(t *testing.T, maxConcurrency int) BaseGraphService {
+	t.Helper()
+
+	selectorName := fmt.Sprintf("GatewaySelectorRace%d", maxConcurrency)
+	pool.RemoveSelector(selectorName + "com.owncloud.api.gateway")
+
+	gatewayClient := &cs3mocks.GatewayAPIClient{}
+	gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, req *storageprovider.StatRequest, _ ...grpc.CallOption) *storageprovider.StatResponse {
+			return &storageprovider.StatResponse{
+				Status: status.NewOK(context.Background()),
+				Info: &storageprovider.ResourceInfo{
+					Id:   req.GetRef().GetResourceId(),
+					Type: storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				},
+			}
+		},
+		nil,
+	)
+	gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(
+		&userpb.GetUserResponse{
+			Status: status.NewOK(context.Background()),
+			User: &userpb.User{
+				Id:          &userpb.UserId{Idp: "idp", OpaqueId: "user-id"},
+				DisplayName: "User Name",
+			},
+		},
+		nil,
+	)
+	gatewayClient.On("GetPublicShare", mock.Anything, mock.Anything).Return(
+		&link.GetPublicShareResponse{Status: status.NewOK(context.Background())},
+		nil,
+	)
+
+	gatewaySelector := pool.GetSelector[gateway.GatewayAPIClient](
+		selectorName,
+		"com.owncloud.api.gateway",
+		func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
+			return gatewayClient
+		},
+	)
+
+	cfg := defaults.FullDefaultConfig()
+	cfg.Identity.LDAP.CACert = ""
+	cfg.TokenManager.JWTSecret = "loremipsum"
+	cfg.MaxConcurrency = maxConcurrency
+
+	logger := log.NewLogger()
+
+	return BaseGraphService{
+		logger:          &logger,
+		gatewaySelector: gatewaySelector,
+		identityCache:   identity.NewIdentityCache(identity.IdentityCacheWithGatewaySelector(gatewaySelector)),
+		config:          cfg,
+	}
+}
+
+// raceTestShares returns one user share per resource, all distinct resources so
+// that every share becomes its own unit of work.
+func raceTestShares() []*collaboration.Share {
+	editorResourcePermissions := conversions.NewEditorRole().CS3ResourcePermissions()
+
+	shares := make([]*collaboration.Share, 0, numRaceTestResources)
+	for i := 0; i < numRaceTestResources; i++ {
+		shares = append(shares, &collaboration.Share{
+			Id: &collaboration.ShareId{OpaqueId: fmt.Sprintf("share-id-%d", i)},
+			ResourceId: &storageprovider.ResourceId{
+				StorageId: "storageid",
+				SpaceId:   "spaceid",
+				OpaqueId:  fmt.Sprintf("opaqueid-%d", i),
+			},
+			Grantee: &storageprovider.Grantee{
+				Type: storageprovider.GranteeType_GRANTEE_TYPE_USER,
+				Id: &storageprovider.Grantee_UserId{
+					UserId: &userpb.UserId{OpaqueId: "user-id"},
+				},
+			},
+			Permissions: &collaboration.SharePermissions{Permissions: editorResourcePermissions},
+		})
+	}
+	return shares
+}
+
+// TestCS3UserSharesToDriveItemsConcurrentMapAccess reproduces OCISDEV-1088: the
+// errgroup workers read the driveItems map while the collecting loop writes to
+// it, which makes the Go runtime abort the process with
+// "fatal error: concurrent map read and map write".
+//
+// Run with -race to catch it deterministically.
+func TestCS3UserSharesToDriveItemsConcurrentMapAccess(t *testing.T) {
+	// A non-empty map is required: the workers only read the map when looking
+	// for an already known drive item, and an empty map read is not enough for
+	// the race detector to flag a conflicting access pattern on every run.
+	driveItems := make(driveItemsByResourceID, numRaceTestResources)
+	for i := 0; i < numRaceTestResources; i++ {
+		driveItems[fmt.Sprintf("storageid$spaceid!seed-%d", i)] = libregraph.DriveItem{}
+	}
+
+	g := newRaceTestService(t, defaults.FullDefaultConfig().MaxConcurrency)
+
+	items, err := g.cs3UserSharesToDriveItems(context.Background(), raceTestShares(), driveItems)
+	require.NoError(t, err)
+	require.Len(t, items, numRaceTestResources+numRaceTestResources)
+}
+
+// TestCS3UserSharesToDriveItemsConcurrentMapAccessMaxConcurrencyOne covers the
+// single worker path.
+//
+// This case exists because lowering OCIS_MAX_CONCURRENCY /
+// GRAPH_MAX_CONCURRENCY to 1 looks like an obvious operational workaround for
+// OCISDEV-1088, but it never was one: even with a single worker the map was
+// still read concurrently with the collecting loop, because the results channel
+// is buffered and the worker never blocks handing off an item. Before the fix
+// this test failed under -race exactly like the one above.
+func TestCS3UserSharesToDriveItemsConcurrentMapAccessMaxConcurrencyOne(t *testing.T) {
+	driveItems := make(driveItemsByResourceID, numRaceTestResources)
+	for i := 0; i < numRaceTestResources; i++ {
+		driveItems[fmt.Sprintf("storageid$spaceid!seed-%d", i)] = libregraph.DriveItem{}
+	}
+
+	g := newRaceTestService(t, 1)
+
+	items, err := g.cs3UserSharesToDriveItems(context.Background(), raceTestShares(), driveItems)
+	require.NoError(t, err)
+	require.Len(t, items, numRaceTestResources+numRaceTestResources)
+}


### PR DESCRIPTION
Forward port of #12670 (merged into `stable-8.1`) via `git cherry-pick -x`.

## Description

The errgroup workers that convert CS3 shares into Graph DriveItems read from the
shared `driveItems` map while the collecting loop was already writing results
into that same map. Because the `results` channel is buffered with `len(shares)`,
the workers never block when handing over an item, so the collecting loop starts
writing while workers are still reading.

The Go runtime aborts on a detected concurrent map read and write. This is a
fatal runtime fault, not a normal panic, so it cannot be caught with `recover` —
it takes down the whole process and drops every in-flight connection. In a
single-binary deployment that means a full restart.

The results are now collected after all workers have finished, which removes the
overlapping access. No deadlock risk: the channel buffer is `len(shares)`, an
upper bound on what the workers can send, so no worker blocks before
`errg.Wait()` returns.

The same pattern existed in three functions, all fixed:

- `cs3UserSharesToDriveItems` (base.go)
- `cs3OCMSharesToDriveItems` (base.go)
- `cs3PublicSharesToDriveItems` (base.go)

Introduced in `9fea5c30020` ("graph concurrent share listing").

Note for admins looking for a stopgap: lowering `OCIS_MAX_CONCURRENCY` /
`GRAPH_MAX_CONCURRENCY` to `1` does **not** avoid this. A single worker still
runs concurrently with the collecting loop, and the race reproduces identically.
There is no configuration workaround.

## Related Issue

Internal issue: OCISDEV-1088

## Motivation and Context

Reported in the field on 8.1.0 as an intermittent full process crash under load,
with share listing in the stack trace. The affected code is present here
unchanged, so this branch has the same crash.

The cherry-pick applied cleanly; the only change relative to #12670 is the
changelog PR link, which points at this PR.

## How Has This Been Tested?

- test environment: `go test -race`, local build of the oCIS binary on this branch
- test case 1: `TestCS3UserSharesToDriveItemsConcurrentMapAccess` passes with the
  fix. Verified it still genuinely reproduces the bug on this branch by reverting
  only the `base.go` change and re-running: it fails with `WARNING: DATA RACE` and
  `fatal error: concurrent map read and map write`, so the test is not passing for
  the wrong reason.
- test case 2: `TestCS3UserSharesToDriveItemsConcurrentMapAccessMaxConcurrencyOne`
  covers the single worker path, pinning the fact that reducing max concurrency is
  not a workaround.
- test case 3: full `services/graph` module suite green under `-race`; `gofmt`
  clean on the changed files; `ocis` binary builds.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a — no user-facing or config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
