### PR TITLE
fix(web): stop breadcrumb items from being announced twice

### DIFF
--- a/changelog/unreleased/bugfix-breadcrumb-duplicate-announcement.md
+++ b/changelog/unreleased/bugfix-breadcrumb-duplicate-announcement.md
@@ -1,0 +1,10 @@
+Bugfix: Stop breadcrumb items from being announced twice
+
+Each breadcrumb list item had `tabindex="0"`, putting the item itself in the
+keyboard/screen reader focus order in addition to the link or button nested
+inside it. This caused every breadcrumb segment to be announced twice in a
+row. The list item is no longer a separate focus stop; only its inner link
+or button is, while the item remains focusable enough for existing
+drag-and-drop styling to keep working.
+
+https://github.com/owncloud/ocis/pull/12643

--- a/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.spec.ts
+++ b/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.spec.ts
@@ -22,6 +22,13 @@ describe('OcBreadcrumb', () => {
     )
     expect(wrapper.html()).toMatchSnapshot()
   })
+  it('does not make list items focusable to avoid duplicate screen reader announcements', () => {
+    const { wrapper } = getWrapper()
+    const listItems = wrapper.findAll('.oc-breadcrumb-list-item:not(.oc-invisible-sr)')
+    listItems.forEach((li) => {
+      expect(li.attributes('tabindex')).not.toBe('0')
+    })
+  })
   it('displays context menu trigger if enabled via property', () => {
     const { wrapper } = getWrapper({ showContextActions: true })
     expect(wrapper.find('#oc-breadcrumb-contextmenu-trigger').exists()).toBe(true)

--- a/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
+++ b/web/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
@@ -12,7 +12,8 @@
         :data-key="index"
         :data-item-id="item.id"
         :aria-hidden="item.isTruncationPlaceholder"
-        :tabindex="item.isTruncationPlaceholder ? -1 : 0"
+        :inert="item.isTruncationPlaceholder || undefined"
+        tabindex="-1"
         :class="[
           'oc-breadcrumb-list-item',
           'oc-flex',

--- a/web/packages/design-system/src/components/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.ts.snap
+++ b/web/packages/design-system/src/components/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.ts.snap
@@ -3,27 +3,27 @@
 exports[`OcBreadcrumb > displays all items 1`] = `
 "<nav id="oc-breadcrumbs-2" class="oc-breadcrumb oc-breadcrumb-default" aria-label="Breadcrumbs">
   <ol class="oc-breadcrumb-list oc-flex oc-m-rm oc-p-rm">
-    <li data-key="0" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="0" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">First folder</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="1" aria-hidden="true" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">
+    <li data-key="1" aria-hidden="true" inert="" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">...</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="2" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="2" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-flex"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Subfolder</span></oc-button-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="3" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="3" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]" aria-current="page"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Deep</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="4" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
+    <li data-key="4" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
       <!--v-if-->
       <!--v-if-->
     </li>
@@ -39,27 +39,27 @@ exports[`OcBreadcrumb > displays all items 1`] = `
 exports[`OcBreadcrumb > sets correct variation 1`] = `
 "<nav id="oc-breadcrumbs-1" class="oc-breadcrumb oc-breadcrumb-lead" aria-label="Breadcrumbs">
   <ol class="oc-breadcrumb-list oc-flex oc-m-rm oc-p-rm">
-    <li data-key="0" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="0" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">First folder</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="1" aria-hidden="true" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">
+    <li data-key="1" aria-hidden="true" inert="" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle oc-invisible-sr">
       <router-link-stub tag="a" to="[object Object]"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">...</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="2" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="2" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-flex"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Subfolder</span></oc-button-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="3" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
+    <li data-key="3" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle">
       <router-link-stub tag="a" to="[object Object]" aria-current="page"><span class="oc-breadcrumb-item-text oc-breadcrumb-item-navigable">Deep</span></router-link-stub>
       <oc-icon-stub name="arrow-right-s" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="var(--oc-color-text-default)" class="oc-mx-xs"></oc-icon-stub>
       <!--v-if-->
     </li>
-    <li data-key="4" tabindex="0" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
+    <li data-key="4" tabindex="-1" class="oc-breadcrumb-list-item oc-flex oc-flex-middle"><span class="oc-breadcrumb-item-text" tabindex="-1">Deeper ellipsize in responsive mode</span>
       <!--v-if-->
       <!--v-if-->
     </li>


### PR DESCRIPTION
Each breadcrumb list item had tabindex="0", putting it in the keyboard/screen reader focus order alongside the link or button nested inside it, causing every segment to be announced twice.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
