### PR TITLE
fix: [OCISDEV-1053] Warn when resetting a service user password locks out login

### DIFF
--- a/changelog/unreleased/bugfix-idm-resetpw-sync-bind-config.md
+++ b/changelog/unreleased/bugfix-idm-resetpw-sync-bind-config.md
@@ -1,0 +1,15 @@
+Bugfix: Keep bind config in sync when resetting a service user password
+
+Resetting an IDM service user password with `ocis idm resetpassword
+--user-type service` only changed the entry in the IDM directory. Services such
+as auth-basic, users and groups still bound to LDAP as the `reva` service user
+using the old `bind_password` from their configuration, so after a restart
+those binds failed and regular admin login started returning 401 Unauthorized.
+
+The command now rewrites the matching `bind_password` and
+`service_user_passwords` keys in `ocis.yaml` when it is present, and always
+prints the environment variables that must carry the new password for env-var
+and distributed deployments it cannot rewrite.
+
+https://github.com/owncloud/ocis/pull/12716
+https://github.com/owncloud/ocis/issues/12569

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	stash.kopano.io/kgol/rndm v1.1.2
 )
@@ -351,7 +352,6 @@ require (
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/services/idm/pkg/command/configsync.go
+++ b/services/idm/pkg/command/configsync.go
@@ -1,0 +1,99 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// configFilePerm is the permission mask used when rewriting ocis.yaml, matching
+// the mask `ocis init` uses to create it.
+const configFilePerm = 0o600
+
+// serviceUserConfigKeys maps an IDM service user (the ou=sysusers entries plus
+// the bootstrap password keys) to the ocis.yaml key paths that must hold the
+// same secret so services can still bind to LDAP after a password reset.
+//
+// reva, libregraph and idp share OCIS_LDAP_BIND_PASSWORD across several
+// services but bind as distinct DNs, so their bind_password lives under
+// different service sections. The idm.service_user_passwords.* keys are what
+// `ocis init` writes and what re-bootstrapping a fresh database would read.
+var serviceUserConfigKeys = map[string][][]string{
+	"reva": {
+		{"auth_basic", "auth_providers", "ldap", "bind_password"},
+		{"users", "drivers", "ldap", "bind_password"},
+		{"groups", "drivers", "ldap", "bind_password"},
+		{"idm", "service_user_passwords", "reva_password"},
+	},
+	"libregraph": {
+		{"graph", "identity", "ldap", "bind_password"},
+		{"idm", "service_user_passwords", "idm_password"},
+	},
+	"idp": {
+		{"idp", "ldap", "bind_password"},
+		{"idm", "service_user_passwords", "idp_password"},
+	},
+}
+
+// syncServiceUserPasswordInConfig rewrites the bind_password / service user
+// password keys associated with the given service user to newPassword,
+// preserving the rest of the document (including comments and unrelated keys).
+// It returns the updated document, the dotted paths that were actually changed,
+// and any error. Paths that are not present in the document are skipped.
+func syncServiceUserPasswordInConfig(data []byte, userName, newPassword string) ([]byte, []string, error) {
+	paths, ok := serviceUserConfigKeys[userName]
+	if !ok {
+		// Not a known service user with bind config to sync.
+		return data, nil, nil
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	if len(root.Content) == 0 {
+		return data, nil, nil
+	}
+	doc := root.Content[0]
+
+	updated := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if node := lookupYAMLNode(doc, path); node != nil {
+			node.SetString(newPassword)
+			updated = append(updated, strings.Join(path, "."))
+		}
+	}
+
+	if len(updated) == 0 {
+		return data, nil, nil
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize config: %w", err)
+	}
+	return out, updated, nil
+}
+
+// lookupYAMLNode walks a mapping node along path and returns the scalar value
+// node at the end, or nil if any segment is missing.
+func lookupYAMLNode(node *yaml.Node, path []string) *yaml.Node {
+	for _, key := range path {
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		var next *yaml.Node
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				next = node.Content[i+1]
+				break
+			}
+		}
+		if next == nil {
+			return nil
+		}
+		node = next
+	}
+	return node
+}

