### PR TITLE
feat(storage-users): add recalculate-treesize command

### DIFF
--- a/changelog/unreleased/enhancement-recalculate-treesize.md
+++ b/changelog/unreleased/enhancement-recalculate-treesize.md
@@ -1,0 +1,21 @@
+Enhancement: Add a command to recalculate the treesize of a space
+
+The reported quota usage of a space can drift from the data actually stored on
+disk. The treesize of a directory is maintained as a running counter that is
+updated on every change, so a failed or incomplete update leaves the counter
+wrong. Removing a node without propagating the size change, for example, leaves
+its size counted against the quota forever, with no way to reclaim it.
+
+The new command walks a space bottom up, recalculates the treesize of every
+directory from the actual size of its children and corrects the stored values:
+
+```
+ocis storage-users spaces recalculate-treesize --space-id <id>
+ocis storage-users spaces recalculate-treesize --space-id <id> --dry-run=false
+```
+
+Omit `--space-id` to process all spaces. As with the other maintenance commands,
+`--dry-run` defaults to true, so the command reports what it would change until
+it is explicitly told to write.
+
+https://github.com/owncloud/ocis/pull/12746

--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -181,6 +181,45 @@ OPTIONS:
    --help, -h       show help
 ```
 
+Note that removing a stale node does not reclaim the quota it consumed. Use the
+Recalculate Treesize command afterwards to correct the reported quota usage of the space.
+
+#### Recalculate Treesize command
+
+The treesize of a directory is maintained as a running counter that is updated on every
+change, so a failed or incomplete update leaves the counter wrong and the reported quota
+usage of a space drifts from the data actually stored on disk. This command walks a space
+bottom up, recalculates the treesize of every directory from the actual size of its
+children and corrects the stored values.
+
+```bash
+    ~/ocis storage-users spaces recalculate-treesize <commandoptions>
+```
+```
+NAME:
+   ocis storage-users spaces recalculate-treesize - Recalculate the treesize of all directories in a space from the actual size of their children. Use this to repair a space whose reported quota usage drifted from the data on disk
+
+USAGE:
+   ocis storage-users spaces recalculate-treesize [command options]
+
+OPTIONS:
+   --space-id value, -s value  Space ID to recalculate (omit to process all spaces)
+   --dry-run                   Only show which treesizes would be corrected without writing them (default: true)
+   --verbose, -v               Enable verbose logging (default: false)
+   --help, -h                  show help
+```
+
+```bash
+# report incorrect treesizes of a single space without changing anything
+ocis storage-users spaces recalculate-treesize --space-id 43972c79-f7ce-441b-9fe0-cf5170e4d61e
+
+# correct them
+ocis storage-users spaces recalculate-treesize --space-id 43972c79-f7ce-441b-9fe0-cf5170e4d61e --dry-run=false
+```
+
+Note: the command reads the metadata of every node in the space, so it is I/O intensive on
+large spaces. Prefer targeting a single space with `--space-id` over processing all spaces.
+
 #### Command Examples
 
 Dry run to see what would be deleted (recommended first step)

--- a/services/storage-users/pkg/command/spaces.go
+++ b/services/storage-users/pkg/command/spaces.go
@@ -33,6 +33,7 @@ func Spaces(cfg *config.Config) *cli.Command {
 		Usage: "manage spaces",
 		Subcommands: []*cli.Command{
 			PurgeDisabledSpaces(cfg),
+			RecalculateTreesize(cfg),
 		},
 	}
 }

--- a/services/storage-users/pkg/command/treesize.go
+++ b/services/storage-users/pkg/command/treesize.go
@@ -1,0 +1,222 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/owncloud/ocis/v2/ocis-pkg/config/configlog"
+	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config"
+	"github.com/owncloud/ocis/v2/services/storage-users/pkg/config/parser"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/lookup"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	"github.com/shamaton/msgpack/v2"
+	"github.com/urfave/cli/v2"
+)
+
+// metadataExtension is the suffix of the messagepack metadata file of a node
+const metadataExtension = ".mpk"
+
+// RecalculateTreesize is the entry point for the recalculate-treesize command
+func RecalculateTreesize(cfg *config.Config) *cli.Command {
+	return &cli.Command{
+		Name: "recalculate-treesize",
+		Usage: "Recalculate the treesize of all directories in a space from the actual size of their children. " +
+			"Use this to repair a space whose reported quota usage drifted from the data on disk",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "space-id",
+				Usage:    "Space ID to recalculate (omit to process all spaces)",
+				Required: false,
+				Aliases:  []string{"s"},
+			},
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Only show which treesizes would be corrected without writing them",
+				Value: true, // default must be true to avoid accidental writes!
+			},
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Usage:   "Enable verbose logging",
+				Value:   false,
+				Aliases: []string{"v"},
+			},
+		},
+		Before: func(c *cli.Context) error {
+			return configlog.ReturnFatal(parser.ParseConfig(cfg))
+		},
+		Action: func(c *cli.Context) error {
+			dryRun := c.Bool("dry-run")
+			verbose := c.Bool("verbose")
+
+			spaceIDs := []string{}
+			if c.IsSet("space-id") {
+				spaceIDs = append(spaceIDs, c.String("space-id"))
+			} else {
+				fmt.Println("Scanning all spaces for incorrect treesizes...")
+				spaceIDs = globSpaceIDs(cfg)
+			}
+
+			if dryRun {
+				fmt.Print("Dry run mode enabled, no treesize will be written\n\n")
+			}
+
+			var (
+				table     *tablewriter.Table
+				corrected int
+			)
+			table = tablewriter.NewTable(os.Stdout)
+			table.Header("Space", "Node", "Stored", "Calculated", "Difference")
+
+			for _, spaceID := range spaceIDs {
+				if verbose {
+					fmt.Printf("Recalculating treesizes for space: %s\n", spaceID)
+				}
+				root := filepath.Join(cfg.Drivers.OCIS.Root, "spaces", lookup.Pathify(spaceID, 1, 2), "nodes", lookup.Pathify(spaceID, 4, 2))
+				_, n, err := recalculateNode(cfg, spaceID, root, dryRun, verbose, table)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error recalculating space %s: %s\n", spaceID, err)
+					continue
+				}
+				corrected += n
+			}
+
+			if corrected > 0 {
+				table.Render()
+			}
+
+			switch {
+			case corrected == 0:
+				fmt.Println("All treesizes are correct")
+			case dryRun:
+				fmt.Printf("Would correct %d treesizes. Run with --dry-run=false to apply\n", corrected)
+			default:
+				fmt.Printf("Corrected %d treesizes\n", corrected)
+			}
+
+			return nil
+		},
+	}
+}
+
+// recalculateNode calculates the size of the node at the given path. For directories it
+// recurses into the children first, so the whole subtree is corrected bottom up, and
+// compares the sum against the stored treesize. It returns the calculated size of the
+// node and the number of corrected treesizes in the subtree.
+func recalculateNode(cfg *config.Config, spaceID, path string, dryRun, verbose bool, table *tablewriter.Table) (uint64, int, error) {
+	attribs, err := readAttributes(path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Files simply report their blobsize, there is nothing to recalculate. Only an
+	// explicit file type is treated as a file, everything else is walked as a
+	// directory: a space root for example carries no type attribute at all. This
+	// matches how the propagator classifies children.
+	if string(attribs[prefixes.TypeAttr]) == strconv.FormatUint(uint64(provider.ResourceType_RESOURCE_TYPE_FILE), 10) {
+		size, err := strconv.ParseUint(string(attribs[prefixes.BlobsizeAttr]), 10, 64)
+		if err != nil {
+			// a node without a blobsize contributes nothing, but it is worth reporting
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  Could not read blobsize of %s: %s\n", path, err)
+			}
+			return 0, 0, nil
+		}
+		return size, 0, nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+
+	var (
+		calculated uint64
+		corrected  int
+	)
+	for _, entry := range entries {
+		child, err := filepath.EvalSymlinks(filepath.Join(path, entry.Name()))
+		if err != nil {
+			// dangling child entry, it contributes nothing
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  Could not resolve child %s: %s\n", entry.Name(), err)
+			}
+			continue
+		}
+		size, n, err := recalculateNode(cfg, spaceID, child, dryRun, verbose, table)
+		if err != nil {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  Could not recalculate child %s: %s\n", child, err)
+			}
+			continue
+		}
+		calculated += size
+		corrected += n
+	}
+
+	stored, storedErr := strconv.ParseUint(string(attribs[prefixes.TreesizeAttr]), 10, 64)
+	if storedErr == nil && stored == calculated {
+		return calculated, corrected, nil
+	}
+
+	storedStr := string(attribs[prefixes.TreesizeAttr])
+	if storedStr == "" {
+		storedStr = "unset"
+	}
+	diff := "n/a"
+	if storedErr == nil {
+		diff = fmt.Sprintf("%+d", int64(calculated)-int64(stored))
+	}
+	table.Append([]string{spaceID, nodeIDFromPath(path), storedStr, strconv.FormatUint(calculated, 10), diff})
+	corrected++
+
+	if !dryRun {
+		if err := writeTreesize(path, attribs, calculated); err != nil {
+			return calculated, corrected, fmt.Errorf("could not write treesize of %s: %w", path, err)
+		}
+	}
+
+	return calculated, corrected, nil
+}
+
+// readAttributes reads the messagepack metadata of the node at the given path
+func readAttributes(path string) (map[string][]byte, error) {
+	b, err := os.ReadFile(path + metadataExtension)
+	if err != nil {
+		return nil, err
+	}
+	attribs := map[string][]byte{}
+	if err := msgpack.Unmarshal(b, &attribs); err != nil {
+		return nil, err
+	}
+	return attribs, nil
+}
+
+// writeTreesize sets the treesize attribute of the node at the given path
+func writeTreesize(path string, attribs map[string][]byte, size uint64) error {
+	attribs[prefixes.TreesizeAttr] = []byte(strconv.FormatUint(size, 10))
+	b, err := msgpack.Marshal(attribs)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path+metadataExtension, b, 0600)
+}
+
+// nodeIDFromPath rebuilds the node id from a pathified node path, i.e.
+// .../nodes/5b/ba/1e/a7/-f185-4f31-8342-ed4b5743f096 -> 5bba1ea7-f185-4f31-8342-ed4b5743f096
+func nodeIDFromPath(path string) string {
+	parts := strings.Split(path, string(filepath.Separator))
+	if len(parts) < 5 {
+		return path
+	}
+	return strings.Join(parts[len(parts)-5:], "")
+}

--- a/services/storage-users/pkg/command/treesize_test.go
+++ b/services/storage-users/pkg/command/treesize_test.go
@@ -1,0 +1,180 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	"github.com/shamaton/msgpack/v2"
+	"github.com/test-go/testify/require"
+)
+
+// writeNode creates a node file with the given attributes on disk
+func writeNode(t *testing.T, path string, attribs map[string][]byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	b, err := msgpack.Marshal(attribs)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path+metadataExtension, b, 0600))
+}
+
+// writeFileNode creates a file node with the given blobsize. The node file itself
+// has to exist as well, decomposedfs resolves children through it.
+func writeFileNode(t *testing.T, path string, blobsize int) {
+	t.Helper()
+	writeNode(t, path, map[string][]byte{
+		prefixes.TypeAttr:     []byte(strconv.FormatUint(uint64(provider.ResourceType_RESOURCE_TYPE_FILE), 10)),
+		prefixes.BlobsizeAttr: []byte(strconv.Itoa(blobsize)),
+	})
+	require.NoError(t, os.WriteFile(path, []byte{}, 0600))
+}
+
+// writeDirNode creates a directory node with the given stored treesize
+func writeDirNode(t *testing.T, path string, treesize int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(path, 0700))
+	writeNode(t, path, map[string][]byte{
+		prefixes.TypeAttr:     []byte(strconv.FormatUint(uint64(provider.ResourceType_RESOURCE_TYPE_CONTAINER), 10)),
+		prefixes.TreesizeAttr: []byte(strconv.Itoa(treesize)),
+	})
+}
+
+// storedTreesize reads back the treesize attribute of a node
+func storedTreesize(t *testing.T, path string) string {
+	t.Helper()
+	attribs, err := readAttributes(path)
+	require.NoError(t, err)
+	return string(attribs[prefixes.TreesizeAttr])
+}
+
+// linkChild links a child node into a parent directory, mirroring how decomposedfs
+// references children by symlink
+func linkChild(t *testing.T, parent, child, name string) {
+	t.Helper()
+	rel, err := filepath.Rel(parent, child)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(rel, filepath.Join(parent, name)))
+}
+
+func TestRecalculateNode(t *testing.T) {
+	t.Run("corrects a wrong treesize", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		writeDirNode(t, dir, 999)
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 100)
+		linkChild(t, dir, f, "file")
+
+		size, corrected, err := recalculateNode(nil, "spaceid", dir, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(100), size)
+		require.Equal(t, 1, corrected)
+		require.Equal(t, "100", storedTreesize(t, dir))
+	})
+
+	t.Run("leaves a correct treesize untouched", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		writeDirNode(t, dir, 100)
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 100)
+		linkChild(t, dir, f, "file")
+
+		size, corrected, err := recalculateNode(nil, "spaceid", dir, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(100), size)
+		require.Equal(t, 0, corrected)
+	})
+
+	t.Run("does not write in dry-run mode", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		writeDirNode(t, dir, 999)
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 100)
+		linkChild(t, dir, f, "file")
+
+		size, corrected, err := recalculateNode(nil, "spaceid", dir, true, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(100), size)
+		require.Equal(t, 1, corrected)
+		require.Equal(t, "999", storedTreesize(t, dir), "dry-run must not write the treesize")
+	})
+
+	t.Run("sums nested directories bottom up", func(t *testing.T) {
+		root := t.TempDir()
+		outer := filepath.Join(root, "outer")
+		writeDirNode(t, outer, 0)
+		inner := filepath.Join(root, "inner")
+		writeDirNode(t, inner, 0)
+		f1 := filepath.Join(root, "f1")
+		writeFileNode(t, f1, 10)
+		f2 := filepath.Join(root, "f2")
+		writeFileNode(t, f2, 32)
+
+		linkChild(t, inner, f2, "f2")
+		linkChild(t, outer, f1, "f1")
+		linkChild(t, outer, inner, "inner")
+
+		size, corrected, err := recalculateNode(nil, "spaceid", outer, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(42), size)
+		require.Equal(t, 2, corrected, "both the inner and the outer directory are corrected")
+		require.Equal(t, "32", storedTreesize(t, inner))
+		require.Equal(t, "42", storedTreesize(t, outer))
+	})
+
+	t.Run("treats a node without a type attribute as a directory", func(t *testing.T) {
+		// space roots carry no type attribute
+		root := t.TempDir()
+		spaceRoot := filepath.Join(root, "space")
+		require.NoError(t, os.MkdirAll(spaceRoot, 0700))
+		writeNode(t, spaceRoot, map[string][]byte{
+			prefixes.TreesizeAttr: []byte("999"),
+		})
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 64)
+		linkChild(t, spaceRoot, f, "file")
+
+		size, corrected, err := recalculateNode(nil, "spaceid", spaceRoot, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(64), size)
+		require.Equal(t, 1, corrected)
+		require.Equal(t, "64", storedTreesize(t, spaceRoot))
+	})
+
+	t.Run("skips dangling child links", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		writeDirNode(t, dir, 0)
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 20)
+		linkChild(t, dir, f, "file")
+		require.NoError(t, os.Symlink("../gone", filepath.Join(dir, "gone")))
+
+		size, _, err := recalculateNode(nil, "spaceid", dir, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, uint64(20), size, "the dangling entry contributes nothing")
+	})
+
+	t.Run("sets an unset treesize", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "dir")
+		require.NoError(t, os.MkdirAll(dir, 0700))
+		writeNode(t, dir, map[string][]byte{
+			prefixes.TypeAttr: []byte(strconv.FormatUint(uint64(provider.ResourceType_RESOURCE_TYPE_CONTAINER), 10)),
+		})
+		f := filepath.Join(root, "file")
+		writeFileNode(t, f, 7)
+		linkChild(t, dir, f, "file")
+
+		_, corrected, err := recalculateNode(nil, "spaceid", dir, false, false, tablewriter.NewTable(os.Stdout))
+		require.NoError(t, err)
+		require.Equal(t, 1, corrected)
+		require.Equal(t, "7", storedTreesize(t, dir))
+	})
+}


### PR DESCRIPTION
## Problem

The treesize of a directory is maintained as a running counter that is updated on every change. Any failed or incomplete update therefore leaves the counter permanently wrong, and the reported quota usage of a space drifts from the data actually stored on disk.

The clearest case: removing a node without propagating the size change leaves that size counted against the quota forever. `RevertCurrentRevision` falls back to `node.Purge` when there is no prior revision, and `Purge` removes the node, its parent child-entry and its metadata — but never calls `Propagate`.

Reproduced on a local instance: after `uploads delete-stale-nodes` removed a stuck node, the file was gone (404) but the space treesize was unchanged. The user loses both the file *and* the space it occupied, with no way to reclaim either.

There is currently no command to correct this. `storage-users` offers only `uploads`, `trash-bin` and `spaces purge`. The only workaround is a manual filesystem intervention — unset the `user.ocis.treesize` attribute in the node's messagepack metadata, restart the service to clear the metadata cache, then trigger a write so the propagator falls back to recalculating. Not something to hand to operators.

## Changes

Adds `ocis storage-users spaces recalculate-treesize`, which walks a space bottom up, recalculates the treesize of every directory from the actual size of its children, and corrects the stored values.

```bash
# report what is wrong, without changing anything
ocis storage-users spaces recalculate-treesize --space-id <id>

