### PR TITLE
fix: [OCISDEV-615] Allow renaming and editing files with the editor-lite role

### DIFF
--- a/changelog/unreleased/fix-editor-lite-rename-and-write.md
+++ b/changelog/unreleased/fix-editor-lite-rename-and-write.md
@@ -1,0 +1,41 @@
+Bugfix: Allow renaming, moving and editing files with the editor-lite role
+
+We've fixed the editor-lite role ("Can edit" in the web UI). Sharees can now
+rename a file inside a shared folder, move it and change its contents. Before,
+they could only upload new files, and the web UI offered neither the rename nor
+the overwrite action.
+
+The role has always granted Move, but the persisted ACE format had no flag of
+its own for it: Move shared the "w" flag with InitiateFileUpload and was only
+recovered on read by assuming a grant may move whenever it may write, download
+and delete. The editor-lite role has no delete, so its Move was dropped as soon
+as the grant was written to disk, `Decomposedfs.Move` then refused the rename
+and propfind reported the grant as a create-only uploader. Move is now
+persisted under its own "m" flag in `pkg/storage/utils/ace/ace.go`; grants
+written before that flag existed carry no "m" and keep using the old inference.
+On top of that, `RoleFromResourcePermissions` in `pkg/conversions/role.go` did
+not treat Move as write, so the WebDAV permissions string lacked "NV" (rename)
+and "W" (overwrite) even for a grant that had kept its Move. Move now implies
+write for grants that do not carry delete, which leaves the OCS permissions of
+the deletable roles unchanged.
+
+Note: the effective permission set of the editor-lite role changed. The CS3
+resource permissions returned by `NewEditorLiteRole` are unchanged - Stat,
+GetPath, ListContainer, InitiateFileDownload, InitiateFileUpload,
+CreateContainer and Move, still no Delete and no ListFileVersions - but a grant
+created from it is now stored as "txrwma" instead of "txrwa", reports the OCS
+permissions 6 (create + write) instead of 4 (create), and reports the WebDAV
+permissions "SNVW" on a shared file and "SNVCK" on a shared folder instead of
+"S" and "SCK".
+
+This fix DOES NOT include a migration of stored grants. Shares created with
+that role before this update keep their old grant on disk, which carries no "m"
+flag. For them, Move stays unset and the WebDAV permissions string stays
+unchanged, while the share record itself has always kept Move and therefore
+already reports the new OCS permissions. Only shares created with that role
+AFTER THE UPDATE get the new permission set. Re-creating an affected share, or
+updating its role, re-writes the grant and picks up the fix.
+
+https://github.com/owncloud/ocis/pull/12721
+https://github.com/owncloud/reva/pull/689
+https://github.com/owncloud/ocis/issues/11977

--- a/changelog/unreleased/fix-editor-lite-rename-and-write.md
+++ b/changelog/unreleased/fix-editor-lite-rename-and-write.md
@@ -28,6 +28,14 @@ permissions 6 (create + write) instead of 4 (create), and reports the WebDAV
 permissions "SNVW" on a shared file and "SNVCK" on a shared folder instead of
 "S" and "SCK".
 
+The same "m" flag also restores Move for any other non-deletable grant that
+carries it. In particular the Uploader share role is affected: like editor-lite
+it is a create grant without delete, so its Move used to be dropped on
+write-back and is now preserved. This is why the previously expected-to-fail
+"sharee moves a file within a shared folder" scenarios for the Uploader role now
+pass, and the matching entries were removed from
+`tests/acceptance/expected-failures-API-on-OCIS-storage.md`.
+
 This fix DOES NOT include a migration of stored grants. Shares created with
 that role before this update keep their old grant on disk, which carries no "m"
 flag. For them, Move stays unset and the WebDAV permissions string stays

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/beevik/etree v1.7.0
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/cs3org/go-cs3apis v0.0.0-20241105092511-3ad35d174fc1
 	github.com/davidbyttow/govips/v2 v2.18.0
