### PR TITLE
fix(web): use correct color variable for group icon in share list

### DIFF
--- a/changelog/unreleased/bugfix-group-share-icon-invisible.md
+++ b/changelog/unreleased/bugfix-group-share-icon-invisible.md
@@ -1,0 +1,8 @@
+Bugfix: Fix invisible group icon in share collaborator list
+
+The icon shown next to group entries in the share collaborator autocomplete
+list used a color variable that no longer resolved to a valid value, making
+the icon effectively invisible against the background. The icon now uses the
+correct default text color variable so it renders properly again.
+
+https://github.com/owncloud/ocis/pull/12722

--- a/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -17,7 +17,7 @@
       :name="shareTypeKey"
       :icon="shareTypeIcon"
       icon-size="large"
-      icon-color="var(--oc-color-text)"
+      icon-color="var(--oc-color-text-default)"
       background="transparent"
       class="oc-mr-s"
     />


### PR DESCRIPTION
## Description
The group icon shown next to group entries in the share collaborator autocomplete list was invisible. It referenced a CSS variable (`--oc-color-text`) that no longer exists, so the icon rendered with no color and blended into the background. This change switches the icon to use the current default text color variable (`--oc-color-text-default`), restoring its visibility.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1169

## Motivation and Context
The `--oc-color-text` variable was removed/renamed at some point, but this component was never updated to match, leaving the group icon invisible in the "Add people" / share collaborator autocomplete list.

## How Has This Been Tested?
- test environment: local oCIS web dev setup
- test case 1: Open a file/folder's share panel, start typing in the "Add people" autocomplete field, and confirm group results now show a visible icon.
- test case 2: Verify user-type results still render their icon correctly (no regression from the shared color variable change).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
