### PR TITLE
fix(oidc): respect (no) proxy env vars in OIDC HTTP client

### DIFF
--- a/changelog/unreleased/change-oidc-http-client-respects-proxy-env-vars.md
+++ b/changelog/unreleased/change-oidc-http-client-respects-proxy-env-vars.md
@@ -1,0 +1,10 @@
+Change: Respect proxy environment variables for OIDC requests
+
+The proxy and webfinger services now route OIDC requests through the
+`HTTP_PROXY` and `HTTPS_PROXY` settings from the environment. Deployments that
+should not send the OIDC issuer host through the proxy, or whose proxy cannot
+reach that host, must list the issuer hostname in `NO_PROXY`, otherwise
+authentication can fail when oCIS's own external hostname is reached through
+the proxy.
+
+https://github.com/owncloud/ocis/pull/12703

--- a/services/proxy/pkg/command/server.go
+++ b/services/proxy/pkg/command/server.go
@@ -98,6 +98,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			oidcHTTPClient := &http.Client{
 				Transport: &http.Transport{
+					Proxy: http.ProxyFromEnvironment,
 					TLSClientConfig: &tls.Config{
 						MinVersion:         tls.VersionTLS12,
 						InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec
@@ -269,6 +270,7 @@ func loadMiddlewares(logger log.Logger, cfg *config.Config,
 
 	oidcHTTPClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: cfg.OIDC.Insecure, //nolint:gosec

--- a/services/webfinger/pkg/server/http/server.go
+++ b/services/webfinger/pkg/server/http/server.go
@@ -63,6 +63,7 @@ func Server(opts ...Option) (ohttp.Service, error) {
 
 	var oidcHTTPClient = &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: options.Config.Insecure, //nolint:gosec


### PR DESCRIPTION
## Description

This change makes the OIDC HTTP clients honor the standard proxy environment variables. The root cause was that the custom `http.Transport` instances did not set `Proxy: http.ProxyFromEnvironment`, so requests to the OIDC provider ignored `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` in air-gapped environments and other proxy-based setups.

## Related Issue

- https://github.com/owncloud/ocis/issues/5614

## Motivation and Context

OIDC authentication flows need to reach the identity provider through the configured proxy in environments where outbound traffic must pass through a proxy. Without this change, requests fail when proxy variables are set, especially in air-gapped environments.

## How Has This Been Tested?

- test environment:
  - local development environment
- test case 1:
  - verified that the OIDC HTTP client transport now uses the proxy configured in the environment variables.
- test case 2:
  - verified that the OIDC HTTP client works as intended without the proxy related environment variables.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: N/A