--- a/services/idm/pkg/command/configsync_test.go
+++ b/services/idm/pkg/command/configsync_test.go
@@ -1,0 +1,138 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// sampleOcisConfig mirrors the relevant subset of an `ocis init` generated
+// ocis.yaml, carrying the bind_password keys the reva/libregraph/idp service
+// users are wired into.
+const sampleOcisConfig = `token_manager:
+  jwt_secret: keepme
+idm:
+  service_user_passwords:
+    admin_password: adminpw
+    idm_password: OLDIDM
+    reva_password: OLDREVA
+    idp_password: OLDIDP
+idp:
+  ldap:
+    bind_password: OLDIDP
+auth_basic:
+  auth_providers:
+    ldap:
+      bind_password: OLDREVA
+users:
+  drivers:
+    ldap:
+      bind_password: OLDREVA
+groups:
+  drivers:
+    ldap:
+      bind_password: OLDREVA
+graph:
+  identity:
+    ldap:
+      bind_password: OLDIDM
+`
+
+func getYAMLPath(t *testing.T, data []byte, path ...string) string {
+	t.Helper()
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(data, &root))
+	node := root.Content[0]
+	for _, key := range path {
+		var next *yaml.Node
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				next = node.Content[i+1]
+				break
+			}
+		}
+		require.NotNilf(t, next, "path %v: key %q not found", path, key)
+		node = next
+	}
+	return node.Value
+}
+
+func TestSyncServiceUserPasswordReva(t *testing.T) {
+	out, updated, err := syncServiceUserPasswordInConfig([]byte(sampleOcisConfig), "reva", "NEWPW")
+	require.NoError(t, err)
+
+	// reva binds via auth_basic, users and groups, and is bootstrapped via
+	// idm.service_user_passwords.reva_password — all must move to NEWPW.
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "auth_basic", "auth_providers", "ldap", "bind_password"))
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "users", "drivers", "ldap", "bind_password"))
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "groups", "drivers", "ldap", "bind_password"))
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "idm", "service_user_passwords", "reva_password"))
+
+	// Unrelated service users must stay untouched.
+	assert.Equal(t, "OLDIDM", getYAMLPath(t, out, "graph", "identity", "ldap", "bind_password"))
+	assert.Equal(t, "OLDIDP", getYAMLPath(t, out, "idp", "ldap", "bind_password"))
+	assert.Equal(t, "OLDIDM", getYAMLPath(t, out, "idm", "service_user_passwords", "idm_password"))
+
+	// Unrelated keys and comments-free structure must survive the round-trip.
+	assert.Equal(t, "keepme", getYAMLPath(t, out, "token_manager", "jwt_secret"))
+
+	assert.ElementsMatch(t, []string{
+		"auth_basic.auth_providers.ldap.bind_password",
+		"users.drivers.ldap.bind_password",
+		"groups.drivers.ldap.bind_password",
+		"idm.service_user_passwords.reva_password",
+	}, updated)
+}
+
+func TestSyncServiceUserPasswordLibregraph(t *testing.T) {
+	out, updated, err := syncServiceUserPasswordInConfig([]byte(sampleOcisConfig), "libregraph", "NEWPW")
+	require.NoError(t, err)
+
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "graph", "identity", "ldap", "bind_password"))
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "idm", "service_user_passwords", "idm_password"))
+	// reva keys stay put
+	assert.Equal(t, "OLDREVA", getYAMLPath(t, out, "users", "drivers", "ldap", "bind_password"))
+
+	assert.ElementsMatch(t, []string{
+		"graph.identity.ldap.bind_password",
+		"idm.service_user_passwords.idm_password",
+	}, updated)
+}
+
+func TestSyncServiceUserPasswordIdp(t *testing.T) {
+	out, updated, err := syncServiceUserPasswordInConfig([]byte(sampleOcisConfig), "idp", "NEWPW")
+	require.NoError(t, err)
+
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "idp", "ldap", "bind_password"))
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "idm", "service_user_passwords", "idp_password"))
+
+	assert.ElementsMatch(t, []string{
+		"idp.ldap.bind_password",
+		"idm.service_user_passwords.idp_password",
+	}, updated)
+}
+
+func TestSyncServiceUserPasswordUnknownUser(t *testing.T) {
+	// An arbitrary (non service) user has no bind config to sync; the config
+	// must be returned unchanged with no reported updates.
+	out, updated, err := syncServiceUserPasswordInConfig([]byte(sampleOcisConfig), "einstein", "NEWPW")
+	require.NoError(t, err)
+	assert.Empty(t, updated)
+	assert.Equal(t, strings.TrimSpace(sampleOcisConfig), strings.TrimSpace(string(out)))
+}
+
+func TestSyncServiceUserPasswordMissingKeys(t *testing.T) {
+	// A slim config that omits some bind_password keys: only the present ones
+	// are updated and reported, absent ones are silently skipped.
+	const slim = `idm:
+  service_user_passwords:
+    reva_password: OLDREVA
+`
+	out, updated, err := syncServiceUserPasswordInConfig([]byte(slim), "reva", "NEWPW")
+	require.NoError(t, err)
+	assert.Equal(t, "NEWPW", getYAMLPath(t, out, "idm", "service_user_passwords", "reva_password"))
+	assert.ElementsMatch(t, []string{"idm.service_user_passwords.reva_password"}, updated)
+}

