### PR TITLE
[tests-only][full-ci] test(apiGraphGroup): add acceptance test for configurable LDAP group object class

### DIFF
--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -380,10 +380,10 @@ trait Provisioning {
 	}
 
 	/**
-	 * Connects to the LDAP server bundled with oCIS (idm) to allow direct
+	 * Connects to the LDAP server bundled with oCIS (IDM) to allow direct
 	 * inspection of entries that oCIS services write, e.g. the objectClass
 	 * that the graph service sets on group entries. Connection parameters
-	 * match the idm defaults used by the acceptance test environment.
+	 * match the IDM defaults used by the acceptance test environment.
 	 *
 	 * @return void
 	 */
@@ -430,20 +430,24 @@ trait Provisioning {
 	 * @Then /^the LDAP entry "([^"]*)" should (not|)\s?have the object class "([^"]*)"$/
 	 *
 	 * @param string $dn
-	 * @param string $not (not|)
+	 * @param string $shouldOrNot (not|)
 	 * @param string $objectClass
 	 *
 	 * @return void
 	 */
-	public function theLdapEntryShouldHaveObjectClass(string $dn, string $not, string $objectClass): void {
+	public function theLdapEntryShouldHaveObjectClass(string $dn, string $shouldOrNot, string $objectClass): void {
 		$this->connectToIdm();
 		$entry = $this->idmLdap->getEntry($dn);
 		Assert::assertNotNull($entry, "LDAP entry '$dn' does not exist");
 		$objectClasses = \array_map('strtolower', Laminas\Ldap\Attribute::getAttribute($entry, 'objectClass'));
-		$shouldHave = ($not !== "not");
+		$shouldHave = ($shouldOrNot !== "not");
+		$message = "Expected LDAP entry '$dn' to "
+			. ($shouldHave ? 'have' : 'not have')
+			. " the object class '$objectClass', but the entry has: "
+			. \implode(', ', $objectClasses);
 		Assert::assertTrue(
 			\in_array(\strtolower($objectClass), $objectClasses, true) === $shouldHave,
-			"Expected LDAP entry '$dn' to " . ($shouldHave ? 'have' : 'not have') . " the object class '$objectClass', but the entry has: " . \implode(', ', $objectClasses),
+			$message,
 		);
 	}
 

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -365,8 +365,7 @@ trait Provisioning {
 			'baseDn' => $this->ldapBaseDN,
 			'username' => $this->ldapAdminUser,
 		];
-		$this->ldap = new Ldap($options);
-		$this->ldap->bind();
+		$this->ldap = $this->bindLdap($options);
 
 		$ldifFile = __DIR__ . $suiteParameters['ldapInitialUserFilePath'];
 		if (!$this->skipImportLdif) {
@@ -393,8 +392,17 @@ trait Provisioning {
 			return;
 		}
 		\putenv('LDAPTLS_REQCERT=never');
+		$idmHost = '';
+		$hostSourceEnvs = ['TEST_SERVER_URL', 'OCIS_WRAPPER_URL'];
+		foreach ($hostSourceEnvs as $envName) {
+			$envValue = \getenv($envName);
+			if ($envValue !== false && $envValue !== '') {
+				$idmHost = \parse_url($envValue, PHP_URL_HOST) ?: $envValue;
+				break;
+			}
+		}
 		$options = [
-			'host' => '127.0.0.1',
+			'host' => $idmHost ?: '127.0.0.1',
 			'port' => 9235,
 			'useSsl' => true,
 			'baseDn' => 'o=libregraph-idm',
@@ -402,8 +410,20 @@ trait Provisioning {
 			'username' => 'uid=admin,ou=users,o=libregraph-idm',
 			'password' => \getenv('IDM_ADMIN_PASSWORD') ?: 'admin',
 		];
-		$this->idmLdap = new Ldap($options);
-		$this->idmLdap->bind();
+		$this->idmLdap = $this->bindLdap($options);
+	}
+
+	/**
+	 * Creates a bound Ldap connection from the given options.
+	 *
+	 * @param array $options
+	 *
+	 * @return Ldap
+	 */
+	private function bindLdap(array $options): Ldap {
+		$ldap = new Ldap($options);
+		$ldap->bind();
+		return $ldap;
 	}
 
 	/**
@@ -423,7 +443,7 @@ trait Provisioning {
 		$shouldHave = ($not !== "not");
 		Assert::assertTrue(
 			\in_array(\strtolower($objectClass), $objectClasses, true) === $shouldHave,
-			"Expected LDAP entry '$dn' to " . ($shouldHave ? 'have' : 'not have') . " the object class '$objectClass'",
+			"Expected LDAP entry '$dn' to " . ($shouldHave ? 'have' : 'not have') . " the object class '$objectClass', but the entry has: " . \implode(', ', $objectClasses),
 		);
 	}
 

--- a/tests/acceptance/bootstrap/Provisioning.php
+++ b/tests/acceptance/bootstrap/Provisioning.php
@@ -48,6 +48,7 @@ trait Provisioning {
 	private array $createdGroups = [];
 	private array $userTokens = [];
 	private array $createdKeycloakUsers = [];
+	private ?Ldap $idmLdap = null;
 
 	/**
 	 * @param array $user
@@ -377,6 +378,53 @@ trait Provisioning {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Connects to the LDAP server bundled with oCIS (idm) to allow direct
+	 * inspection of entries that oCIS services write, e.g. the objectClass
+	 * that the graph service sets on group entries. Connection parameters
+	 * match the idm defaults used by the acceptance test environment.
+	 *
+	 * @return void
+	 */
+	private function connectToIdm(): void {
+		if ($this->idmLdap !== null) {
+			return;
+		}
+		\putenv('LDAPTLS_REQCERT=never');
+		$options = [
+			'host' => '127.0.0.1',
+			'port' => 9235,
+			'useSsl' => true,
+			'baseDn' => 'o=libregraph-idm',
+			'bindRequiresDn' => true,
+			'username' => 'uid=admin,ou=users,o=libregraph-idm',
+			'password' => \getenv('IDM_ADMIN_PASSWORD') ?: 'admin',
+		];
+		$this->idmLdap = new Ldap($options);
+		$this->idmLdap->bind();
+	}
+
+	/**
+	 * @Then /^the LDAP entry "([^"]*)" should (not|)\s?have the object class "([^"]*)"$/
+	 *
+	 * @param string $dn
+	 * @param string $not (not|)
+	 * @param string $objectClass
+	 *
+	 * @return void
+	 */
+	public function theLdapEntryShouldHaveObjectClass(string $dn, string $not, string $objectClass): void {
+		$this->connectToIdm();
+		$entry = $this->idmLdap->getEntry($dn);
+		Assert::assertNotNull($entry, "LDAP entry '$dn' does not exist");
+		$objectClasses = \array_map('strtolower', Laminas\Ldap\Attribute::getAttribute($entry, 'objectClass'));
+		$shouldHave = ($not !== "not");
+		Assert::assertTrue(
+			\in_array(\strtolower($objectClass), $objectClasses, true) === $shouldHave,
+			"Expected LDAP entry '$dn' to " . ($shouldHave ? 'have' : 'not have') . " the object class '$objectClass'",
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/apiGraphGroup/createGroup.feature
+++ b/tests/acceptance/features/apiGraphGroup/createGroup.feature
@@ -50,7 +50,7 @@ Feature: create group
 
   @env-config @issue-11775
   Scenario: admin creates a group with the configured LDAP group object class
-    Given the config "OCIS_LDAP_GROUP_OBJECTCLASS" has been set to "groupOfUniqueNames"
+    Given the config "OCIS_LDAP_GROUP_OBJECTCLASS" has been set to "groupOfUniqueNames" for "graph" service
     When the administrator creates a group "uniquegroup" using the Graph API
     Then the HTTP status code should be "201"
     And the LDAP entry "cn=uniquegroup,ou=groups,o=libregraph-idm" should have the object class "groupOfUniqueNames"

--- a/tests/acceptance/features/apiGraphGroup/createGroup.feature
+++ b/tests/acceptance/features/apiGraphGroup/createGroup.feature
@@ -47,3 +47,11 @@ Feature: create group
   Scenario: admin user tries to create a group that is the empty string
     When user "Alice" tries to create a group "" using the Graph API
     Then the HTTP status code should be "400"
+
+  @env-config @issue-11775
+  Scenario: admin creates a group with the configured LDAP group object class
+    Given the config "OCIS_LDAP_GROUP_OBJECTCLASS" has been set to "groupOfUniqueNames"
+    When the administrator creates a group "uniquegroup" using the Graph API
+    Then the HTTP status code should be "201"
+    And the LDAP entry "cn=uniquegroup,ou=groups,o=libregraph-idm" should have the object class "groupOfUniqueNames"
+    And the LDAP entry "cn=uniquegroup,ou=groups,o=libregraph-idm" should not have the object class "groupOfNames"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Adds an acceptance test for the graph service group creation honoring the configured LDAP group object class (issue #11775). Previously the graph service always created groups with `objectClass: groupOfNames` regardless of the `OCIS_LDAP_GROUP_OBJECTCLASS` setting.
 
## What's changed
- **`apiGraphGroup/createGroup.feature`** - new `@env-config` scenario that sets `OCIS_LDAP_GROUP_OBJECTCLASS=groupOfUniqueNames`, creates a group via the Graph API, and asserts the resulting LDAP entry has `groupOfUniqueNames` and **not** `groupOfNames`.
- **`bootstrap/Provisioning.php`** - new `@Then` step asserting an LDAP entry's object class by reading the embedded idm directly (the Graph API never returns `objectClass`).

 
## Related issue
- Test coverage for: #11775
- Part of https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
