### PR TITLE
Fix/ocisdev 1165/resource with same name gets prefix on share

### DIFF
--- a/changelog/unreleased/bump-reva.md
+++ b/changelog/unreleased/bump-reva.md
@@ -8,3 +8,4 @@ https://github.com/owncloud/ocis/pull/12137
 https://github.com/owncloud/ocis/pull/12302
 https://github.com/owncloud/ocis/pull/12439
 https://github.com/owncloud/ocis/pull/12266
+https://github.com/owncloud/ocis/pull/TODO

--- a/changelog/unreleased/bump-reva.md
+++ b/changelog/unreleased/bump-reva.md
@@ -8,4 +8,4 @@ https://github.com/owncloud/ocis/pull/12137
 https://github.com/owncloud/ocis/pull/12302
 https://github.com/owncloud/ocis/pull/12439
 https://github.com/owncloud/ocis/pull/12266
-https://github.com/owncloud/ocis/pull/TODO
+https://github.com/owncloud/ocis/pull/12730

--- a/changelog/unreleased/fix-vault-share-mountpoint-collision.md
+++ b/changelog/unreleased/fix-vault-share-mountpoint-collision.md
@@ -1,0 +1,12 @@
+Bugfix: Do not collide vault and non-vault share mountpoints
+
+Received shares mounted from the Vault storage and received shares mounted
+from regular drives were treated as one flat namespace when computing a
+unique mountpoint name. Sharing a resource with the same name once from a
+regular drive and once from the Vault caused the second one to get a
+spurious ` (1)` suffix, even though the two shares are rendered in
+completely separate, segregated lists and never actually collide.
+Mountpoint name collisions are now only checked against other shares within
+the same vault/non-vault group.
+
+https://github.com/owncloud/ocis/pull/12730

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/open-policy-agent/opa v1.18.2
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
-	github.com/owncloud/reva/v2 v2.0.0-20260805070924-99e16422505f
+	github.com/owncloud/reva/v2 v2.0.0-20260805165023-441d6e77b33d
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245 h1:JRidLTAKhnvyLMRtVtSF4lhBa0NSAOs6fof+d6JnKII=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20260805070924-99e16422505f h1:8hdtqKeMvuTIdSLWYktyxTWihn35ol5KsKAKub3Tpe0=
-github.com/owncloud/reva/v2 v2.0.0-20260805070924-99e16422505f/go.mod h1:XBnHPPDOGYq+Uf/PD1wGXne3xTvoghBxXPUULcSZjlc=
+github.com/owncloud/reva/v2 v2.0.0-20260805165023-441d6e77b33d h1:auQ960+PZrtSuX67xizNIhP1PPgYsL/mt/1Ea9NMtO4=
+github.com/owncloud/reva/v2 v2.0.0-20260805165023-441d6e77b33d/go.mod h1:XBnHPPDOGYq+Uf/PD1wGXne3xTvoghBxXPUULcSZjlc=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.12 h1:DVJJTFMDlSAdO46yisPF2vzozs/r+4k6ih8MVghq78M=

--- a/vendor/github.com/owncloud/reva/v2/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/vendor/github.com/owncloud/reva/v2/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -661,6 +661,7 @@ func getMountpointAndUnmountedShares(ctx context.Context, receivedShares []*coll
 	mount := base
 	existingMountpoint := ""
 	mountedShares := make([]string, 0, len(receivedShares))
+	newShareInVault := id.GetStorageId() == utils.VaultStorageProviderID
 	var pathExists bool
 	var err error
 
@@ -684,6 +685,14 @@ func getMountpointAndUnmountedShares(ctx context.Context, receivedShares []*coll
 		if resourceIDEqual && s.State != collaboration.ShareState_SHARE_STATE_ACCEPTED {
 			// a share to the resource already exists but is not mounted, collect the unmounted share
 			unmountedShares = append(unmountedShares, s)
+		}
+
+		// vault and non-vault shares are rendered in separate, segregated lists (see
+		// pkg/storage/registry/spaces/spaces.go), so name collisions must only be checked
+		// against mountpoints within the same list, not across both.
+		existingShareInVault := s.GetShare().GetResourceId().GetStorageId() == utils.VaultStorageProviderID
+		if existingShareInVault != newShareInVault {
+			continue
 		}
 
 		if s.State == collaboration.ShareState_SHARE_STATE_ACCEPTED {

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -234,6 +234,12 @@ func New(o *options.Options, aspects aspects.Aspects, log *zerolog.Logger) (stor
 		aspects.UserMapper = &usermapper.NullMapper{}
 	}
 
+	// posix has no disable_versioning config key and sets this on the aspects only.
+	// One-directional: a driver that cannot keep revisions overrides the preference.
+	if aspects.DisableVersioning {
+		o.DisableVersioning = true
+	}
+
 	fs := &Decomposedfs{
 		tp:              aspects.Tree,
 		lu:              aspects.Lookup,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1316,7 +1316,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260805070924-99e16422505f
+# github.com/owncloud/reva/v2 v2.0.0-20260805165023-441d6e77b33d
 ## explicit; go 1.26
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
## Description
Bumps the vendored `reva` version to pull in a fix for received-share mountpoint naming. Previously, mountpoint name uniqueness was computed across a single flat namespace of all received shares, regardless of whether they came from the Vault storage or from regular drives. Sharing a resource with the same name once from a regular drive and once from the Vault caused the second share to get a spurious ` (1)` suffix in its mountpoint name, even though Vault and non-vault shares are rendered in completely separate, segregated lists in the UI and never actually collide. Mountpoint name collisions are now only checked against other shares within the same vault/non-vault group.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1165

## Motivation and Context
Users sharing a file or folder with the same name to both a regular drive and the Vault saw the second share unexpectedly renamed with a `(1)` suffix, which is confusing since the two shares never actually appear together or conflict in any list.

## How Has This Been Tested?
- test environment: local build against the bumped reva dependency
- test case 1: `go mod vendor` regenerates cleanly and `go build ./...` succeeds with the new reva version
- test case 2 (manual, still to do): share a resource with the same name once to a regular drive and once to the Vault, verify both mountpoints keep their original name without a `(1)` suffix
- test case 3 (manual, still to do): share two resources with the same name twice within the same group (both vault or both non-vault), verify the second one still correctly receives a `(1)` suffix

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