@@ -66,7 +67,7 @@ require (
 	github.com/open-policy-agent/opa v1.18.2
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
-	github.com/owncloud/reva/v2 v2.0.0-20260806120523-b19e6c62c8f9
+	github.com/owncloud/reva/v2 v2.0.0-20260807092659-5e5d7767ea70
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2
@@ -108,6 +109,7 @@ require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	stash.kopano.io/kgol/rndm v1.1.2
 )
@@ -154,7 +156,6 @@ require (
 	github.com/blevesearch/zapx/v17 v17.1.2 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/bombsimon/logrusr/v3 v3.1.0 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/ceph/go-ceph v0.40.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73 // indirect
@@ -351,7 +352,6 @@ require (
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/beevik/etree v1.7.0
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/cs3org/go-cs3apis v0.0.0-20241105092511-3ad35d174fc1
 	github.com/davidbyttow/govips/v2 v2.18.0
@@ -67,7 +66,7 @@ require (
 	github.com/open-policy-agent/opa v1.18.2
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
-	github.com/owncloud/reva/v2 v2.0.0-20260806083646-53c5e2d95c65
+	github.com/owncloud/reva/v2 v2.0.0-20260806120523-b19e6c62c8f9
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.23.2
@@ -109,7 +108,6 @@ require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	stash.kopano.io/kgol/rndm v1.1.2
 )
@@ -156,6 +154,7 @@ require (
 	github.com/blevesearch/zapx/v17 v17.1.2 // indirect
 	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/bombsimon/logrusr/v3 v3.1.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/ceph/go-ceph v0.40.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cevaris/ordered_map v0.0.0-20190319150403-3adeae072e73 // indirect
@@ -352,6 +351,7 @@ require (
 	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245 h1:JRidLTAKhnvyLMRtVtSF4lhBa0NSAOs6fof+d6JnKII=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20260806083646-53c5e2d95c65 h1:BaCiqfUvgRd2s37z/61pt4MG490p+MyoQwYhXLS4u+E=
-github.com/owncloud/reva/v2 v2.0.0-20260806083646-53c5e2d95c65/go.mod h1:zJV1uSPyjLXGhb3JwI0EuUx8GJaq1d/NCmpuqN0U4IE=
+github.com/owncloud/reva/v2 v2.0.0-20260807092659-5e5d7767ea70 h1:CmCVRdKEOJipgY1zPsgTUU8dk3ExbMPg9xUgDUjycXM=
+github.com/owncloud/reva/v2 v2.0.0-20260807092659-5e5d7767ea70/go.mod h1:zJV1uSPyjLXGhb3JwI0EuUx8GJaq1d/NCmpuqN0U4IE=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.12 h1:DVJJTFMDlSAdO46yisPF2vzozs/r+4k6ih8MVghq78M=

--- a/tests/acceptance/expected-failures-API-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-API-on-OCIS-storage.md
@@ -204,11 +204,6 @@ _ocdav: api compatibility, return correct status code_
 - [coreApiWebdavUploadTUS/uploadFileMtime.feature:85](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature#L85)
 - [coreApiWebdavUploadTUS/uploadFileMtime.feature:86](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFileMtime.feature#L86)
 
-#### Uploaders are not allowed to `MOVE`
-- [coreApiWebdavMove2/moveShareOnOcis.feature:279](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L279)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:281](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L281)
-- [coreApiWebdavMove2/moveShareOnOcis.feature:283](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveShareOnOcis.feature#L283)
-
 ### Won't fix
 
 Not everything needs to be implemented for ocis. While the oc10 testsuite covers these things we are not looking at them right now.

--- a/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-localAPI-on-OCIS-storage.md
@@ -374,10 +374,6 @@ The expected failures in this file are from features in the owncloud/ocis repo.
 
 - [apiActivities/activitiesByFileId.feature:2190](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiActivities/activitiesByFileId.feature#L2190)
 
-#### Uploaders are not allowed to `MOVE`
-
-- [apiSpacesShares/moveSpaces.feature:377](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiSpacesShares/moveSpaces.feature#L377)
-
 #### [Activities. no event for restoring file](https://github.com/owncloud/ocis/issues/10010)
 
 - [apiActivities/activities.feature:3772](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/apiActivities/activities.feature#L3772)

--- a/tests/acceptance/features/apiSharingNgShares/enableDisablePermissionsRole.feature
+++ b/tests/acceptance/features/apiSharingNgShares/enableDisablePermissionsRole.feature
@@ -610,7 +610,7 @@ Feature: enable disable permissions role
     Examples:
       | resource      | permissions-role | permissions | resource-to-download        | role-id                              |
       | textfile.txt  | Viewer           | S           | textfile.txt                | b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5 |
-      | folderToShare | Uploader         | SCK         | folderToShare/textfile1.txt | 1c996275-f1c9-4e71-abdf-a42f6495e960 |
+      | folderToShare | Uploader         | SNVCK       | folderToShare/textfile1.txt | 1c996275-f1c9-4e71-abdf-a42f6495e960 |
       | folderToShare | Editor           | SDNVCK      | folderToShare/textfile1.txt | fb6c3e19-e378-47e5-b277-9732f9de6e21 |
       | folderToShare | Viewer           | S           | folderToShare/textfile1.txt | b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5 |
 
@@ -669,7 +669,7 @@ Feature: enable disable permissions role
       | resource      | permissions-role | permissions | resource-to-download        | role-id                              |
       | textfile.txt  | File Editor      | SW          | textfile.txt                | 2d00ce52-1fc2-4dbc-8b95-a73b73395f5a |
       | textfile.txt  | Viewer           | S           | textfile.txt                | b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5 |
-      | folderToShare | Uploader         | SCK         | folderToShare/textfile1.txt | 1c996275-f1c9-4e71-abdf-a42f6495e960 |
+      | folderToShare | Uploader         | SNVCK       | folderToShare/textfile1.txt | 1c996275-f1c9-4e71-abdf-a42f6495e960 |
       | folderToShare | Editor           | SDNVCK      | folderToShare/textfile1.txt | fb6c3e19-e378-47e5-b277-9732f9de6e21 |
       | folderToShare | Viewer           | S           | folderToShare/textfile1.txt | b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5 |
 

--- a/vendor/github.com/owncloud/reva/v2/pkg/conversions/role.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/conversions/role.go
@@ -63,7 +63,7 @@ const (
 	RoleFileEditorListGrantsWithVersions = "file-editor-list-grants-with-versions"
 	// RoleCoowner grants co-owner permissions on a resource.
 	RoleCoowner = "coowner"
-	// RoleEditorLite grants permission to upload and download to a resource.
+	// RoleEditorLite grants permission to download, upload, rename and change the contents of a resource, but not to delete it or see its versions.
 	RoleEditorLite = "editor-lite"
 	// RoleUploader grants uploader permission to upload onto a resource (no download).
 	RoleUploader = "uploader"
@@ -604,8 +604,14 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
+	// Move implies write for the non-deletable roles: a grantee that may rename a
+	// resource may also replace its contents. Without it the editor-lite role
+	// would come back read-only here, and clients would hide rename and overwrite
+	// even though the storage layer accepts both. Deletable grants are excluded
+	// because the persisted ACE format cannot tell "w" (upload) apart from Move,
+	// so every legacy delete+create+read grant would read back as writable too.
 	if rp.InitiateFileUpload &&
-		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle)) {
+		(rp.RestoreRecycleItem || (rp.Delete && !rp.ListRecycle) || (rp.Move && !rp.Delete)) {
 		r.ocsPermissions |= PermissionWrite
 	}
 	if rp.Stat &&
@@ -645,7 +651,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		r.Name = RoleSecureViewer
 		return r
 	}
-	if r.ocsPermissions == PermissionCreate {
+	if r.ocsPermissions == PermissionCreate || r.ocsPermissions == PermissionCreate|PermissionWrite {
 		if rp.GetPath && rp.InitiateFileDownload && rp.ListContainer && rp.Move {
 			r.Name = RoleEditorLite
 			return r

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/ace/ace.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/ace/ace.go
@@ -102,6 +102,10 @@ the extended attributes will look like this
 
   - w write-data (files) / create-file (directories)
 
+  - m move - rename or move the file/directory. Not an NFSv4 permission. Grants
+    written before this flag existed encoded move in w, so a missing m on a
+    w+r+d grant still means move.
+
   - a append-data (files) / create-subdirectory (directories)
 
   - x execute (files) / change-directory (directories)
@@ -332,9 +336,16 @@ func (e *ACE) grantPermissionSet() *provider.ResourcePermissions {
 	// w
 	if strings.Contains(e.permissions, "w") {
 		p.InitiateFileUpload = true
+		// Grants persisted before "m" existed encoded Move in "w" as well, so for
+		// those the only way to tell the two apart is this heuristic. Newer grants
+		// carry "m" and do not need it.
 		if p.InitiateFileDownload && p.Delete {
 			p.Move = true
 		}
+	}
+	// m
+	if strings.Contains(e.permissions, "m") {
+		p.Move = true
 	}
 	// a
 	if strings.Contains(e.permissions, "a") {
@@ -450,6 +461,9 @@ func getACEPerm(set *provider.ResourcePermissions) string {
 	}
 	if set.InitiateFileUpload || set.Move {
 		b.WriteString("w")
+	}
+	if set.Move {
+		b.WriteString("m")
 	}
 	if set.CreateContainer {
 		b.WriteString("a")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1321,7 +1321,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260806083646-53c5e2d95c65
+# github.com/owncloud/reva/v2 v2.0.0-20260807092659-5e5d7767ea70
 ## explicit; go 1.25.8
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
Bugfix: Allow renaming, moving and editing files with the editor-lite role

We've fixed the editor-lite role ("Can edit" in the web UI). Sharees can now
rename a file inside a shared folder, move it and change its contents. Before,
they could only upload new files, and the web UI offered neither the rename nor
the overwrite action.

The role has always granted Move, but the persisted ACE format had no flag of
its own for it: Move shared the "w" flag with InitiateFileUpload and was only
recovered on read by assuming a grant may move whenever it may write, download
and delete. The editor-lite role has no delete, so its Move was dropped as soon
as the grant was written to disk, `Decomposedfs.Move` then refused the rename
and propfind reported the grant as a create-only uploader. Move is now
persisted under its own "m" flag in `pkg/storage/utils/ace/ace.go`; grants
written before that flag existed carry no "m" and keep using the old inference.
On top of that, `RoleFromResourcePermissions` in `pkg/conversions/role.go` did
not treat Move as write, so the WebDAV permissions string lacked "NV" (rename)
and "W" (overwrite) even for a grant that had kept its Move. Move now implies
write for grants that do not carry delete, which leaves the OCS permissions of
the deletable roles unchanged.

Note: the effective permission set of the editor-lite role changed. The CS3
resource permissions returned by `NewEditorLiteRole` are unchanged - Stat,
GetPath, ListContainer, InitiateFileDownload, InitiateFileUpload,
CreateContainer and Move, still no Delete and no ListFileVersions - but a grant
created from it is now stored as "txrwma" instead of "txrwa", reports the OCS
permissions 6 (create + write) instead of 4 (create), and reports the WebDAV
permissions "SNVW" on a shared file and "SNVCK" on a shared folder instead of
"S" and "SCK".

This fix DOES NOT include a migration of stored grants. Shares created with
that role before this update keep their old grant on disk, which carries no "m"
flag. For them, Move stays unset and the WebDAV permissions string stays
unchanged, while the share record itself has always kept Move and therefore
already reports the new OCS permissions. Only shares created with that role
AFTER THE UPDATE get the new permission set. Re-creating an affected share, or
updating its role, re-writes the grant and picks up the fix.


Issue https://github.com/owncloud/ocis/issues/11977
Related RP https://github.com/owncloud/reva/pull/689