### PR TITLE
fix: restore hover feedback lost to background-highlight/default coll…

### DIFF
--- a/changelog/unreleased/bugfix-restore-hover-contrast.md
+++ b/changelog/unreleased/bugfix-restore-hover-contrast.md
@@ -1,0 +1,15 @@
+Bugfix: Restore hover feedback in high-contrast and dark themes
+
+The Light and Dark High-Contrast themes set the background-highlight color
+token equal to the default page background, making hover backgrounds
+indistinguishable from the resting background wherever background-highlight
+was used for interactive feedback, such as the global search results
+dropdown. The non-high-contrast Dark theme had the same collision.
+
+background-highlight now matches background-hover in the affected theme
+definitions, and the search results dropdown and create-shortcut context
+menu now use the background-hover color directly for their hover and active
+states, since background-highlight is otherwise used for static surfaces
+like cards, modals and form fields rather than interaction feedback.
+
+https://github.com/owncloud/ocis/pull/12613

--- a/services/web/assets/themes/owncloud/theme.json
+++ b/services/web/assets/themes/owncloud/theme.json
@@ -147,7 +147,7 @@
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",
               "background-default": "#ffffff",
-              "background-highlight": "#ffffff",
+              "background-highlight": "oklch(87.2% 0.01 258.338)",
               "background-muted": "#ffffff",
               "background-secondary": "#ffffff",
               "background-hover": "oklch(87.2% 0.01 258.338)",
@@ -212,7 +212,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "#383838",
               "background-muted": "oklch(21% 0.034 264.665)",
               "background-secondary": "#404040",
               "background-hover": "#383838",
@@ -279,7 +279,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "oklch(21% 0.034 264.665)",
               "background-muted": "#000000",
               "background-secondary": "#000000",
               "background-hover": "oklch(21% 0.034 264.665)",
@@ -423,7 +423,7 @@
             "colorPalette": {
               "background-accentuate": "rgba(255, 255, 5, 0.1)",
               "background-default": "#ffffff",
-              "background-highlight": "#ffffff",
+              "background-highlight": "oklch(87.2% 0.01 258.338)",
               "background-muted": "#ffffff",
               "background-secondary": "#ffffff",
               "background-hover": "oklch(87.2% 0.01 258.338)",
@@ -489,7 +489,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "#383838",
               "background-muted": "oklch(21% 0.034 264.665)",
               "background-secondary": "#404040",
               "background-hover": "#383838",
@@ -563,7 +563,7 @@
             "colorPalette": {
               "background-accentuate": "#696969",
               "background-default": "#000000",
-              "background-highlight": "#000000",
+              "background-highlight": "oklch(21% 0.034 264.665)",
               "background-muted": "#000000",
               "background-secondary": "#000000",
               "background-hover": "oklch(21% 0.034 264.665)",

--- a/web/packages/web-app-search/src/portals/SearchBar.vue
+++ b/web/packages/web-app-search/src/portals/SearchBar.vue
@@ -830,7 +830,7 @@ onBeforeUnmount(() => {
 
           &:hover,
           &.active {
-            background-color: var(--oc-color-background-highlight);
+            background-color: var(--oc-color-background-hover);
           }
 
           &.disabled {

--- a/web/packages/web-pkg/src/components/CreateShortcutModal.vue
+++ b/web/packages/web-pkg/src/components/CreateShortcutModal.vue
@@ -430,7 +430,7 @@ defineExpose({ onConfirm })
 
   li:hover,
   li.active {
-    background-color: var(--oc-color-background-highlight);
+    background-color: var(--oc-color-background-hover);
   }
 }
 </style>


### PR DESCRIPTION
…ision

The Light/Dark High-Contrast themes set colorPalette.background-highlight equal to background-default, making hover backgrounds indistinguishable from the resting page background wherever background-highlight was used for interactive feedback (e.g. the global search results dropdown). The non-high-contrast Dark theme had the same collision.

Set background-highlight to the same value as background-hover in those theme blocks, and point SearchBar's result-preview hover/active state and CreateShortcutModal's context-menu hover/active state at --oc-color-background-hover directly, since background-highlight is otherwise used for static surfaces (cards, modals, form fields) rather than interaction feedback.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
