### PR TITLE
chore: remove Vue warnings in web

### DIFF
--- a/web/packages/web-app-external/src/App.vue
+++ b/web/packages/web-app-external/src/App.vue
@@ -1,24 +1,8 @@
 <template>
-  <iframe
-    v-if="appUrl && method === 'GET'"
-    ref="appIframe"
-    :src="appUrl"
-    class="oc-width-1-1 oc-height-1-1"
-    :title="iFrameTitle"
-    allowfullscreen
-    allow="camera; clipboard-read; clipboard-write"
-    @load="onIframeLoad"
-  />
-  <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
-    <form :action="appUrl" target="app-iframe" method="post">
-      <input ref="subm" type="submit" :value="formParameters" class="oc-hidden" />
-      <div v-for="(item, key, index) in formParameters" :key="index">
-        <input :name="key" :value="item" type="hidden" />
-      </div>
-    </form>
+  <div class="oc-width-1-1 oc-height-1-1">
     <iframe
+      v-if="appUrl && method === 'GET'"
       ref="appIframe"
-      name="app-iframe"
       :src="appUrl"
       class="oc-width-1-1 oc-height-1-1"
       :title="iFrameTitle"
@@ -26,6 +10,24 @@
       allow="camera; clipboard-read; clipboard-write"
       @load="onIframeLoad"
     />
+    <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
+      <form :action="appUrl" target="app-iframe" method="post">
+        <input ref="subm" type="submit" :value="formParameters" class="oc-hidden" />
+        <div v-for="(item, key, index) in formParameters" :key="index">
+          <input :name="key" :value="item" type="hidden" />
+        </div>
+      </form>
+      <iframe
+        ref="appIframe"
+        name="app-iframe"
+        :src="appUrl"
+        class="oc-width-1-1 oc-height-1-1"
+        :title="iFrameTitle"
+        allowfullscreen
+        allow="camera; clipboard-read; clipboard-write"
+        @load="onIframeLoad"
+      />
+    </div>
   </div>
 </template>
 

--- a/web/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/web/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,24 +1,26 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
-
-<!--v-if-->"
+"<div class="oc-width-1-1 oc-height-1-1"><iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+  <!--v-if-->
+</div>"
 `;
 
 exports[`The app provider extension > should be able to load an iFrame via post 1`] = `
-"<!--v-if-->
-
-<div class="oc-height-1-1 oc-width-1-1">
-  <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
-    <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
-    <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+"<div class="oc-width-1-1 oc-height-1-1">
+  <!--v-if-->
+  <div class="oc-height-1-1 oc-width-1-1">
+    <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
+      <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
+      <div><input name="access_token_ttl" type="hidden" value="123456"></div>
+    </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+  </div>
 </div>"
 `;
 
 exports[`The app provider extension > should fail for unauthenticated users 1`] = `
