### PR TITLE
fix(web): [OCISDEV-1168] open files whose name contains a hash or question mark

### DIFF
--- a/changelog/unreleased/fix-open-files-with-special-characters-in-name.md
+++ b/changelog/unreleased/fix-open-files-with-special-characters-in-name.md
@@ -1,0 +1,17 @@
+Bugfix: Open files whose name contains a hash or question mark
+
+Cmd+Clicking or middle-clicking a file with a `#` or `?` in its name opened the
+space root instead of the file, and the top bar showed the space name rather than
+the file name. The file's path is carried in a route parameter which the router
+percent-encodes when it builds the URL, but the editor route was resolved twice
+and resolving twice does not encode twice: the second pass rebuilt the URL from
+the still-decoded parameter with the encoding step skipped. The browser then read
+everything from the `#` onward as a fragment, discarding the query string along
+with the `fileId` needed to identify the file. Left clicks were unaffected because
+they never leave the app.
+
+Editor routes are now handed to links unresolved, so the file name is encoded
+exactly once and survives both a new tab and an in-app navigation. Hash and
+question mark remain valid characters in file names.
+
+https://github.com/owncloud/ocis/pull/12740

--- a/web/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/web/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -205,8 +205,7 @@ export const useFileActions = () => {
   }) => {
     const remoteItemId = isShareSpaceResource(space) ? space.id : undefined
     const routeName = appFileExtension.routeName || appFileExtension.app
-    const routeOpts = getEditorRouteOpts(routeName, space, resource, mode, remoteItemId)
-    return router.resolve(routeOpts)
+    return getEditorRouteOpts(routeName, space, resource, mode, remoteItemId)
   }
   const getEditorRouteOpts = (
     routeName: RouteRecordName,

--- a/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
@@ -3,7 +3,8 @@ import { Action, FileActionOptions, useFileActions } from '../../../../../src/co
 import {
   defaultComponentMocks,
   RouteLocation,
-  getComposableWrapper
+  getComposableWrapper,
+  createRouter
 } from '@ownclouders/web-test-helpers'
 import { computed, unref } from 'vue'
 import { describe } from 'vitest'
@@ -57,6 +58,27 @@ describe('fileActions', () => {
       })
     })
   })
+  describe('editor action "route"', () => {
+    it.each([
+      ['#.txt', '/personal%2Fadmin%2F%23.txt'],
+      ['a?b.txt', '/personal%2Fadmin%2Fa%3Fb.txt'],
+      ['a#b?c.txt', '/personal%2Fadmin%2Fa%23b%3Fc.txt']
+    ])('percent-encodes "%s" when the router resolves the route', (fileName, expectedPath) => {
+      getWrapper({
+        setup: ({ editorActions }) => {
+          const [textEditor] = unref(editorActions)
+          const route = (textEditor as Action<FileActionOptions>).route({
+            space: mock<SpaceResource>({
+              getDriveAliasAndItem: () => `personal/admin/${fileName}`
+            }),
+            resources: [mock<Resource>({ path: `/${fileName}`, extension: 'txt' })]
+          })
+
+          expect(createTextEditorRouter().resolve(route).path).toEqual(expectedPath)
+        }
+      })
+    })
+  })
   describe('secure view context', () => {
     describe('computed property "editorActions"', () => {
       it('only displays editors that support secure view', () => {
@@ -82,6 +104,14 @@ describe('fileActions', () => {
     })
   })
 })
+
+function createTextEditorRouter() {
+  return createRouter({
+    routes: [
+      { path: '/:driveAliasAndItem(.*)?', name: 'text-editor', component: { template: '<div />' } }
+    ]
+  })
+}
 
 function getWrapper({
   setup,


### PR DESCRIPTION
## Description

Cmd+Clicking (or middle-clicking) a file with a `#` in its name opened the space root instead of the file, and the top bar showed the space name rather than the file name. Files containing a `?` were affected in the same way.

A file's path is carried in a route parameter, which the router percent-encodes when it builds the URL. That encoding was lost because the route was resolved twice, and resolving twice does not encode twice: the second pass rebuilt the URL from the parameter again, but with the encoding step skipped. For a file named `#.txt`:

* **First resolve:** parameter `personal/admin/#.txt` is encoded, then glued into a URL, giving `/text-editor/personal/admin/%23.txt?fileId=abc123` — correct. The resolved route it returns still carries the parameter in decoded form.
* **Second resolve:** the finished URL is discarded and rebuilt from that decoded parameter, this time without encoding, giving `/text-editor/personal/admin/#.txt?fileId=abc123`.

The browser then reads everything from the `#` onward as a fragment, so the path became `/text-editor/personal/admin/` and the whole query string — including the `fileId` needed to identify the file — was discarded before the app ever saw it. Plain left clicks appeared to work only because they never leave the app, letting it recover the file from that parameter.

`getEditorRoute` in `useFileActions.ts` now returns the raw route options instead of a pre-resolved route, so links receive them unresolved and the file name is encoded exactly once. `<router-link>` resolves internally, which is the single encoding pass. Hash and question mark remain valid characters in file names.

Affected consumers all funnel through this one producer (`ResourceTable` → `ResourceListItem` → `ResourceLink`, plus `ActionMenuItem` in the sidebar), so no component changes were needed.

## Related Issue
- Fixes OCISDEV-1168

## Motivation and Context

Files with a `#` or `?` in the name could not be opened in a new tab at all — the malformed href silently dropped the `fileId`, leaving the app with nothing to resolve. Banning these characters was considered and rejected: existing files would stay broken, and desktop sync and WebDAV bypass web-side validation anyway. Preventing the malformed href addresses every entry point.

## How Has This Been Tested?

- test environment: local oCIS instance
- test case 1: file with `#` in its name — Cmd+Click / middle-click opens the correct file in a new tab, and the top bar shows the file name
- test case 2: file with `?` in its name — same
- test case 3: folders with `#` and `?` in the name — open correctly (folders route through a different producer, `folderLinkUtils.getFolderLink`, which this change does not touch; checked for no regression)
- test case 4: unit tests, see the checklist below

## Screenshots (if appropriate):

N.A.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>

Unit test added in `useFileActions.spec.ts` resolves the action's route through a real vue-router built from the same route definition `web-app-text-editor` registers, and asserts the encoded path for `#.txt`, `a?b.txt` and `a#b?c.txt`. Verified to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

