### PR TITLE
fix(web): use centralized vault detection for nav labels

### DIFF
--- a/changelog/unreleased/bugfix-vault-nav-labels-not-updating-on-switch.md
+++ b/changelog/unreleased/bugfix-vault-nav-labels-not-updating-on-switch.md
@@ -1,0 +1,14 @@
+Bugfix: Vault navigation labels not updating on switch
+
+The Files app navigation labels for the personal space and spaces list
+sometimes kept showing the regular names instead of the vault-specific
+ones after switching into the vault, and vice versa. This happened
+because the vault detection only looked at the plain URL path and
+missed cases such as hash-based routes or the redirect right after
+logging in.
+
+The vault detection has been centralized and now also recognizes
+hash-based vault routes and the post-login redirect target, so the
+navigation labels correctly reflect whether the user is in the vault.
+
+https://github.com/owncloud/ocis/pull/12729

--- a/web/packages/web-app-files/src/index.ts
+++ b/web/packages/web-app-files/src/index.ts
@@ -14,7 +14,8 @@ import {
   useCapabilityStore,
   useEmbedMode,
   useSpacesStore,
-  useUserStore
+  useUserStore,
+  useVault
 } from '@ownclouders/web-pkg'
 import { extensions } from './extensions'
 import { buildRoutes } from '@ownclouders/web-pkg'
@@ -40,8 +41,7 @@ const appInfo: ApplicationInformation = {
 }
 
 export const navItems = (context: ComponentCustomProperties): AppNavigationItem[] => {
-  const currentPath = window.location.pathname
-  const isVault = currentPath.startsWith('/vault')
+  const { isInVault } = useVault()
   const spacesStores = useSpacesStore()
   const userStore = useUserStore()
   const capabilityStore = useCapabilityStore()
@@ -50,7 +50,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
   return [
     {
       name() {
-        return isVault ? $gettext('Safe-Personal') : $gettext('Personal')
+        return isInVault ? $gettext('Safe-Personal') : $gettext('Personal')
       },
       icon: appInfo.icon,
       route: {
@@ -103,7 +103,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       priority: 30
     },
     {
-      name: isVault ? $gettext('Safe-Spaces') : $gettext('Spaces'),
+      name: isInVault ? $gettext('Safe-Spaces') : $gettext('Spaces'),
       icon: 'layout-grid',
       route: {
         path: `/${appInfo.id}/spaces/projects`


### PR DESCRIPTION
## Description
The Files app navigation used `window.location.pathname.startsWith('/vault')` directly to decide whether to show the vault-specific labels ("Safe-Personal" / "Safe-Spaces") or the regular ones ("Personal" / "Spaces"). This check missed hash-based vault routes and the post-login redirect target stored during the OIDC callback, so the nav labels sometimes did not reflect the actual vault state after switching or after logging in. This change replaces the local path check with the existing `useVault` composable from `web-pkg`, which centralizes vault detection and also covers hash-based routes and the post-login redirect case.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1077

## Motivation and Context
Users switching into or out of the vault could see stale navigation labels (e.g. still showing "Personal"/"Spaces" while inside the vault, or vice versa), which is confusing and makes it harder to tell which mode is active. Centralizing the detection in `useVault` fixes the inconsistency and avoids duplicating vault-detection logic across the web apps.

## How Has This Been Tested?
- test environment: local oCIS web dev setup with the vault extension enabled
- test case 1: navigate to `/vault` directly and verify the Files app nav shows "Safe-Personal" and "Safe-Spaces"
- test case 2: navigate to a regular (non-vault) route and verify the nav shows "Personal" and "Spaces"
- test case 3: log in and get redirected into the vault via the post-login redirect and verify the nav labels correctly show the vault variants after the OIDC callback

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
