### PR TITLE
fix(web): [OCISDEV-996] truncate long resource names instead of overlapping the next column

### DIFF
--- a/changelog/unreleased/bugfix-resource-name-column-overflow.md
+++ b/changelog/unreleased/bugfix-resource-name-column-overflow.md
@@ -1,0 +1,14 @@
+Bugfix: Truncate long resource names instead of overlapping the next column
+
+In resource tables, a name that was too long for its column was not truncated.
+Instead it kept its full width and was painted over the value of the adjacent
+column, making both unreadable. This was most visible in the Spaces overview,
+where a long space name overlapped the "Manager" column, but it affected every
+resource table using the name column, including the files list and search
+results, as well as the parent folder path shown below a search result.
+
+The name is now truncated with an ellipsis at the column boundary, and the
+rename button stays inside the name column. The full name remains available via
+the title tooltip on hover.
+
+https://github.com/owncloud/ocis/pull/12754

--- a/web/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -189,6 +189,7 @@ const tooltipLabelIcon = computed(() => {
   display: inline-flex;
   justify-content: flex-start;
   overflow: visible !important;
+  min-width: 0;
 
   &-no-interaction {
     pointer-events: none;


### PR DESCRIPTION
## Description

In resource tables, a name too long for its column was not truncated. It kept its full width and was painted over the adjacent column's value, making both unreadable.

`.oc-resource` is an `inline-flex` container. As a flex item it had an automatic `min-width: auto`, which floors the element at its min-content width and prevents it from shrinking. The existing `oc-text-truncate` rule on the name span therefore never had a constrained width to truncate against.

This adds `min-width: 0` to `.oc-resource`, letting the element shrink below its content width so the name truncates with an ellipsis at the column boundary. The full name remains available via the title tooltip on hover.

Most visible in the Spaces overview, where a long space name overlapped the "Manager" column, but it affected every resource table using the name column, including the files list and search results.

## Related Issue
- Fixes OCISDEV-996

## Motivation and Context

N.A.

## How Has This Been Tested?

N.A.

## Screenshots (if appropriate):

N.A.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>

🤖 Generated with [Claude Code](https://claude.com/claude-code)