-"<!--v-if-->
-
-<!--v-if-->"
+"<div class="oc-width-1-1 oc-height-1-1">
+  <!--v-if-->
+  <!--v-if-->
+</div>"
 `;

--- a/web/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/web/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -26,7 +26,7 @@ import {
 import { isProjectSpaceResource, SpaceResource } from '@ownclouders/web-client'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
-import { unref } from 'vue'
+import { markRaw, unref } from 'vue'
 import { fileSideBarExtensionPoint } from '../../extensionPoints'
 import AudioMetaPanel from '../../components/SideBar/Audio/AudioMetaPanel.vue'
 import { isEmpty } from 'lodash-es'
@@ -49,7 +49,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'no-selection',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: NoSelection,
+        component: markRaw(NoSelection),
         isRoot: () => true,
         isVisible: ({ parent, items }) => {
           if (isLocationTrashActive(router, 'files-trash-overview')) {
@@ -76,7 +76,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'no-selection',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: TrashNoSelection,
+        component: markRaw(TrashNoSelection),
         isRoot: () => true,
         isVisible: () => {
           return isLocationTrashActive(router, 'files-trash-overview')
@@ -91,7 +91,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'details',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: FileDetails,
+        component: markRaw(FileDetails),
         componentAttrs: ({ items }) => ({
           previewEnabled: unref(isFilesAppActive),
           tagsEnabled:
@@ -116,7 +116,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'details-multiple',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: FileDetailsMultiple,
+        component: markRaw(FileDetailsMultiple),
         componentAttrs: () => ({
           get showSpaceCount() {
             return (
@@ -144,7 +144,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'exif',
         icon: 'image',
         title: () => $gettext('Image Info'),
-        component: ExifPanel,
+        component: markRaw(ExifPanel),
         isVisible: ({ items }) => {
           if (items?.length !== 1) {
             return false
@@ -165,7 +165,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'audio-meta',
         icon: 'music',
         title: () => $gettext('Audio Info'),
-        component: AudioMetaPanel,
+        component: markRaw(AudioMetaPanel),
         isVisible: ({ items }) => {
           if (items?.length !== 1) {
             return false
@@ -187,7 +187,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         icon: 'play-circle',
         iconFillType: 'line',
         title: () => $gettext('Actions'),
-        component: FileActions,
+        component: markRaw(FileActions),
         isRoot: () => false,
         isVisible: ({ items }) => {
           if (items?.length !== 1) {
@@ -211,7 +211,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         icon: 'user-add',
         iconFillType: 'line',
         title: () => $gettext('Shares'),
-        component: SharesPanel,
+        component: markRaw(SharesPanel),
         componentAttrs: () => ({
           showSpaceMembers: false,
           get showLinks() {
@@ -238,7 +238,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'versions',
         icon: 'git-branch',
         title: () => $gettext('Versions'),
-        component: FileVersions,
+        component: markRaw(FileVersions),
         componentAttrs: () => ({
           isReadOnly: !unref(isFilesAppActive)
         }),
@@ -258,7 +258,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'no-selection',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: SpaceNoSelection,
+        component: markRaw(SpaceNoSelection),
         isRoot: () => true,
         isVisible: ({ items }) => {
           if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
@@ -277,7 +277,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'details-space',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: SpaceDetails,
+        component: markRaw(SpaceDetails),
         isRoot: () => true,
         isVisible: ({ items }) => {
           return items?.length === 1 && isProjectSpaceResource(items[0])
@@ -292,7 +292,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'details-space-multiple',
         icon: 'questionnaire-line',
         title: () => $gettext('Details'),
-        component: SpaceDetailsMultiple,
+        component: markRaw(SpaceDetailsMultiple),
         componentAttrs: ({ items }) => ({
           selectedSpaces: items
         }),
@@ -311,7 +311,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         icon: 'play-circle',
         iconFillType: 'line',
         title: () => $gettext('Actions'),
-        component: SpaceActions,
+        component: markRaw(SpaceActions),
         isVisible: ({ items }) => {
           if (items?.length !== 1) {
             return false
@@ -337,7 +337,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'space-share',
         icon: 'group',
         title: () => $gettext('Members'),
-        component: SharesPanel,
+        component: markRaw(SharesPanel),
         componentAttrs: () => ({
           showSpaceMembers: true,
           get showLinks() {
@@ -357,7 +357,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
         name: 'activities',
         icon: 'pulse',
         title: () => $gettext('Activities'),
-        component: ActivitiesPanel,
+        component: markRaw(ActivitiesPanel),
         isVisible: ({ items }) => {
           if (items?.length !== 1) {
             return false

--- a/web/packages/web-app-files/src/composables/extensions/useFolderViews.ts
+++ b/web/packages/web-app-files/src/composables/extensions/useFolderViews.ts
@@ -1,5 +1,6 @@
 import { FolderViewExtension, ResourceTable, ResourceTiles } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
+import { markRaw } from 'vue'
 import {
   folderViewsFavoritesExtensionPoint,
   folderViewsFolderExtensionPoint,
@@ -25,7 +26,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
           name: 'menu-line',
           fillType: 'none'
         },
-        component: ResourceTable
+        component: markRaw(ResourceTable)
       }
     },
     {
@@ -39,7 +40,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
           name: 'menu-line-condensed',
           fillType: 'none'
         },
-        component: ResourceTable
+        component: markRaw(ResourceTable)
       }
     },
     {
@@ -57,7 +58,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
           name: 'apps-2',
           fillType: 'line'
         },
-        component: ResourceTiles
+        component: markRaw(ResourceTiles)
       }
     }
   ]

--- a/web/packages/web-app-search/src/extensions.ts
+++ b/web/packages/web-app-search/src/extensions.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, markRaw } from 'vue'
 import { CustomComponentExtension, Extension } from '@ownclouders/web-pkg'
 import SearchBar from './portals/SearchBar.vue'
 
@@ -6,7 +6,7 @@ const searchBarExtension: CustomComponentExtension = {
   id: 'com.github.owncloud.web.search.search-bar',
   type: 'customComponent',
   extensionPointIds: ['app.runtime.header.center'],
-  content: SearchBar
+  content: markRaw(SearchBar)
 }
 
 export const extensions = () => {

--- a/web/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/web/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -147,8 +147,8 @@ const url = ref('')
 const loading = ref(!unref(noResourceLoading))
 const loadingError: Ref<Error> = ref()
 const isReadOnly = ref(false)
-const serverContent = ref()
-const currentContent = ref()
+const serverContent = ref('')
+const currentContent = ref('')
 
 const { actions: saveAsActions } = useFileActionsSaveAs({ content: currentContent })
 const { actions: exportAsPdfActions } = useFileActionsExportAsPdf({ content: currentContent })
@@ -685,7 +685,7 @@ const slotAttrs = computed(() => ({
     space.value = unref(unref(currentFileContext).space)
     selectedResources.value = [value]
   },
-  'onUpdate:currentContent': (value: unknown) => {
+  'onUpdate:currentContent': (value: string) => {
     currentContent.value = value
   },
 

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -1,7 +1,7 @@
 <template>
-  <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
   <div
     ref="observerTarget"
+    role="presentation"
     class="oc-tile-card oc-card oc-card-default oc-rounded"
     :data-item-id="resource.id"
     :class="{

--- a/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -201,6 +201,15 @@ describe('ResourceTiles component', () => {
       ;(wrapper.vm as any).fileDropped(mock<Resource>(), { dataTransfer: {} } as DragEvent)
       expect(wrapper.emitted('fileDropped')).toBeDefined()
     })
+    it('highlights a folder tile on drag enter via its root element', () => {
+      const folder = { ...resources[0], id: 'folder', type: 'folder', isFolder: true } as Resource
+      const { wrapper } = getWrapper({ props: { resources: [folder] } })
+      ;(wrapper.vm as any).setDropStyling(folder, false, {
+        dataTransfer: { types: [] }
+      } as unknown as DragEvent)
+      const tileEl = (wrapper.vm as any).tileRefs.tiles[folder.id].$el as HTMLElement
+      expect(tileEl.classList.contains('oc-tiles-item-drop-highlight')).toBe(true)
+    })
   })
   describe('context menu', () => {
     it('triggers the positioned dropdown on click', async () => {

--- a/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTile.spec.ts.snap
@@ -1,9 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcTile component > renders default space correctly 1`] = `
-"<!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
-
-<div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="lorem-id">
+"<div role="presentation" class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="lorem-id">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->
@@ -29,9 +27,7 @@ exports[`OcTile component > renders default space correctly 1`] = `
 `;
 
 exports[`OcTile component > renders disabled space correctly 1`] = `
