### PR TITLE
fix(graph): [OCISDEV-751] return correct issuerAssignedId on /me

### DIFF
--- a/changelog/unreleased/fix-issuerassignedid-on-me.md
+++ b/changelog/unreleased/fix-issuerassignedid-on-me.md
@@ -1,0 +1,14 @@
+Bugfix: Return correct issuerAssignedId on /me
+
+The `/graph/v1.0/me` endpoint reported the internal user UUID as
+`identities[].issuerAssignedId` instead of the issuer-assigned identity (the
+OIDC `sub`). The endpoint took a fast path that built the user model from the
+CS3 user in the request context, which does not carry the external identity, so
+it fell back to the internal UUID. `/me` now always resolves the user through
+the identity backend, which reads the stored external identity and returns the
+correct value. Group memberships are still only expanded when
+`$expand=memberOf` is requested.
+
+https://github.com/owncloud/ocis/pull/12727
+https://github.com/owncloud/ocis/pull/12431
+https://github.com/owncloud/ocis/pull/12411

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -62,22 +62,22 @@ func (g Graph) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var me *libregraph.User
-	// We can just return the user from context unless we need to expand the group memberships
-	if !slices.Contains(exp, "memberOf") {
-		me = identity.CreateUserModelFromCS3(u)
-	} else {
-		var err error
-		logger.Debug().Msg("calling get user on backend")
-		me, err = g.identityBackend.GetUser(r.Context(), u.GetId().GetOpaqueId(), odataReq)
-		if err != nil {
-			logger.Debug().Err(err).Interface("user", u).Msg("could not get user from backend")
-			errorcode.RenderError(w, r, err)
-			return
-		}
-		if me.MemberOf == nil {
-			me.MemberOf = []libregraph.Group{}
-		}
+	// Always resolve the user through the identity backend. The CS3 user from
+	// the request context does not carry the issuer-assigned identity (OIDC
+	// sub), so building the model from it (CreateUserModelFromCS3) would report
+	// the internal user UUID as identities[].issuerAssignedId. The backend reads
+	// the stored external identity and returns the correct value. Group
+	// memberships are only expanded (and thus only queried) when $expand=memberOf
+	// is requested, so the extra cost here is a single user lookup.
+	logger.Debug().Msg("calling get user on backend")
+	me, err := g.identityBackend.GetUser(r.Context(), u.GetId().GetOpaqueId(), odataReq)
+	if err != nil {
+		logger.Debug().Err(err).Interface("user", u).Msg("could not get user from backend")
+		errorcode.RenderError(w, r, err)
+		return
+	}
+	if slices.Contains(exp, "memberOf") && me.MemberOf == nil {
+		me.MemberOf = []libregraph.Group{}
 	}
 
 	// expand appRoleAssignments if requested

--- a/services/graph/pkg/service/v0/users_test.go
+++ b/services/graph/pkg/service/v0/users_test.go
@@ -115,6 +115,16 @@ var _ = Describe("Users", func() {
 			})
 
 			It("gets the information", func() {
+				user := &libregraph.User{
+					Id: libregraph.PtrString("user"),
+					Identities: []libregraph.ObjectIdentity{
+						{
+							Issuer:           libregraph.PtrString("https://idp.example.com"),
+							IssuerAssignedId: libregraph.PtrString("the-oidc-sub"),
+						},
+					},
+				}
+				identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
 				valueService.On("GetValueByUniqueIdentifiers", mock.Anything, mock.Anything, mock.Anything).
 					Return(&settings.GetValueResponse{
 						Value: &settingsmsg.ValueWithIdentifier{
@@ -139,6 +149,19 @@ var _ = Describe("Users", func() {
 				svc.GetMe(rr, r)
 
 				Expect(rr.Code).To(Equal(http.StatusOK))
+
+				data, err := io.ReadAll(rr.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				responseUser := &libregraph.User{}
+				err = json.Unmarshal(data, &responseUser)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The identity (issuerAssignedId, the OIDC sub) must come from the
+				// backend, not be fabricated from the internal user UUID. See
+				// OCISDEV-751.
+				Expect(responseUser.GetIdentities()).To(HaveLen(1))
+				Expect(responseUser.GetIdentities()[0].GetIssuerAssignedId()).To(Equal("the-oidc-sub"))
 			})
 
 			It("expands the memberOf", func() {
@@ -193,6 +216,10 @@ var _ = Describe("Users", func() {
 						RoleId:      "some-appRole-ID",
 					},
 				}
+				user := &libregraph.User{
+					Id: libregraph.PtrString("user"),
+				}
+				identityBackend.On("GetUser", mock.Anything, mock.Anything, mock.Anything).Return(user, nil)
 				roleService.On("ListRoleAssignments", mock.Anything, mock.Anything, mock.Anything).Return(&settings.ListRoleAssignmentsResponse{Assignments: assignments}, nil)
 				valueService.On("GetValueByUniqueIdentifiers", mock.Anything, mock.Anything, mock.Anything).
 					Return(&settings.GetValueResponse{


### PR DESCRIPTION
Backport of #12431 to `stable-8.2`.

The `/graph/v1.0/me` endpoint reported the internal user UUID as `identities[].issuerAssignedId` instead of the issuer-assigned identity (the OIDC `sub`). The endpoint took a fast path that built the user model from the CS3 user in the request context, which does not carry the external identity, so it fell back to the internal UUID. `/me` now always resolves the user through the identity backend, which reads the stored external identity and returns the correct value. Group memberships are still only expanded when `$expand=memberOf` is requested.

The fix shipped in 8.1.0 (#12411) and 8.0.7 (#12635), but `stable-8.2` branched off master before the master forward-port landed, so it was never picked up here. Without this, upgrading from 8.1.0 to 8.2.0 would regress the field.

The change to `services/graph/` is byte-identical to the merged master commit; only the changelog entry differs (PR reference added).

- [x] Cherry-picked cleanly, no conflicts
- [x] `go test ./pkg/service/v0/...` passes in `services/graph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)