### PR TITLE
fix: pass mount id to the s3ng storage driver

### DIFF
--- a/changelog/unreleased/bugfix-s3ng-postprocessing-mount-id.md
+++ b/changelog/unreleased/bugfix-s3ng-postprocessing-mount-id.md
@@ -1,0 +1,13 @@
+Bugfix: Fix uploads stuck in processing with the s3ng storage driver
+
+Uploads to a `s3ng` backed storage-users service never left the processing
+state, so the file stayed unreadable and unmodifiable forever. Restoring a file
+version was affected in the same way.
+
+Decomposedfs ignores any event whose storage id does not match its configured
+mount id. The `s3ng` driver never received a `mount_id`, so that comparison was
+made against an empty string and every `PostprocessingFinished`,
+`RestartPostprocessing` and `RevertRevision` event was discarded. The `s3ng`
+driver now passes `mount_id` the same way the `ocis` driver already does.
+
+https://github.com/owncloud/ocis/pull/12756

--- a/changelog/unreleased/bugfix-s3ng-postprocessing-mount-id.md
+++ b/changelog/unreleased/bugfix-s3ng-postprocessing-mount-id.md
@@ -1,13 +1,20 @@
 Bugfix: Fix uploads stuck in processing with the s3ng storage driver
 
 Uploads to a `s3ng` backed storage-users service never left the processing
-state, so the file stayed unreadable and unmodifiable forever. Restoring a file
-version was affected in the same way.
+state, so the file stayed unreadable and unmodifiable forever. Every client was
+affected equally, because the defect sits below the protocol layer: WebDAV, the
+desktop sync client and the Web UI alike.
 
 Decomposedfs ignores any event whose storage id does not match its configured