# correct it
ocis storage-users spaces recalculate-treesize --space-id <id> --dry-run=false
```

Omit `--space-id` to process all spaces. `--dry-run` defaults to `true`, consistent with `spaces purge` and `uploads delete-stale-nodes`. Corrections are reported in a table (space, node, stored, calculated, difference).

Implemented entirely in oCIS — no reva change required. Reuses the existing `globSpaceIDs` helper and `lookup.Pathify`.

## Notes

Reva has an equivalent calculation in `tree/propagator/propagator.go` (`calculateTreeSize`), but it is unexported *and* non-recursive — it sums the children's *stored* treesize for subdirectories rather than descending — so it is not reusable here, and the propagator's unset-attribute fallback only repairs a single level.

Worth flagging for review: nodes are classified by testing for `== RESOURCE_TYPE_FILE`, treating everything else as a directory, mirroring the propagator. The inverse test (`!= CONTAINER`) is wrong, because a space root carries no type attribute at all and would be misread as a file — which makes the whole walk return zero. This was caught in manual testing, not by the unit tests as originally written.

**Scope:** this corrects the accounting, it does not fix the underlying leak. Every future `delete-stale-nodes` run will drift again until the missing propagation in the purge path is fixed. That is tracked separately; this command is the remediation tool for spaces that are already wrong. The README notes the pairing.

## Tests

7 unit tests covering: correcting a wrong treesize, leaving a correct one untouched, dry-run not writing, bottom-up sums across nested directories, nodes without a type attribute, dangling child links, and an unset treesize.

Verified manually on a local instance: with the space root treesize corrupted to `999999999`, the command reported the correct value `517521`, corrected it, preserved all 13 metadata attributes, reported no changes on a second run, and WebDAV `quota-used-bytes` then returned `517521`.

Verified end to end on a local instance: the command detected and corrected a deliberately corrupted treesize, and the `quota-used-bytes` reported over WebDAV matched the recalculated value afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
