### PR TITLE
Generate web timestamp by env/git log; make it buildable without .git

### DIFF
--- a/changelog/unreleased/fix-web-timestamp-and-non-git-building.md
+++ b/changelog/unreleased/fix-web-timestamp-and-non-git-building.md
@@ -1,0 +1,5 @@
+Bugfix: Generate web timestamp by env/git log; make it buildable without .git
+
+Change compilationTimeStamp to distTimeStamp, set its value from env EPOCH, or timestamp of last git commit, or fallback to current time. Also fixes a problem that raises an error during make ci-node-generate due to running git clean -xfd in a non-repository directory (usually an extracted source tarball), showing a message instead.
+
+https://github.com/owncloud/ocis/pull/12758

--- a/changelog/unreleased/fix-web-timestamp-and-non-git-building.md
+++ b/changelog/unreleased/fix-web-timestamp-and-non-git-building.md
@@ -1,5 +1,5 @@
 Bugfix: Generate web timestamp by env/git log; make it buildable without .git
 
-Change compilationTimeStamp to distTimeStamp, set its value from env EPOCH, or timestamp of last git commit, or fallback to current time. Also fixes a problem that raises an error during make ci-node-generate due to running git clean -xfd in a non-repository directory (usually an extracted source tarball), showing a message instead.
+Change compilationTimeStamp to distTimeStamp, set its value from env SOURCE_DATE_EPOCH, or timestamp of last git commit, or fallback to current time. Also fixes a problem that raises an error during make ci-node-generate due to running git clean -xfd in a non-repository directory (usually an extracted source tarball), showing a message instead.
 
 https://github.com/owncloud/ocis/pull/12758

--- a/services/web/Makefile
+++ b/services/web/Makefile
@@ -34,7 +34,7 @@ ci-node-generate: build-assets
 build-assets:
 	cd $(WEB_DIR) && pnpm install && pnpm check:types && pnpm build
 	cp $(WEB_DIR)/config/config.json.dist $(WEB_DIR)/dist/
-	git clean -xfd assets
+	if ! git status > /dev/null; then echo 'Re-extract the source to a clean directory to avoid leftover files.'; else git clean -xfd assets; fi
 	cp -r $(WEB_DIR)/dist/. assets/core/
 
 ############ licenses ############

--- a/web/index.html
+++ b/web/index.html
@@ -12,11 +12,11 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.7/require.min.js"></script>
     <script>
       if (typeof requirejs === 'undefined') {
-        document.write('<script src="js/require.js?<%= data.compilationTimestamp %>">\x3C/script>')
+        document.write('<script src="js/require.js?<%= data.distTimestamp %>">\x3C/script>')
       }
     </script>
     <% } else { %>
-    <script src="js/require.js?<%= data.compilationTimestamp %>"></script>
+    <script src="js/require.js?<%= data.distTimestamp %>"></script>
     <% } %>
     <script type="module" src="./packages/web-runtime/src/index.ts"></script>
     <script type="module">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -24,6 +24,7 @@ import { getUserAgentRegex } from 'browserslist-useragent-regexp'
 import browserslistToEsbuild from 'browserslist-to-esbuild'
 import fetch from 'node-fetch'
 import { Agent } from 'https'
+import { execSync } from 'child_process'
 
 // @ts-ignore
 import ejs from 'ejs'
@@ -83,6 +84,29 @@ type ConfigJsonResponseBody = {
 
 const getConfigJson = async (url: string) => {
   return (await getJson(url)) as ConfigJsonResponseBody
+}
+
+const getDistTime = () => {
+  const epoch = process.env.SOURCE_DATE_EPOCH
+  if (epoch) {
+    const num = Number(epoch)
+    if (!isNaN(num) && num > 0) {
+      return num * 1000
+    }
+  }
+  try {
+    const stdout = execSync('git log -1 --format=%ct', {
+      cwd: '..',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8'
+    })
+    const num = parseInt(stdout.trim(), 10)
+    if (!isNaN(num) && num > 0) {
+      return num * 1000
+    }
+  } catch {
+  }
+  return new Date().getTime()
 }
 
 export const historyModePlugins = () =>
@@ -297,7 +321,7 @@ export default defineConfig(({ mode, command }) => {
                   buildConfig,
 
                   title: process.env.TITLE || 'ownCloud',
-                  compilationTimestamp: new Date().getTime(),
+                  distTimestamp: getDistTime(),
                   supportedBrowsersRegex: supportedBrowsersRegex
                 }
               })

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -103,8 +103,7 @@ const getDistTime = () => {
     if (!isNaN(num) && num > 0) {
       return num * 1000
     }
-  } catch {
-  }
+  } catch {}
   return new Date().getTime()
 }
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -96,7 +96,6 @@ const getDistTime = () => {
   }
   try {
     const stdout = execSync('git log -1 --format=%ct', {
-      cwd: '..',
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8'
     })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Change `compilationTimeStamp` to `distTimeStamp`, set its value from env `SOURCE_DATE_EPOCH`, or timestamp of last git commit, or fallback to current time. This also fixes a problem that raises an error during `make ci-node-generate` due to running `git clean -xfd` in a non-repository directory (usually an extracted source tarball), showing a message instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #12757 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current implementation breaks reproducibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: linux/amd64
- test case 1: run `make ci-node-generate` multiple times in `./ocis` with env `EPOCH` - PASSED
- test case 2: run `make ci-node-generate` multiple times in `./ocis` without env `EPOCH` - PASSED
- test case 3: remove `./.git` then run `make ci-node-generate` multiple times in `./ocis` without env `EPOCH` - PASSED

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
