### PR TITLE
fix: [OCISDEV-857] Return metadata client init errors from the settings store

### DIFF
--- a/changelog/unreleased/fix-settings-store-nil-mdc-panic.md
+++ b/changelog/unreleased/fix-settings-store-nil-mdc-panic.md
@@ -1,0 +1,16 @@
+Bugfix: Return metadata client init errors from the settings store
+
+The settings metadata store initialized its metadata client lazily. When
+initialization failed, for example because the settings metadata space was
+owned by a different user than the configured system user, `Store.Init()`
+logged the error but left the client nil and returned normally. Every
+subsequent store call then dereferenced the nil client and panicked with a nil
+pointer dereference, which masked the real cause and surfaced as opaque proxy
+500s during login.
+
+`Store.Init()` now returns the underlying initialization error and every public
+store method short-circuits on it, so callers receive a specific, actionable
+error instead of a panic. The client is left nil on failure so the next call
+retries initialization.
+
+https://github.com/owncloud/ocis/pull/12680

--- a/services/settings/pkg/store/metadata/assignments.go
+++ b/services/settings/pkg/store/metadata/assignments.go
@@ -27,7 +27,9 @@ func (s *Store) ListRoleAssignments(accountUUID string) ([]*settingsmsg.UserRole
 			}, nil
 		}
 	}
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 	assIDs, err := s.mdc.ReadDir(ctx, accountPath(accountUUID))
 	switch err.(type) {
@@ -64,7 +66,9 @@ func (s *Store) ListRoleAssignments(accountUUID string) ([]*settingsmsg.UserRole
 
 // ListRoleAssignmentsByRole returns all role assignmentes matching the give roleID
 func (s *Store) ListRoleAssignmentsByRole(roleID string) ([]*settingsmsg.UserRoleAssignment, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 	accountIDs, err := s.mdc.ReadDir(ctx, accountsFolderLocation)
 	switch err.(type) {
@@ -117,7 +121,9 @@ func (s *Store) ListRoleAssignmentsByRole(roleID string) ([]*settingsmsg.UserRol
 
 // WriteRoleAssignment appends the given role assignment to the existing assignments of the respective account.
 func (s *Store) WriteRoleAssignment(accountUUID, roleID string) (*settingsmsg.UserRoleAssignment, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 	// as per https://github.com/owncloud/product/issues/103 "Each user can have exactly one role"
 	err := s.mdc.Delete(ctx, accountPath(accountUUID))
@@ -149,7 +155,9 @@ func (s *Store) WriteRoleAssignment(accountUUID, roleID string) (*settingsmsg.Us
 
 // RemoveRoleAssignment deletes the given role assignment from the existing assignments of the respective account.
 func (s *Store) RemoveRoleAssignment(assignmentID string) error {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return err
+	}
 	ctx := context.TODO()
 	accounts, err := s.mdc.ReadDir(ctx, accountsFolderLocation)
 	switch err.(type) {

--- a/services/settings/pkg/store/metadata/bundles.go
+++ b/services/settings/pkg/store/metadata/bundles.go
@@ -16,7 +16,9 @@ import (
 
 // ListBundles returns all bundles in the dataPath folder that match the given type.
 func (s *Store) ListBundles(bundleType settingsmsg.Bundle_Type, bundleIDs []string) ([]*settingsmsg.Bundle, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	if len(bundleIDs) == 0 {
@@ -69,7 +71,9 @@ func (s *Store) ReadBundle(bundleID string) (*settingsmsg.Bundle, error) {
 		return defaults.ServiceAccountBundle(), nil
 	}
 
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 	b, err := s.mdc.SimpleDownload(ctx, bundlePath(bundleID))
 	switch err.(type) {
@@ -87,7 +91,9 @@ func (s *Store) ReadBundle(bundleID string) (*settingsmsg.Bundle, error) {
 
 // ReadSetting tries to find a setting by the given id from the metadata service
 func (s *Store) ReadSetting(settingID string) (*settingsmsg.Setting, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	ids, err := s.mdc.ReadDir(ctx, bundleFolderLocation)
@@ -122,7 +128,9 @@ func (s *Store) ReadSetting(settingID string) (*settingsmsg.Setting, error) {
 
 // WriteBundle sends the givens record to the metadataclient. returns `record` for legacy reasons
 func (s *Store) WriteBundle(record *settingsmsg.Bundle) (*settingsmsg.Bundle, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	b, err := json.Marshal(record)
@@ -134,7 +142,9 @@ func (s *Store) WriteBundle(record *settingsmsg.Bundle) (*settingsmsg.Bundle, er
 
 // AddSettingToBundle adds the given setting to the bundle with the given bundleID.
 func (s *Store) AddSettingToBundle(bundleID string, setting *settingsmsg.Setting) (*settingsmsg.Setting, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	b, err := s.ReadBundle(bundleID)
 	if err != nil {
 		if !errors.Is(err, settings.ErrNotFound) {

--- a/services/settings/pkg/store/metadata/permissions.go
+++ b/services/settings/pkg/store/metadata/permissions.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"errors"
+
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/settings"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/util"
@@ -12,8 +14,11 @@ func (s *Store) ListPermissionsByResource(resource *settingsmsg.Resource, roleID
 	for _, roleID := range roleIDs {
 		role, err := s.ReadBundle(roleID)
 		if err != nil {
-			s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
-			continue
+			if errors.Is(err, settings.ErrNotFound) {
+				s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
+				continue
+			}
+			return nil, err
 		}
 		records = append(records, extractPermissionsByResource(resource, role)...)
 	}
@@ -25,8 +30,11 @@ func (s *Store) ReadPermissionByID(permissionID string, roleIDs []string) (*sett
 	for _, roleID := range roleIDs {
 		role, err := s.ReadBundle(roleID)
 		if err != nil {
-			s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
-			continue
+			if errors.Is(err, settings.ErrNotFound) {
+				s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
+				continue
+			}
+			return nil, err
 		}
 		for _, permission := range role.Settings {
 			if permission.Id == permissionID {
@@ -44,8 +52,11 @@ func (s *Store) ReadPermissionByName(name string, roleIDs []string) (*settingsms
 	for _, roleID := range roleIDs {
 		role, err := s.ReadBundle(roleID)
 		if err != nil {
-			s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
-			continue
+			if errors.Is(err, settings.ErrNotFound) {
+				s.Logger.Debug().Str("roleID", roleID).Msg("role not found, skipping")
+				continue
+			}
+			return nil, err
 		}
 		for _, permission := range role.Settings {
 			if permission.Name == name {

--- a/services/settings/pkg/store/metadata/store.go
+++ b/services/settings/pkg/store/metadata/store.go
@@ -45,30 +45,49 @@ type Store struct {
 	mdc MetadataClient
 	cfg *config.Config
 
+	// newMDC builds the underlying metadata client. It is a field so it can be
+	// swapped out in tests.
+	newMDC func() MetadataClient
+
 	l *sync.Mutex
 }
 
-// Init initialize the store once, later calls are noops
-func (s *Store) Init() {
+// Init initializes the store once, later calls are noops. It returns the error
+// encountered while initializing the metadata client so that callers can
+// surface a specific, actionable error instead of dereferencing a nil client.
+// On failure s.mdc is left nil so that the next call retries initialization.
+func (s *Store) Init() error {
 	if s.mdc != nil {
-		return
+		return nil
 	}
 
 	s.l.Lock()
 	defer s.l.Unlock()
 
 	if s.mdc != nil {
-		return
+		return nil
 	}
 
 	mdc := &CachedMDC{
-		next:   NewMetadataClient(s.cfg.Metadata),
+		next:   s.metadataClient(),
 		cfg:    s.cfg,
 		logger: s.Logger,
 	}
 	if err := s.initMetadataClient(mdc); err != nil {
 		s.Logger.Error().Err(err).Msg("error initializing metadata client")
+		return err
 	}
+	return nil
+}
+
+// metadataClient builds the underlying metadata client, falling back to the
+// default factory when newMDC is not set (e.g. when a Store is built via a
+// struct literal instead of New).
+func (s *Store) metadataClient() MetadataClient {
+	if s.newMDC != nil {
+		return s.newMDC()
+	}
+	return NewMetadataClient(s.cfg.Metadata)
 }
 
 // New creates a new store
@@ -83,6 +102,7 @@ func New(cfg *config.Config) settings.Manager {
 		cfg: cfg,
 		l:   &sync.Mutex{},
 	}
+	s.newMDC = func() MetadataClient { return NewMetadataClient(s.cfg.Metadata) }
 
 	return &s
 }

--- a/services/settings/pkg/store/metadata/store_test.go
+++ b/services/settings/pkg/store/metadata/store_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	olog "github.com/owncloud/ocis/v2/ocis-pkg/log"
 	settingsmsg "github.com/owncloud/ocis/v2/protogen/gen/ocis/messages/settings/v0"
 	"github.com/owncloud/ocis/v2/services/settings/pkg/config/defaults"
 	rdefaults "github.com/owncloud/ocis/v2/services/settings/pkg/store/defaults"
@@ -107,6 +109,16 @@ func (*MockedMetadataClient) Init(_ context.Context, _ string) error {
 	return nil
 }
 
+// failingInitMetadataClient always fails on Init to simulate a metadata space
+// owner/system-user mismatch.
+type failingInitMetadataClient struct {
+	MockedMetadataClient
+}
+
+func (*failingInitMetadataClient) Init(_ context.Context, id string) error {
+	return errtypes.AlreadyExists("user X does not have access to metadata space " + id + ", but it exists")
+}
+
 // IDExists is a helper to check if an id exists
 func (m *MockedMetadataClient) IDExists(id string) bool {
 	_, ok := m.data[id]
@@ -116,6 +128,78 @@ func (m *MockedMetadataClient) IDExists(id string) bool {
 // IDHasContent returns true if the value stored under id has the given content (converted to string)
 func (m *MockedMetadataClient) IDHasContent(id string, content []byte) bool {
 	return string(m.data[id]) == string(content)
+}
+
+// TestInitFailurePropagates verifies that when the metadata client cannot be
+// initialized (e.g. the settings metadata space is owned by a different user
+// than the configured system user), the store methods return the underlying
+// init error instead of panicking with a nil pointer dereference.
+func TestInitFailurePropagates(t *testing.T) {
+	RegisterTestingT(t)
+	s := &Store{
+		Logger: olog.NewLogger(),
+		cfg:    defaults.DefaultConfig(),
+		l:      &sync.Mutex{},
+		newMDC: func() MetadataClient { return &failingInitMetadataClient{} },
+	}
+
+	// A public store call must not panic; it must return the init error.
+	_, err := s.ListRoleAssignments(accountUUID1)
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("does not have access to metadata space"))
+
+	// mdc must remain nil so a later call retries initialization.
+	Expect(s.mdc).To(BeNil())
+}
+
+// TestInitDefaultsMetadataClientFactory verifies that a Store built via a
+// struct literal (without newMDC set) does not panic when the metadata client
+// is constructed, but falls back to the default factory.
+func TestInitDefaultsMetadataClientFactory(t *testing.T) {
+	RegisterTestingT(t)
+	s := &Store{
+		Logger: olog.NewLogger(),
+		cfg:    defaults.DefaultConfig(),
+		l:      &sync.Mutex{},
+	}
+
+	var mdc MetadataClient
+	Expect(func() { mdc = s.metadataClient() }).ToNot(Panic())
+	Expect(mdc).ToNot(BeNil())
+}
+
+// newFailingInitStore builds a store whose metadata client always fails to
+// initialize.
+func newFailingInitStore() *Store {
+	return &Store{
+		Logger: olog.NewLogger(),
+		cfg:    defaults.DefaultConfig(),
+		l:      &sync.Mutex{},
+		newMDC: func() MetadataClient { return &failingInitMetadataClient{} },
+	}
+}
+
+// TestPermissionsInitFailurePropagates verifies that the permission lookups
+// surface the metadata client init error instead of silently reporting "no
+// permissions found".
+func TestPermissionsInitFailurePropagates(t *testing.T) {
+	RegisterTestingT(t)
+	roleIDs := []string{"f36db5e6-a03c-40df-8413-711c67e40b47"}
+
+	s := newFailingInitStore()
+	_, err := s.ListPermissionsByResource(&settingsmsg.Resource{Type: settingsmsg.Resource_TYPE_BUNDLE}, roleIDs)
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("does not have access to metadata space"))
+
+	s = newFailingInitStore()
+	_, err = s.ReadPermissionByID("readID", roleIDs)
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("does not have access to metadata space"))
+
+	s = newFailingInitStore()
+	_, err = s.ReadPermissionByName("read", roleIDs)
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(ContainSubstring("does not have access to metadata space"))
 }
 
 // TestAdminUserIDInit test the happy path during initialization

--- a/services/settings/pkg/store/metadata/values.go
+++ b/services/settings/pkg/store/metadata/values.go
@@ -17,7 +17,9 @@ import (
 // If the accountUUID is empty, only values with empty accountUUID are returned.
 // If the accountUUID is not empty, values with an empty or with a matching accountUUID are returned.
 func (s *Store) ListValues(bundleID, accountUUID string) ([]*settingsmsg.Value, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	vIDs, err := s.mdc.ReadDir(ctx, valuesFolderLocation)
@@ -68,7 +70,9 @@ func (s *Store) ListValues(bundleID, accountUUID string) ([]*settingsmsg.Value, 
 
 // ReadValue tries to find a value by the given valueId within the dataPath
 func (s *Store) ReadValue(valueID string) (*settingsmsg.Value, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	b, err := s.mdc.SimpleDownload(ctx, valuePath(valueID))
@@ -89,7 +93,9 @@ func (s *Store) ReadValueByUniqueIdentifiers(accountUUID, settingID string) (*se
 	if settingID == "" {
 		return nil, fmt.Errorf("settingID can not be empty %w", settings.ErrNotFound)
 	}
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	vIDs, err := s.mdc.ReadDir(ctx, valuesFolderLocation)
@@ -123,7 +129,9 @@ func (s *Store) ReadValueByUniqueIdentifiers(accountUUID, settingID string) (*se
 
 // WriteValue writes the given value into a file within the dataPath
 func (s *Store) WriteValue(value *settingsmsg.Value) (*settingsmsg.Value, error) {
-	s.Init()
+	if err := s.Init(); err != nil {
+		return nil, err
+	}
 	ctx := context.TODO()
 
 	if value.Id == "" {


### PR DESCRIPTION
Bugfix: Return metadata client init errors from the settings store

The settings metadata store initialized its metadata client lazily. When
initialization failed, for example because the settings metadata space was
owned by a different user than the configured system user, `Store.Init()`
logged the error but left the client nil and returned normally. Every
subsequent store call then dereferenced the nil client and panicked with a nil
pointer dereference, which masked the real cause and surfaced as opaque proxy
500s during login.

`Store.Init()` now returns the underlying initialization error and every public
store method short-circuits on it, so callers receive a specific, actionable
error instead of a panic. The client is left nil on failure so the next call
retries initialization.