### PR TITLE
fix(web): use correct color variable for group icon in share list

### DIFF
--- a/changelog/unreleased/bugfix-group-share-icon-invisible.md
+++ b/changelog/unreleased/bugfix-group-share-icon-invisible.md
@@ -1,0 +1,8 @@
+Bugfix: Fix invisible group icon in share collaborator list
+
+The icon shown next to group entries in the share collaborator autocomplete
+list used a color variable that no longer resolved to a valid value, making
+the icon effectively invisible against the background. The icon now uses the
+correct default text color variable so it renders properly again.
+
+https://github.com/owncloud/ocis/pull/TODO

--- a/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -17,7 +17,7 @@
       :name="shareTypeKey"
       :icon="shareTypeIcon"
       icon-size="large"
-      icon-color="var(--oc-color-text)"
+      icon-color="var(--oc-color-text-default)"
       background="transparent"
       class="oc-mr-s"
     />


### PR DESCRIPTION
The group icon in the share collaborator autocomplete list referenced a removed CSS variable, making it invisible. Switch to the current default text color variable.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
