### PR TITLE
fix(web): [OCISDEV-136] sync .psec pointer file on password-protected folder rename

### DIFF
--- a/changelog/unreleased/bugfix-password-protected-folder-rename-sync.md
+++ b/changelog/unreleased/bugfix-password-protected-folder-rename-sync.md
@@ -1,0 +1,13 @@
+Bugfix: Sync the `.psec` file name when a password-protected folder is renamed
+
+Renaming a password-protected folder did not update its `.psec` pointer file,
+so the main file listing kept showing the old name. This happened both when
+renaming the folder via the hidden `.PasswordProtectedFolders` location and
+when renaming it from inside the folder-view modal.
+
+Renaming the real folder now also renames its `.psec` counterpart. Inside the
+folder-view modal, the framed public-link session notifies the parent window
+at the moment of rename, so the pointer file stays in sync even on refresh or
+another device.
+
+https://github.com/owncloud/ocis/pull/12684

--- a/web/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
+++ b/web/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
@@ -17,6 +17,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
+import { PASSWORD_PROTECTED_FOLDER_VIEW_QUERY } from '@ownclouders/web-client'
 import { Modal, useThemeStore } from '@ownclouders/web-pkg/src/composables'
 import AppLoadingSpinner from '@ownclouders/web-pkg/src/components/AppLoadingSpinner.vue'
 import { unref } from 'vue'
@@ -46,6 +47,9 @@ iframeUrl.searchParams.append('hide-app-switcher', 'true')
 iframeUrl.searchParams.append('hide-account-menu', 'true')
 iframeUrl.searchParams.append('hide-navigation', 'true')
 iframeUrl.searchParams.append('lang', current)
