### PR TITLE
[tests-only][full-ci] test(cli): add acceptance tests for the search optimize command

### DIFF
--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -294,6 +294,19 @@ class CliContext implements Context {
 	}
 
 	/**
+	 * @When the administrator optimizes the search index using the CLI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorOptimizesTheSearchIndexUsingTheCli(): void {
+		$command = "search optimize";
+		$body = [
+			"command" => $command,
+		];
+		$this->featureContext->setResponse(CliHelper::runCommand($body));
+	}
+
+	/**
 	 * @When the administrator removes the file versions of space :space using the CLI
 	 *
 	 * @param string $space

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -67,6 +67,7 @@ class SearchContext implements Context {
 	): ResponseInterface {
 		// The search service can lag behind the rest of oCIS after a (re)start and
 		// answers with 5xx until it is ready — poll until it answers HTTP 207 first.
+		// Initial wait 3s, then retry every 2s, up to ~61s total.
 		$response = null;
 		for ($attempt = 0; $attempt < SERVICE_READY_RETRY_COUNT; $attempt++) {
 			\sleep($attempt === 0 ? 3 : 2);
@@ -90,13 +91,20 @@ class SearchContext implements Context {
 			}
 			break;
 		}
-		// Indexing is async — poll until results appear, then let the assertion
-		// steps produce the failure message if the results never show up.
 		for ($attempt = 0; $attempt < STANDARD_RETRY_COUNT; $attempt++) {
 			if ($attempt > 0) {
 				\sleep(2);
 			}
-			$response = $this->searchFiles($user, $pattern, $limit, $scopeType, $scope, $spaceName, $properties);
+			$response = $this->searchFiles(
+				$user,
+				$pattern,
+				$isVault,
+				$limit,
+				$scopeType,
+				$scope,
+				$spaceName,
+				$properties,
+			);
 			if ($this->searchResponseHasResults($response)) {
 				return $response;
 			}

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -65,11 +65,10 @@ class SearchContext implements Context {
 		?string $spaceName = null,
 		?TableNode $properties = null,
 	): ResponseInterface {
-		// Indexing is async — poll until results appear.
-		// Initial wait 3s, then retry every 2s, up to ~13s total.
-		$maxAttempts = STANDARD_RETRY_COUNT;
+		// The search service can lag behind the rest of oCIS after a (re)start and
+		// answers with 5xx until it is ready — poll until it answers HTTP 207 first.
 		$response = null;
-		for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+		for ($attempt = 0; $attempt < SERVICE_READY_RETRY_COUNT; $attempt++) {
 			\sleep($attempt === 0 ? 3 : 2);
 			$response = $this->searchFiles(
 				$user,
@@ -81,13 +80,39 @@ class SearchContext implements Context {
 				$spaceName,
 				$properties,
 			);
-			$parsed = HttpRequestHelper::parseResponseAsXml($response);
-			if (\is_array($parsed) && isset($parsed["value"]) && !empty($parsed["value"])) {
+			if ($response->getStatusCode() !== 207) {
+				continue;
+			}
+			// Service is up — return immediately if results are already there,
+			// otherwise fall through to the result-polling loop below.
+			if ($this->searchResponseHasResults($response)) {
+				return $response;
+			}
+			break;
+		}
+		// Indexing is async — poll until results appear, then let the assertion
+		// steps produce the failure message if the results never show up.
+		for ($attempt = 0; $attempt < STANDARD_RETRY_COUNT; $attempt++) {
+			if ($attempt > 0) {
+				\sleep(2);
+			}
+			$response = $this->searchFiles($user, $pattern, $limit, $scopeType, $scope, $spaceName, $properties);
+			if ($this->searchResponseHasResults($response)) {
 				return $response;
 			}
 		}
 		// return last response even if empty — let the assertion step produce the failure message
 		return $response;
+	}
+
+	/**
+	 * @param ResponseInterface $response
+	 *
+	 * @return bool
+	 */
+	private function searchResponseHasResults(ResponseInterface $response): bool {
+		$parsed = HttpRequestHelper::parseResponseAsXml($response);
+		return \is_array($parsed) && isset($parsed["value"]) && !empty($parsed["value"]);
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/SearchContext.php
+++ b/tests/acceptance/bootstrap/SearchContext.php
@@ -40,9 +40,10 @@ class SearchContext implements Context {
 	private FeatureContext $featureContext;
 
 	/**
-	 * Retry search until results are non-empty or timeout is reached.
-	 * Indexing of newly uploaded files in ocis is async, so a single
-	 * fixed sleep is not reliable — poll instead.
+	 * Search until the results show up.
+	 *
+	 * After a (re)start the search service answers with 5xx until it is ready,
+	 * and indexing of new uploads is async, so poll for both.
 	 *
 	 * @param string $user
 	 * @param string $pattern
@@ -65,51 +66,41 @@ class SearchContext implements Context {
 		?string $spaceName = null,
 		?TableNode $properties = null,
 	): ResponseInterface {
-		// The search service can lag behind the rest of oCIS after a (re)start and
-		// answers with 5xx until it is ready — poll until it answers HTTP 207 first.
-		// Initial wait 3s, then retry every 2s, up to ~61s total.
-		$response = null;
+		$search = fn (): ResponseInterface => $this->searchFiles(
+			$user,
+			$pattern,
+			$isVault,
+			$limit,
+			$scopeType,
+			$scope,
+			$spaceName,
+			$properties,
+		);
+
 		for ($attempt = 0; $attempt < SERVICE_READY_RETRY_COUNT; $attempt++) {
-			\sleep($attempt === 0 ? 3 : 2);
-			$response = $this->searchFiles(
-				$user,
-				$pattern,
-				$isVault,
-				$limit,
-				$scopeType,
-				$scope,
-				$spaceName,
-				$properties,
-			);
-			if ($response->getStatusCode() !== 207) {
-				continue;
+			\sleep($attempt === 0 ? SEARCH_INDEXING_INITIAL_WAIT_SEC : STANDARD_REQUEST_POLLING_INTERVAL_SEC);
+			$response = $search();
+			// 5xx means the service is still starting up
+			if ($response->getStatusCode() < 500) {
+				break;
 			}
-			// Service is up — return immediately if results are already there,
-			// otherwise fall through to the result-polling loop below.
-			if ($this->searchResponseHasResults($response)) {
-				return $response;
-			}
-			break;
 		}
-		for ($attempt = 0; $attempt < STANDARD_RETRY_COUNT; $attempt++) {
-			if ($attempt > 0) {
-				\sleep(2);
-			}
-			$response = $this->searchFiles(
-				$user,
-				$pattern,
-				$isVault,
-				$limit,
-				$scopeType,
-				$scope,
-				$spaceName,
-				$properties,
-			);
+
+		// a client error or an existing result cannot change by polling
+		if ($response->getStatusCode() >= 400 || $this->searchResponseHasResults($response)) {
+			return $response;
+		}
+
+		// indexing is async, so poll for the results
+		for ($attempt = 0; $attempt < MAX_REQUEST_RETRY_COUNT; $attempt++) {
+			\sleep(STANDARD_REQUEST_POLLING_INTERVAL_SEC);
+			$response = $search();
 			if ($this->searchResponseHasResults($response)) {
 				return $response;
 			}
 		}
-		// return last response even if empty — let the assertion step produce the failure message
+
+		// let the assertion step report an empty result
 		return $response;
 	}
 

--- a/tests/acceptance/bootstrap/bootstrap.php
+++ b/tests/acceptance/bootstrap/bootstrap.php
@@ -101,3 +101,8 @@ if (!\defined('MAX_REQUEST_RETRY_COUNT')) {
 if (!\defined('STANDARD_REQUEST_POLLING_INTERVAL_SEC')) {
 	\define('STANDARD_REQUEST_POLLING_INTERVAL_SEC', 1);
 }
+
+// Number of times to poll for a service to become ready after a (re)start.
+if (!\defined('SERVICE_READY_RETRY_COUNT')) {
+	\define('SERVICE_READY_RETRY_COUNT', 30);
+}

--- a/tests/acceptance/bootstrap/bootstrap.php
+++ b/tests/acceptance/bootstrap/bootstrap.php
@@ -102,7 +102,15 @@ if (!\defined('STANDARD_REQUEST_POLLING_INTERVAL_SEC')) {
 	\define('STANDARD_REQUEST_POLLING_INTERVAL_SEC', 1);
 }
 
+// Seconds to wait before the first search, so that async indexing can complete.
+// Polling alone cannot cover this: a search returns as soon as the first result
+// is indexed, which would assert against a partially indexed result.
+if (!\defined('SEARCH_INDEXING_INITIAL_WAIT_SEC')) {
+	\define('SEARCH_INDEXING_INITIAL_WAIT_SEC', 3);
+}
+
 // Number of times to poll for a service to become ready after a (re)start.
+// Polled at STANDARD_REQUEST_POLLING_INTERVAL_SEC, so this allows about a minute.
 if (!\defined('SERVICE_READY_RETRY_COUNT')) {
-	\define('SERVICE_READY_RETRY_COUNT', 30);
+	\define('SERVICE_READY_RETRY_COUNT', 60);
 }

--- a/tests/acceptance/features/cliCommands/searchOptimize.feature
+++ b/tests/acceptance/features/cliCommands/searchOptimize.feature
@@ -1,0 +1,22 @@
+@env-config
+Feature: optimize search index via CLI command
+  As an administrator
+  I want to optimize the search index
+  So that I can improve search query performance
+
+
+  Scenario: optimize the search index
+    Given the administrator has cleaned the search service data
+    And user "Alice" has been created with default attributes
+    And using spaces DAV path
+    And user "Alice" has uploaded file with content "some data" to "textfile.txt"
+    And the administrator reindexes all spaces using the CLI
+    And the administrator has stopped the server
+    When the administrator optimizes the search index using the CLI
+    Then the command should be successful
+    And the command output should contain "index optimization complete"
+    When the administrator starts the server
+    And user "Alice" searches for "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /textfile.txt |

--- a/tests/acceptance/features/cliCommands/searchOptimize.feature
+++ b/tests/acceptance/features/cliCommands/searchOptimize.feature
@@ -4,13 +4,17 @@ Feature: optimize search index via CLI command
   I want to optimize the search index
   So that I can improve search query performance
 
+  Background:
+    Given the administrator has cleaned the search service data
+
 
   Scenario: optimize the search index
-    Given the administrator has cleaned the search service data
-    And user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes
     And using spaces DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile.txt"
-    And the administrator reindexes all spaces using the CLI
+    When the administrator reindexes all spaces using the CLI
+    And user "Alice" searches for "textfile.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
     And the administrator has stopped the server
     When the administrator optimizes the search index using the CLI
     Then the command should be successful
@@ -20,3 +24,10 @@ Feature: optimize search index via CLI command
     Then the HTTP status code should be "207"
     And the search result of user "Alice" should contain only these entries:
       | /textfile.txt |
+
+
+  Scenario: optimize the search index without any indexed content
+    Given the administrator has stopped the server
+    When the administrator optimizes the search index using the CLI
+    Then the command should be successful
+    And the command output should contain "index optimization complete"

--- a/tests/acceptance/features/cliCommands/searchOptimize.feature
+++ b/tests/acceptance/features/cliCommands/searchOptimize.feature
@@ -13,8 +13,11 @@ Feature: optimize search index via CLI command
     And using spaces DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile.txt"
     When the administrator reindexes all spaces using the CLI
-    And user "Alice" searches for "textfile.txt" using the WebDAV API
+    Then the command should be successful
+    When user "Alice" searches for "textfile.txt" using the WebDAV API
     Then the HTTP status code should be "207"
+    And the search result of user "Alice" should contain only these entries:
+      | /textfile.txt |
     And the administrator has stopped the server
     When the administrator optimizes the search index using the CLI
     Then the command should be successful


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

Adds acceptance tests for the new `ocis search optimize` CLI command ([#12136](https://github.com/owncloud/ocis/pull/12136)), which compacts the Bleve search index without re-indexing content.

## What's included

- New feature file `tests/acceptance/features/cliCommands/searchOptimize.feature` with two scenarios:
  - **optimize the search index**: covers the full contract: clean index -> reindex -> baseline search (207) -> stop server -> optimize -> start server -> file still searchable with exact expected results. The baseline search before optimizing isolates failures (reindex problem vs optimize problem).
  - **optimize the search index without any indexed content**: verifies the command succeeds and prints `index optimization complete` on an empty index. No reindex and no search assertions, because optimize compacts segments, it does not index content.
- Reliability fix: `searchWithRetry` in `SearchContext.php` is now two-phase. It polls until the search service answers HTTP 207 after a restart (~63s budget), then polls for results (~13s). This removes the flaky fixed-sleep pattern that failed after server restarts while keeping the old fast path for scenarios that never restart anything.
- New config constant `SERVICE_READY_RETRY_COUNT` in `bootstrap.php`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