-"<!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
-
-<div class="oc-tile-card oc-card oc-card-default oc-rounded oc-tile-card-disabled" data-item-id="lorem-id">
+"<div role="presentation" class="oc-tile-card oc-card oc-card-default oc-rounded oc-tile-card-disabled" data-item-id="lorem-id">
   <resource-link-stub resource="[object Object]" isresourceclickable="true" class="oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1">
     <div class="oc-tile-card-selection"></div>
     <!--v-if-->

--- a/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -18,8 +18,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
   </div>
   <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles">
     <li class="oc-tiles-item has-item-context-menu">
-      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
-      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+      <div role="presentation" class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">
@@ -52,8 +51,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
       </div>
     </li>
     <li class="oc-tiles-item has-item-context-menu">
-      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
-      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="2"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+      <div role="presentation" class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">

--- a/web/packages/web-runtime/src/layouts/Application.vue
+++ b/web/packages/web-runtime/src/layouts/Application.vue
@@ -77,6 +77,7 @@ import { useActiveApp, useRoute, useRouteMeta, useSpacesLoading } from '@ownclou
 import {
   computed,
   defineComponent,
+  markRaw,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -253,7 +254,7 @@ export default defineComponent({
       id: progressBarExtensionId,
       type: 'customComponent',
       extensionPointIds: [progressBarExtensionPointId],
-      content: LoadingIndicator,
+      content: markRaw(LoadingIndicator),
       userPreference: {
         optionLabel: $gettext('Default progress bar')
       }


### PR DESCRIPTION
## Description

This PR removes a set of Vue runtime warnings (and one resulting crash) that were logged in the browser console across the web frontend.

- `ResourceTile`: the template had a leading `eslint-disable` HTML comment before the root `<div>`. In dev builds Vue renders that comment as a vnode, turning the component into a fragment root. As a consequence fallthrough attributes and drag listeners could not auto-inherit onto the element (`Extraneous non-props attributes (draggable) ...`), and the parent's element ref resolved to the comment node instead of the card `<div>`. The latter broke drag-and-drop on tiles view with `el.$el.classList is undefined` in `setDropStyling`. The fix removes the comment (so the `<div>` is the single root) and adds `role="presentation"` to keep the static element's `@contextmenu` handler lint-clean.
- Components passed as plain data into extension registrations and folder-view definitions (`useFileSideBars`, `useFolderViews`, web-app-search `extensions`, runtime `Application` layout) are now wrapped in `markRaw` to silence the "Vue received a Component that was made a reactive object" warnings.
- `web-app-external` `App.vue`: the `GET` iframe and the `POST` form/iframe are wrapped in a single root element to avoid a multi-root fragment.
- `AppWrapper`: `currentContent` is now typed as `string`, fixing a `vue-tsc` type error surfaced by the ref type change.

## Related Issue

- OCISDEV-1201

## Motivation and Context

The browser console was noisy with Vue warnings on normal navigation, which made real issues harder to spot. More importantly, the `ResourceTile` fragment root caused drag-and-drop on tiles view to throw at runtime, so files/folders could not be dragged in that view.

## How Has This Been Tested?

- test environment: local dev (`pnpm vite`), `vue-tsc --noEmit`, `eslint`, and `vitest` unit tests
- test case 1: mounting `ResourceTile` with a `draggable` attribute no longer logs the "Extraneous non-props attributes" warning
- test case 2: added a `ResourceTiles` unit test that drives `setDropStyling` on a folder tile and asserts the highlight class is added to the tile's root element (previously threw `classList is undefined`)
- test case 3: `ResourceTile` / `ResourceTiles` snapshots updated and full unit suites pass; `vue-tsc --noEmit` reports no errors

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