--- a/services/idm/pkg/command/resetpw.go
+++ b/services/idm/pkg/command/resetpw.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"syscall"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/libregraph/idm/pkg/ldbbolt"
 	"github.com/libregraph/idm/server"
 	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	ocisdefaults "github.com/owncloud/ocis/v2/ocis-pkg/config/defaults"
 	"github.com/owncloud/ocis/v2/ocis-pkg/log"
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config"
 	"github.com/owncloud/ocis/v2/services/idm/pkg/config/parser"
@@ -19,6 +21,12 @@ import (
 	"github.com/urfave/cli/v2"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/term"
+)
+
+// User account types accepted by the --user-type flag.
+const (
+	userTypeUser    = "user"
+	userTypeService = "service"
 )
 
 // ResetPassword is the entrypoint for the resetpassword command
@@ -37,7 +45,7 @@ func ResetPassword(cfg *config.Config) *cli.Command {
 			&cli.StringFlag{
 				Name:  "user-type",
 				Usage: "Type of user account: 'user' (ou=users) or 'service' (ou=sysusers)",
-				Value: "user",
+				Value: userTypeUser,
 			},
 		},
 		Before: func(_ *cli.Context) error {
@@ -50,8 +58,8 @@ func ResetPassword(cfg *config.Config) *cli.Command {
 			defer cancel()
 
 			userType := c.String("user-type")
-			if userType != "user" && userType != "service" {
-				return fmt.Errorf("invalid --user-type %q: must be 'user' or 'service'", userType)
+			if userType != userTypeUser && userType != userTypeService {
+				return fmt.Errorf("invalid --user-type %q: must be %q or %q", userType, userTypeUser, userTypeService)
 			}
 
 			return resetPassword(ctx, logger, cfg, c.String("user-name"), userType)
@@ -69,7 +77,7 @@ func resetPassword(_ context.Context, logger log.Logger, cfg *config.Config, use
 	}
 
 	ou := "users"
-	if userType == "service" {
+	if userType == userTypeService {
 		ou = "sysusers"
 	}
 	userDN := fmt.Sprintf("uid=%s,ou=%s,%s", userName, ou, servercfg.LDAPBaseDN)
@@ -105,7 +113,64 @@ func resetPassword(_ context.Context, logger log.Logger, cfg *config.Config, use
 		fmt.Fprintf(os.Stderr, "Failed to update user password: %v\n", err)
 	}
 	fmt.Printf("Password for user '%s' updated.\n", userDN)
+
+	if userType == userTypeService {
+		syncServiceUserBindConfig(userName, newPw)
+	}
 	return nil
+}
+
+// syncServiceUserBindConfig keeps ocis.yaml in sync after a service user's
+// password was changed in the IDM database. Services bind to LDAP as the
+// service users (e.g. uid=reva,ou=sysusers) using the bind_password from their
+// config; if only the directory entry is changed those binds start failing on
+// the next restart, which manifests as admin login returning 401. It rewrites
+// the matching keys in ocis.yaml when present and always prints the env vars
+// the operator must ensure carry the new value (covering env-var and
+// distributed deployments this tool cannot rewrite).
+func syncServiceUserBindConfig(userName, newPassword string) {
+	if _, known := serviceUserConfigKeys[userName]; !known {
+		return
+	}
+
+	configFile := path.Join(ocisdefaults.BaseConfigPath(), "ocis.yaml")
+	if data, err := os.ReadFile(configFile); err == nil {
+		out, updated, err := syncServiceUserPasswordInConfig(data, userName, newPassword)
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "Warning: could not update bind passwords in %q: %v\n", configFile, err)
+		case len(updated) > 0:
+			if err := os.WriteFile(configFile, out, configFilePerm); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not write updated config %q: %v\n", configFile, err)
+			} else {
+				fmt.Printf("Updated bind passwords in %q:\n", configFile)
+				for _, key := range updated {
+					fmt.Printf("  - %s\n", key)
+				}
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(os.Stderr, "Warning: could not read config %q: %v\n", configFile, err)
+	}
+
+	fmt.Printf("\nIMPORTANT: the '%s' service user is used by oCIS services to bind to LDAP.\n", userName)
+	fmt.Printf("Make sure the following environment variable(s) are set to the new password\n")
+	fmt.Printf("wherever they are configured (env, secrets, per-service yaml), then restart oCIS:\n")
+	fmt.Printf("  - OCIS_LDAP_BIND_PASSWORD (shared) or the per-service variables below\n")
+	for _, env := range serviceUserBindEnvVars[userName] {
+		fmt.Printf("  - %s\n", env)
+	}
+}
+
+// serviceUserBindEnvVars lists the per-service bind_password environment
+// variables that carry the given service user's password, for the operator
+// guidance message. OCIS_LDAP_BIND_PASSWORD is a single shared variable used by
+// all of these services, so it is noted separately by the caller rather than
+// per user.
+var serviceUserBindEnvVars = map[string][]string{
+	"reva":       {"AUTH_BASIC_LDAP_BIND_PASSWORD", "USERS_LDAP_BIND_PASSWORD", "GROUPS_LDAP_BIND_PASSWORD", "IDM_REVASVC_PASSWORD"},
+	"libregraph": {"GRAPH_LDAP_BIND_PASSWORD", "IDM_SVC_PASSWORD"},
+	"idp":        {"IDP_LDAP_BIND_PASSWORD", "IDM_IDPSVC_PASSWORD"},
 }
 
 func getPassword() (string, error) {


### PR DESCRIPTION
Bugfix: Keep bind config in sync when resetting a service user password

Resetting an IDM service user password with `ocis idm resetpassword
--user-type service` only changed the entry in the IDM directory. Services such
as auth-basic, users and groups still bound to LDAP as the `reva` service user
using the old `bind_password` from their configuration, so after a restart
those binds failed and regular admin login started returning 401 Unauthorized.

The command now rewrites the matching `bind_password` and
`service_user_passwords` keys in `ocis.yaml` when it is present, and always
prints the environment variables that must carry the new password for env-var
and distributed deployments it cannot rewrite.

https://github.com/owncloud/ocis/pull/12716
https://github.com/owncloud/ocis/issues/12569