-mount id. The `s3ng` driver never received a `mount_id`, so that comparison was
-made against an empty string and every `PostprocessingFinished`,
-`RestartPostprocessing` and `RevertRevision` event was discarded. The `s3ng`
-driver now passes `mount_id` the same way the `ocis` driver already does.
+mount id. The `s3ng` driver never received a `mount_id`, so that comparison ran
+against an empty string and every `PostprocessingFinished` event was discarded.
+The `s3ng` driver now passes `mount_id` the same way the `ocis` driver already
+does.
+
+The same key is also added to `OcisNoEvents` and `S3NGNoEvents`. Those build the
+storage provider rather than the data provider and configure no events, so today
+the value is unused there. Setting it keeps both constructions of the same
+storage consistent about their own identity, rather than leaving one of them to
+report an empty mount id to any future reader of that option.
 
 https://github.com/owncloud/ocis/pull/12756

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -214,6 +214,7 @@ func Ocis(cfg *config.Config) map[string]interface{} {
 // OcisNoEvents is the config mapping for the ocis storage driver emitting no events
 func OcisNoEvents(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{
+		"mount_id":         cfg.MountID,
 		"metadata_backend": "messagepack",
 		"propagator":       cfg.Drivers.OCIS.Propagator,
 		"async_propagator_options": map[string]interface{}{
@@ -339,6 +340,7 @@ func S3NG(cfg *config.Config) map[string]interface{} {
 // S3NGNoEvents is the config mapping for the s3ng storage driver emitting no events
 func S3NGNoEvents(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{
+		"mount_id":         cfg.MountID,
 		"metadata_backend": "messagepack",
 		"propagator":       cfg.Drivers.S3NG.Propagator,
 		"async_propagator_options": map[string]interface{}{

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -272,6 +272,7 @@ func S3(cfg *config.Config) map[string]interface{} {
 // S3NG is the config mapping for the s3ng storage driver
 func S3NG(cfg *config.Config) map[string]interface{} {
 	return map[string]interface{}{
+		"mount_id":         cfg.MountID,
 		"metadata_backend": "messagepack",
 		"propagator":       cfg.Drivers.S3NG.Propagator,
 		"async_propagator_options": map[string]interface{}{


### PR DESCRIPTION
## Description

`services/storage-users/pkg/revaconfig/drivers.go` passes `mount_id` to the `ocis` driver but not to `s3ng`. Since 8.1.0 decomposedfs filters incoming events by mount id, so under `s3ng` that filter compares the event's storage id against an empty string and discards every `PostprocessingFinished` event. Uploads therefore never leave the processing state.

The fix is one line, mirroring what `Ocis()` already does.

## Visible problem

With `STORAGE_USERS_DRIVER=s3ng` and `OCIS_ASYNC_UPLOADS=true` (the default), every uploaded file stays in "processing" forever:

- WebDAV `GET` returns `425 Too Early`
- the Web UI greys the file out and marks it as being processed
- the file can never be opened, edited or downloaded
- `ocis storage-users uploads sessions --processing` lists the upload indefinitely

Because the defect is below the protocol layer, it affects every client equally — WebDAV, the desktop sync client and the Web UI.

Regression since 8.1.0. 8.0.x is not affected.

## Expected behavior

Uploads complete: postprocessing finishes, the processing flag is cleared and the file becomes readable — the same behaviour as `STORAGE_USERS_DRIVER=ocis`.

## Explanation of the fix

Both halves of the vault-storage feature (OCISDEV-533) landed on the same day: reva gained the mount-id event filter, and #12108 added `"mount_id": cfg.MountID` to `Ocis()`. `S3NG()` was not updated, and `s3ng` is decomposedfs with an S3 blobstore, so it reaches the same filter:

```go
if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
	sublog.Debug().Msg("ignoring event for different storage")
	return
}
```

The two sides of that comparison are populated through different paths:

- `ev.ResourceID.GetStorageId()` is set for **every** driver — the storageprovider passes its mount id down to the upload session.
- `fs.o.MountID` comes from the **driver option map**, which only `Ocis()` fills.

So under `s3ng` the comparison is always `"<real-id>" != ""`, and the event is dropped 100% of the time.

`STORAGE_USERS_MOUNT_ID` is already configured correctly — `ocis init` generates it — so this is not a misconfiguration that an operator can work around. The value simply never reached the driver. Setting `OCIS_ASYNC_UPLOADS=false` avoids the affected path, but at the cost of async postprocessing.

Three of the five subscribed events sit behind this filter (`PostprocessingFinished`, `PostprocessingStepFinished`, `RevertRevision`); `RestartPostprocessing` and `CleanUpload` do not, which is why `uploads sessions --restart` can still recover stuck files.

**Scope.** `Posix`, `S3`, `OwnCloudSQL`, `Local`, `LocalHome` and the `EOS*` drivers also omit `mount_id`. This PR deliberately changes only `s3ng`, the one driver I can reproduce and verify. `Posix` does not configure the decomposedfs event consumer, so it is likely unaffected; the others are untested. Happy to widen the change if maintainers prefer.

## What was tested

Deployed to a real tenant running 8.1.1 plus this patch: `STORAGE_USERS_DRIVER=s3ng` against an S3 backend, LDAP identity backend, `OCIS_ASYNC_UPLOADS` left at its default of `true`.

| Test | Before the fix | After the fix |
| --- | --- | --- |
| 5 sequential uploads, read back immediately | **0/5** readable (`425`) | **5/5** readable (`200`) |
| 2.2 MB file | stuck | `PUT 201`, `GET 200`, byte count correct |
| `uploads sessions --processing --restart` | partial recovery | 5/5 recovered |
| Restore a previous file version | works | works (no regression) |
| `"ignoring event for different storage"` in logs | on every upload | **0** occurrences |

The before/after runs included a control: the five files uploaded during the pre-fix baseline were **still stuck** after the patched build was deployed, and recovered only when explicitly restarted, while every file uploaded afterwards completed immediately. That distinguishes the fix from a restart-clears-everything artefact — it acts on newly published events, not on existing state.

Also verified: `go build ./services/storage-users/...` and `gofmt` clean.

## Why CI did not catch this

The acceptance suites run `STORAGE_DRIVER=ocis` only — `s3ng` does not appear anywhere in `.github/workflows/`. Async uploads are covered thoroughly, but exclusively on the one driver that already sets `mount_id`.