+// signals the framed app that it runs inside this modal, so it notifies us when the
+// shared folder is renamed and we can keep the `.psec` pointer file in sync
+iframeUrl.searchParams.append(PASSWORD_PROTECTED_FOLDER_VIEW_QUERY, 'true')
 
 const onLoad = () => {
   isLoading.value = false

--- a/web/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
+++ b/web/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
@@ -1,5 +1,17 @@
-import { FileAction, useClientService, useConfigStore, useModals } from '@ownclouders/web-pkg'
+import {
+  FileAction,
+  renameResource,
+  useClientService,
+  useConfigStore,
+  useModals,
+  useResourcesStore
+} from '@ownclouders/web-pkg'
+import {
+  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
+  PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE
+} from '@ownclouders/web-client'
 import { computed } from 'vue'
+import { dirname, join } from 'path'
 import { useGettext } from 'vue3-gettext'
 import FolderViewModal from '../components/FolderViewModal.vue'
 
@@ -8,6 +20,7 @@ export const useOpenFolderAction = () => {
   const { dispatchModal } = useModals()
   const clientService = useClientService()
   const configStore = useConfigStore()
+  const { upsertResource } = useResourcesStore()
 
   const action = computed<FileAction>(() => ({
     name: 'open-password-protected-folder',
@@ -26,7 +39,8 @@ export const useOpenFolderAction = () => {
           )
         )
       }
-      if (publicLinkUrl.origin !== new URL(configStore.serverUrl).origin) {
+      const serverOrigin = new URL(configStore.serverUrl).origin
+      if (publicLinkUrl.origin !== serverOrigin) {
         throw new Error(
           $pgettext(
             'Error shown when opening a password-protected folder fails because the stored link points to a different server.',
@@ -34,6 +48,39 @@ export const useOpenFolderAction = () => {
           )
         )
       }
+
+      // The real folder is only reachable through the public link session running inside the
+      // modal, so it may be renamed there. The `.psec` pointer file cannot be re-resolved from
+      // the folder afterwards (the two are coupled only by name), so the framed app posts the
+      // new folder name to us at rename time and we keep the `.psec` file in sync here.
+      const onFolderRenamed = async (event: MessageEvent) => {
+        if (event.origin !== serverOrigin) {
+          return
+        }
+        if (event.data?.name !== PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE) {
+          return
+        }
+
+        const newName = event.data?.data?.newName
+        const currentName = file.name.replace(
+          new RegExp(`\\.${PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION}$`),
+          ''
+        )
+        if (!newName || newName === currentName) {
+          return
+        }
+
+        const newPsecName = `${newName}.${PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION}`
+        const newPsecPath = join(dirname(file.path), newPsecName)
+
+        await clientService.webdav.moveFiles(space, file, space, { path: newPsecPath })
+
+        const updatedFile = { ...file }
+        renameResource(space, updatedFile, newPsecPath)
+        upsertResource(updatedFile)
+      }
+
+      window.addEventListener('message', onFolderRenamed)
 
       dispatchModal({
         title: resources.at(0).name,
@@ -44,7 +91,10 @@ export const useOpenFolderAction = () => {
           serverUrl: configStore.serverUrl
         }),
         hideConfirmButton: true,
-        cancelText: $gettext('Close folder')
+        cancelText: $gettext('Close folder'),
+        onCancel: () => {
+          window.removeEventListener('message', onFolderRenamed)
+        }
       })
     },
     label: () => $gettext('Open folder'),

--- a/web/packages/web-app-password-protected-folders/tests/unit/components/FolderViewModal.spec.ts
+++ b/web/packages/web-app-password-protected-folders/tests/unit/components/FolderViewModal.spec.ts
@@ -15,7 +15,7 @@ describe('FolderViewModal', () => {
     const iframe = wrapper.find(SELECTORS.iframe)
 
     expect(iframe.attributes('src')).toEqual(
-      'https://example.org/public-link?hide-logo=true&hide-app-switcher=true&hide-account-menu=true&hide-navigation=true&lang=en'
+      'https://example.org/public-link?hide-logo=true&hide-app-switcher=true&hide-account-menu=true&hide-navigation=true&lang=en&password-protected-folder-view=true'
     )
   })
 

--- a/web/packages/web-app-password-protected-folders/tests/unit/composables/useOpenFolderAction.spec.ts
+++ b/web/packages/web-app-password-protected-folders/tests/unit/composables/useOpenFolderAction.spec.ts
@@ -1,19 +1,44 @@
 import {
   defaultComponentMocks,
+  flushPromises,
   getComposableWrapper,
   writable
 } from '@ownclouders/web-test-helpers'
 import { useOpenFolderAction } from '../../../src/composables/useOpenFolderAction'
 import { unref } from 'vue'
 import { mock } from 'vitest-mock-extended'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
-import { useConfigStore, useModals } from '@ownclouders/web-pkg'
+import {
+  PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE,
+  Resource,
+  SpaceResource
+} from '@ownclouders/web-client'
+import { useConfigStore, useModals, useResourcesStore } from '@ownclouders/web-pkg'
 import { MockedFunction } from 'vitest'
 import FolderViewModal from '../../../src/components/FolderViewModal.vue'
 
 const SERVER_URL = 'https://example.org/'
+const SERVER_ORIGIN = 'https://example.org'
 
 describe('openFolderAction', () => {
+  // the composable registers a `message` listener on `window`, which is shared across tests
+  // in the same jsdom environment. Track and remove them so a listener from one test cannot
+  // react to a message dispatched by another.
+  const trackedListeners: Array<[string, EventListenerOrEventListenerObject]> = []
+  const originalAddEventListener = window.addEventListener.bind(window)
+
+  beforeEach(() => {
+    trackedListeners.length = 0
+    vi.spyOn(window, 'addEventListener').mockImplementation((type, listener) => {
+      trackedListeners.push([type, listener])
+      originalAddEventListener(type, listener)
+    })
+  })
+
+  afterEach(() => {
+    trackedListeners.forEach(([type, listener]) => window.removeEventListener(type, listener))
+    vi.restoreAllMocks()
+  })
+
   it('should open a modal with the public link', () => {
     getWrapper({
       async setup(instance) {
@@ -72,6 +97,121 @@ describe('openFolderAction', () => {
       })
     }
   )
+
+  describe('sync of the .psec file when the folder is renamed inside the modal', () => {
+    const psecFile = mock<Resource>({ name: 'old.psec', path: '/old.psec' })
+    const renamedMessage = (newName: string, origin = SERVER_ORIGIN) =>
+      new MessageEvent('message', {
+        origin,
+        data: { name: PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE, data: { newName } }
+      })
+
+    const openModal = (instance: ReturnType<typeof useOpenFolderAction>) =>
+      unref(instance).handler({
+        resources: [psecFile],
+        space: mock<SpaceResource>({ webDavPath: '/files/admin' })
+      })
+
+    it('renames the .psec file when the folder is renamed in the framed app', async () => {
+      let assertions: () => void
+      const { setupPromise } = getWrapper({
+        async setup(instance, mocks) {
+          await openModal(instance)
+
+          window.dispatchEvent(renamedMessage('new'))
+          await flushPromises()
+
+          assertions = () => {
+            expect(mocks.$clientService.webdav.moveFiles).toHaveBeenCalledWith(
+              expect.anything(),
+              psecFile,
+              expect.anything(),
+              { path: '/new.psec' }
+            )
+            const { upsertResource } = useResourcesStore()
+            expect(upsertResource).toHaveBeenCalledTimes(1)
+          }
+        }
+      })
+      await setupPromise
+      assertions()
+    })
+
+    it('ignores messages from a foreign origin', async () => {
+      let assertions: () => void
+      const { setupPromise } = getWrapper({
+        async setup(instance, mocks) {
+          await openModal(instance)
+
+          window.dispatchEvent(renamedMessage('new', 'https://evil.example.com'))
+          await flushPromises()
+
+          assertions = () => expect(mocks.$clientService.webdav.moveFiles).not.toHaveBeenCalled()
+        }
+      })
+      await setupPromise
+      assertions()
+    })
+
+    it('ignores unrelated messages', async () => {
+      let assertions: () => void
+      const { setupPromise } = getWrapper({
+        async setup(instance, mocks) {
+          await openModal(instance)
+
+          window.dispatchEvent(
+            new MessageEvent('message', {
+              origin: SERVER_ORIGIN,
+              data: { name: 'some-other-message', data: { newName: 'new' } }
+            })
+          )
+          await flushPromises()
+
+          assertions = () => expect(mocks.$clientService.webdav.moveFiles).not.toHaveBeenCalled()
+        }
+      })
+      await setupPromise
+      assertions()
+    })
+
+    it('does nothing when the name is unchanged', async () => {
+      let assertions: () => void
+      const { setupPromise } = getWrapper({
+        async setup(instance, mocks) {
+          await openModal(instance)
+
+          window.dispatchEvent(renamedMessage('old'))
+          await flushPromises()
+
+          assertions = () => expect(mocks.$clientService.webdav.moveFiles).not.toHaveBeenCalled()
+        }
+      })
+      await setupPromise
+      assertions()
+    })
+
+    it('stops listening once the modal is closed', async () => {
+      let assertions: () => void
+      const { setupPromise } = getWrapper({
+        async setup(instance, mocks) {
+          await openModal(instance)
+
+          const { dispatchModal } = useModals()
+          const modalConfig = (dispatchModal as MockedFunction<typeof dispatchModal>).mock.calls
+            .at(0)
+            .at(0)
+          modalConfig.onCancel()
+
+          window.dispatchEvent(renamedMessage('new'))
+          await flushPromises()
+
+          assertions = () => expect(mocks.$clientService.webdav.moveFiles).not.toHaveBeenCalled()
+        }
+      })
+      await setupPromise
+      assertions()
+    })
+  })
 })
 
 function getWrapper({
@@ -87,18 +227,19 @@ function getWrapper({
   const mocks = defaultComponentMocks()
   mocks.$clientService.webdav.getFileContents.mockResolvedValue({ body })
 
-  return {
-    wrapper: getComposableWrapper(
-      () => {
-        const configStore = useConfigStore()
-        writable(configStore).serverUrl = SERVER_URL
-        const instance = useOpenFolderAction()
-        setup(instance, mocks)
-      },
-      {
-        mocks,
-        provide: mocks
-      }
-    )
-  }
+  let setupPromise: unknown
+  const wrapper = getComposableWrapper(
+    () => {
+      const configStore = useConfigStore()
+      writable(configStore).serverUrl = SERVER_URL
+      const instance = useOpenFolderAction()
+      setupPromise = setup(instance, mocks)
+    },
+    {
+      mocks,
+      provide: mocks
+    }
+  )
+
+  return { wrapper, setupPromise }
 }

--- a/web/packages/web-client/src/constants.ts
+++ b/web/packages/web-client/src/constants.ts
@@ -1,6 +1,22 @@
 export const PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION = 'psec'
 
 /**
+ * Query param set on the public link opened inside the password-protected-folder view
+ * modal. It tells the framed app instance that it is running inside that modal, so it can
+ * notify the parent window when the shared folder is renamed (see the message name below).
+ */
+export const PASSWORD_PROTECTED_FOLDER_VIEW_QUERY = 'password-protected-folder-view'
+
+/**
+ * postMessage name emitted by the framed public-link app when the password-protected folder
+ * (the public link root) is renamed inside the modal, so the parent window can keep the
+ * `.psec` pointer file in sync. The `.psec` file cannot be resolved from the folder's new
+ * name (the coupling is name-based), so the new name is delivered here at rename time.
+ */
+export const PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE =
+  'owncloud-password-protected-folder:renamed'
+
+/**
  * List of file extensions that should be hidden from the user.
  * Hiding the extension currently leads to hiding all actions except delete.
  */

--- a/web/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/web/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -1,13 +1,19 @@
 import { isSameResource } from '../../../helpers/resource'
 import { isLocationTrashActive, isLocationSharesActive } from '../../../router'
-import { Resource } from '@ownclouders/web-client'
+import {
+  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
+  PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE,
+  Resource
+} from '@ownclouders/web-client'
 import { dirname, join } from 'path'
 import { WebDAV } from '@ownclouders/web-client/webdav'
 import {
   SpaceResource,
+  isPublicSpaceResource,
   isShareSpaceResource,
   extractNameWithoutExtension
 } from '@ownclouders/web-client'
+import { useResolvePasswordProtectedFolderCounterpart } from '../helpers'
 import { createFileRouteOptions } from '../../../helpers/router'
 import { renameResource as _renameResource } from '../../../helpers/resource'
 import { computed } from 'vue'
@@ -38,6 +44,7 @@ export const useFileActionsRename = () => {
 
   const resourcesStore = useResourcesStore()
   const { setCurrentFolder, upsertResource } = resourcesStore
+  const { getPsecFile } = useResolvePasswordProtectedFolderCounterpart()
 
   const getNameErrorMsg = (
     resource: Resource,
@@ -93,10 +100,55 @@ export const useFileActionsRename = () => {
     let currentFolder = resourcesStore.currentFolder
 
     try {
+      // Renaming the real folder of a password protected folder must keep the `.psec`
+      // pointer file in sync. The pointer is named `<folderName>.psec` and may live in a
+      // different space than the folder (which always lives in the personal space), so it
+      // has to be resolved from the folder's current name *before* the folder is moved.
+      const isPasswordProtectedFolder =
+        resource.isFolder &&
+        resource.path.startsWith('/.PasswordProtectedFolders/projects/') &&
+        resource.name !== newName
+      const psecFilePromise = isPasswordProtectedFolder
+        ? getPsecFile(resource)
+        : Promise.resolve(null)
+
       const newPath = join(dirname(resource.path), newName)
       await (clientService.webdav as WebDAV).moveFiles(space, resource, space, {
         path: newPath
       })
+
+      const resolvedPsecFile = await psecFilePromise
+      if (resolvedPsecFile) {
+        const { psecFile, space: psecSpace } = resolvedPsecFile
+        const newPsecName = `${newName}.${PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION}`
+        const newPsecPath = join(dirname(psecFile.path), newPsecName)
+
+        await (clientService.webdav as WebDAV).moveFiles(psecSpace, psecFile, psecSpace, {
+          path: newPsecPath
+        })
+
+        const updatedPsecFile = { ...psecFile } as Resource
+        _renameResource(psecSpace, updatedPsecFile, newPsecPath)
+        upsertResource(updatedPsecFile)
+      }
+
+      // When this app instance runs framed inside the password-protected-folder view modal,
+      // renaming the shared folder (the public link root) here cannot update the owner's
+      // `.psec` pointer file: it lives in the parent window's session and is coupled only by
+      // name. Notify the parent so it can rename the `.psec` file at the same time. The check
+      // `resource.fileId === space.fileId` guarantees this only fires for the shared folder
+      // itself, never for a child resource renamed inside it.
+      if (
+        window.parent !== window &&
+        configStore.options.passwordProtectedFolderView &&
+        isPublicSpaceResource(space) &&
+        resource.fileId === space.fileId
+      ) {
+        window.parent.postMessage(
+          { name: PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE, data: { newName } },
+          window.location.origin
+        )
+      }
 
       const isCurrentFolder = isSameResource(resource, currentFolder)
 

--- a/web/packages/web-pkg/src/composables/actions/helpers/index.ts
+++ b/web/packages/web-pkg/src/composables/actions/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './useIsSearchActive'
 export * from './useFileActionsDeleteResources'
 export * from './useIsFilesAppActive'
+export * from './useResolvePasswordProtectedFolderCounterpart'
 export * from './useResolveRestorableResources'

--- a/web/packages/web-pkg/src/composables/actions/helpers/useResolvePasswordProtectedFolderCounterpart.ts
+++ b/web/packages/web-pkg/src/composables/actions/helpers/useResolvePasswordProtectedFolderCounterpart.ts
@@ -1,0 +1,89 @@
+import {
+  DavHttpError,
+  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
+  Resource,
+  SpaceResource,
+  urlJoin
+} from '@ownclouders/web-client'
+import { captureException } from '@sentry/vue'
+import { unref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useClientService } from '../../clientService'
+import { useGetMatchingSpace } from '../../spaces'
+import { useSpacesStore } from '../../piniaStores'
+
+/**
+ * The `.psec` pointer file together with the space it lives in. The space is needed
+ * so callers can move/rename the file, since it may reside in a different space than
+ * the real folder (the folder always lives in the personal space).
+ */
+export type ResolvedPsecFile = { psecFile: Resource; space: SpaceResource }
+
+/**
+ * A password protected folder is represented by two independent resources:
+ * the `.psec` pointer file (visible to the owner) and the real folder living under
+ * `/.PasswordProtectedFolders/projects/<space>/...` (accessible via the public link).
+ * This resolves one from the other so callers can keep both in sync.
+ */
+export const useResolvePasswordProtectedFolderCounterpart = () => {
+  const clientService = useClientService()
+  const { getMatchingSpace } = useGetMatchingSpace()
+  const spacesStore = useSpacesStore()
+  const { getSpacesByName } = spacesStore
+  const { personalSpace } = storeToRefs(spacesStore)
+
+  const getPasswordProtectedFolder = async (psecFile: Resource): Promise<Resource | null> => {
+    try {
+      const matchingSpace = getMatchingSpace(psecFile)
+
+      const folderPath = urlJoin(
+        '/.PasswordProtectedFolders/projects/',
+        matchingSpace.name,
+        psecFile.path.replace(psecFile.name, ''),
+        psecFile.name.replace(`.${PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION}`, '')
+      )
+
+      return await clientService.webdav.getFileInfo(unref(personalSpace), { path: folderPath })
+    } catch (error) {
+      if (error instanceof DavHttpError && error.statusCode === 404) {
+        return null
+      }
+
+      console.error(error)
+      captureException(error)
+      return null
+    }
+  }
+
+  const getPsecFile = async (folder: Resource): Promise<ResolvedPsecFile | null> => {
+    const [spaceName, ...psecFilePathParts] = folder.path
+      .replace('/.PasswordProtectedFolders/projects/', '')
+      .split('/')
+    const matchingSpaces = getSpacesByName(spaceName)
+
+    if (matchingSpaces.length < 1) {
+      return null
+    }
+
+    for (const space of matchingSpaces) {
+      try {
+        const psecFile = await clientService.webdav.getFileInfo(space, {
+          path: urlJoin(...psecFilePathParts) + '.' + PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION
+        })
+        return { psecFile, space }
+      } catch (error) {
+        if (error instanceof DavHttpError && error.statusCode === 404) {
+          continue
+        }
+
+        console.error(error)
+        captureException(error)
+        continue
+      }
+    }
+
+    return null
+  }
+
+  return { getPasswordProtectedFolder, getPsecFile }
+}

--- a/web/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/web/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -126,6 +126,11 @@ const OptionsConfigSchema = z.object({
   hideAppSwitcher: z.boolean().optional(),
   hideAccountMenu: z.boolean().optional(),
   hideNavigation: z.boolean().optional(),
+  // set when this app instance runs framed inside the password-protected-folder view modal,
+  // so a rename of the shared folder can be reported to the parent window (see
+  // PASSWORD_PROTECTED_FOLDER_RENAMED_MESSAGE). Read once at bootstrap from a query param,
+  // because the router rewrites the URL query before a rename ever happens.
+  passwordProtectedFolderView: z.boolean().optional(),
   defaultLanguage: z.string().optional()
 })
 

--- a/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRename.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRename.spec.ts
@@ -1,5 +1,7 @@
 import { useFileActionsRename } from '../../../../../src/composables/actions'
+import { useResolvePasswordProtectedFolderCounterpart } from '../../../../../src/composables/actions/helpers/useResolvePasswordProtectedFolderCounterpart'
 import {
+  useConfigStore,
   useMessages,
   useModals,
   useResourcesStore
@@ -8,6 +10,10 @@ import { mock, mockDeep } from 'vitest-mock-extended'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
 import { unref } from 'vue'
+
+vi.mock(
+  '../../../../../src/composables/actions/helpers/useResolvePasswordProtectedFolderCounterpart'
+)
 
 const currentFolder = {
   id: '1',
@@ -163,11 +169,221 @@ describe('rename', () => {
         }
       })
     })
+
+    describe('password protected folder sync', () => {
+      const passwordProtectedFolder = {
+        id: 'ppf',
+        isFolder: true,
+        name: 'test',
+        path: '/.PasswordProtectedFolders/projects/Personal/test',
+        spaceId: '1'
+      } as Resource
+
+      it('renames the .psec counterpart when the real folder is renamed', () => {
+        const psecSpace = mockDeep<SpaceResource>({ webDavPath: 'irrelevant' })
+        const psecFile = mock<Resource>({ id: 'psec', name: 'test.psec', path: '/test.psec' })
+        const getPsecFile = vi.fn().mockResolvedValue({ psecFile, space: psecSpace })
+
+        getWrapper({
+          getPsecFile,
+          setup: async ({ renameResource }, { space, clientService }) => {
+            await renameResource(space, passwordProtectedFolder, 'something')
+
+            expect(getPsecFile).toHaveBeenCalledWith(passwordProtectedFolder)
+            // both the folder itself and the .psec counterpart get moved
+            expect(clientService.webdav.moveFiles).toHaveBeenCalledWith(
+              psecSpace,
+              psecFile,
+              psecSpace,
+              { path: '/something.psec' }
+            )
+            // the renamed folder + the renamed .psec file both get upserted
+            const { upsertResource } = useResourcesStore()
+            expect(upsertResource).toHaveBeenCalledTimes(2)
+          }
+        })
+      })
+
+      it('resolves the .psec counterpart before moving the folder (uses the old name)', () => {
+        const psecSpace = mockDeep<SpaceResource>({ webDavPath: 'irrelevant' })
+        const psecFile = mock<Resource>({ id: 'psec', name: 'test.psec', path: '/test.psec' })
+        const getPsecFile = vi.fn().mockResolvedValue({ psecFile, space: psecSpace })
+
+        getWrapper({
+          getPsecFile,
+          setup: async ({ renameResource }, { space, clientService }) => {
+            const callOrder: string[] = []
+            getPsecFile.mockImplementation(() => {
+              callOrder.push('getPsecFile')
+              return Promise.resolve({ psecFile, space: psecSpace })
+            })
+            clientService.webdav.moveFiles.mockImplementation(() => {
+              callOrder.push('moveFiles')
+              return Promise.resolve(undefined)
+            })
+
+            await renameResource(space, passwordProtectedFolder, 'something')
+
+            // getPsecFile must run before any move so it can derive the path from the old folder name
+            expect(callOrder[0]).toBe('getPsecFile')
+          }
+        })
+      })
+
+      it('does not resolve a .psec counterpart for a regular (non-ppf) rename', () => {
+        const getPsecFile = vi.fn().mockResolvedValue(null)
+
+        getWrapper({
+          getPsecFile,
+          setup: async ({ renameResource }, { space }) => {
+            const resource = {
+              id: '2',
+              isFolder: true,
+              name: 'folder',
+              path: '/folder',
+              spaceId: '1'
+            } as Resource
+            await renameResource(space, resource, 'new name')
+
+            expect(getPsecFile).not.toHaveBeenCalled()
+          }
+        })
+      })
+
+      it('does not resolve a .psec counterpart when the name is unchanged', () => {
+        const getPsecFile = vi.fn().mockResolvedValue(null)
+
+        getWrapper({
+          getPsecFile,
+          setup: async ({ renameResource }, { space }) => {
+            await renameResource(space, passwordProtectedFolder, passwordProtectedFolder.name)
+
+            expect(getPsecFile).not.toHaveBeenCalled()
+          }
+        })
+      })
+
+      it('renames the folder normally when no .psec counterpart is found', () => {
+        const getPsecFile = vi.fn().mockResolvedValue(null)
+
+        getWrapper({
+          getPsecFile,
+          setup: async ({ renameResource }, { space, clientService }) => {
+            await renameResource(space, passwordProtectedFolder, 'something')
+
+            expect(getPsecFile).toHaveBeenCalledWith(passwordProtectedFolder)
+            // only the folder itself is moved, no counterpart move
+            expect(clientService.webdav.moveFiles).toHaveBeenCalledTimes(1)
+            const { upsertResource } = useResourcesStore()
+            expect(upsertResource).toHaveBeenCalledTimes(1)
+          }
+        })
+      })
+    })
+
+    // When this app instance runs framed inside the password-protected-folder view modal, a
+    // rename of the shared folder (the public link root) is posted to the parent window so it
+    // can keep the owner's `.psec` pointer file in sync.
+    describe('password protected folder view modal notification', () => {
+      const publicSpace = mockDeep<SpaceResource>({
+        driveType: 'public',
+        webDavPath: 'irrelevant',
+        fileId: 'root-file-id'
+      })
+      const rootFolder = mock<Resource>({
+        fileId: 'root-file-id',
+        isFolder: true,
+        name: 'shared',
+        path: '/shared'
+      })
+
+      let parentSpy: ReturnType<typeof vi.spyOn>
+      let originalParent: Window
+
+      beforeEach(() => {
+        originalParent = window.parent
+        // jsdom sets window.parent === window; simulate being framed
+        Object.defineProperty(window, 'parent', {
+          value: { postMessage: vi.fn() },
+          configurable: true
+        })
+        parentSpy = vi.spyOn(window.parent, 'postMessage')
+      })
+
+      afterEach(() => {
+        Object.defineProperty(window, 'parent', { value: originalParent, configurable: true })
+      })
+
+      it('notifies the parent window when the shared folder is renamed', () => {
+        getWrapper({
+          passwordProtectedFolderView: true,
+          setup: async ({ renameResource }) => {
+            await renameResource(publicSpace, rootFolder, 'renamed')
+
+            expect(parentSpy).toHaveBeenCalledWith(
+              {
+                name: 'owncloud-password-protected-folder:renamed',
+                data: { newName: 'renamed' }
+              },
+              window.location.origin
+            )
+          }
+        })
+      })
+
+      it('does not notify for a child resource inside the shared folder', () => {
+        const childResource = mock<Resource>({
+          fileId: 'child-file-id',
+          isFolder: true,
+          name: 'child',
+          path: '/child'
+        })
+
+        getWrapper({
+          passwordProtectedFolderView: true,
+          setup: async ({ renameResource }) => {
+            await renameResource(publicSpace, childResource, 'renamed')
+
+            expect(parentSpy).not.toHaveBeenCalled()
+          }
+        })
+      })
+
+      it('does not notify when not running inside the folder view modal', () => {
+        getWrapper({
+          passwordProtectedFolderView: false,
+          setup: async ({ renameResource }) => {
+            await renameResource(publicSpace, rootFolder, 'renamed')
+
+            expect(parentSpy).not.toHaveBeenCalled()
+          }
+        })
+      })
+
+      it('does not notify for a non-public space', () => {
+        const personalSpace = mockDeep<SpaceResource>({
+          driveType: 'personal',
+          webDavPath: 'irrelevant',
+          fileId: 'root-file-id'
+        })
+
+        getWrapper({
+          passwordProtectedFolderView: true,
+          setup: async ({ renameResource }) => {
+            await renameResource(personalSpace, rootFolder, 'renamed')
+
+            expect(parentSpy).not.toHaveBeenCalled()
+          }
+        })
+      })
+    })
   })
 })
 
 function getWrapper({
-  setup
+  setup,
+  getPsecFile = vi.fn().mockResolvedValue(null),
+  passwordProtectedFolderView = false
 }: {
   setup: (
     instance: ReturnType<typeof useFileActionsRename>,
@@ -179,7 +395,14 @@ function getWrapper({
       clientService: ReturnType<typeof defaultComponentMocks>['$clientService']
     }
   ) => void
+  getPsecFile?: ReturnType<typeof vi.fn>
+  passwordProtectedFolderView?: boolean
 }) {
+  vi.mocked(useResolvePasswordProtectedFolderCounterpart).mockReturnValue({
+    getPasswordProtectedFolder: vi.fn().mockResolvedValue(null),
+    getPsecFile
+  } as unknown as ReturnType<typeof useResolvePasswordProtectedFolderCounterpart>)
+
   const mocks = {
     ...defaultComponentMocks(),
     space: mockDeep<SpaceResource>({
@@ -191,6 +414,8 @@ function getWrapper({
     mocks,
     wrapper: getComposableWrapper(
       () => {
+        const configStore = useConfigStore()
+        configStore.options = { ...configStore.options, passwordProtectedFolderView }
         const instance = useFileActionsRename()
         setup(instance, { space: mocks.space, clientService: mocks.$clientService })
       },

--- a/web/packages/web-runtime/src/container/bootstrap.ts
+++ b/web/packages/web-runtime/src/container/bootstrap.ts
@@ -77,7 +77,7 @@ import {
   SseEventWrapperOptions
 } from './sse'
 import { loadAppTranslations } from '../helpers/language'
-import { urlJoin } from '@ownclouders/web-client'
+import { PASSWORD_PROTECTED_FOLDER_VIEW_QUERY, urlJoin } from '@ownclouders/web-client'
 import { supportedLanguages } from '../defaults'
 
 const getEmbedConfigFromQuery = (
@@ -174,6 +174,7 @@ export const announceConfiguration = async ({
     hideAppSwitcher: getQueryParam('hide-app-switcher') === 'true',
     hideAccountMenu: getQueryParam('hide-account-menu') === 'true',
     hideNavigation: getQueryParam('hide-navigation') === 'true',
+    passwordProtectedFolderView: getQueryParam(PASSWORD_PROTECTED_FOLDER_VIEW_QUERY) === 'true',
     defaultLanguage
   }
 


### PR DESCRIPTION
## Description

Renaming a password-protected folder did not keep its `.psec` pointer file in sync, so the main file listing kept showing the old name. This happened in two places:

- Renaming the folder via the hidden `.PasswordProtectedFolders` location: fixed by adding password-protected-folder awareness to the generic rename action (`useFileActionsRename`), which now resolves and renames the `.psec` counterpart alongside the folder.
- Renaming from inside the folder-view modal: the real folder lives in a separate, framed public-link session, so the parent window has no way to observe a rename inside it. A rename that resolved the folder by its old name (instead of a stable identifier) would 404 once the names diverged, permanently desyncing the pair. Fixed by having the framed app post a message to the parent at the moment of rename, so the `.psec` file is kept in sync immediately — even without clicking "Close" or on refresh.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-136

## Motivation and Context

Users lost track of which `.psec` file pointed to which folder after a rename, since the two are only linked by name and there was no mechanism to keep them aligned.

## How Has This Been Tested?
- test environment: local oCIS web dev setup, password-protected folder created via a password-protected public link
- test case 1: rename the real folder via `.PasswordProtectedFolders` → `.psec` file renamed to match in the main listing
- test case 2: rename the folder from inside the folder-view modal, click "Close" → `.psec` file renamed to match
- test case 3: rename the folder from inside the folder-view modal, refresh without clicking "Close" → `.psec` file still renamed to match
- test case 4: delete the folder from inside the modal, click "Close" → no uncaught error, no stale sync attempt
- unit tests added for both the rename-action sync and the modal postMessage sync (36 tests across the two affected suites)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
