### PR TITLE
fix: use specific gookit config instance instance of using global

### DIFF
--- a/changelog/unreleased/bugfix-proxy-service-restart-panic.md
+++ b/changelog/unreleased/bugfix-proxy-service-restart-panic.md
@@ -1,0 +1,12 @@
+Bugfix: Restarting the proxy service on error was causing panics
+
+Starting oCIS with the `ocis server` command causes oCIS to monitor the
+services being started. When a service fails to start, this monitor tries
+to restart the services. For the cause of the proxy service, restarting it
+was a panic.
+
+Now, the proxy service can be restarted as expected, without that panic.
+Note that the service might still fail to start if the actual cause isn't
+fixed, such as the service's port being taken by a different application.
+
+https://github.com/owncloud/ocis/pull/12769

--- a/services/proxy/pkg/middleware/security.go
+++ b/services/proxy/pkg/middleware/security.go
@@ -13,27 +13,30 @@ import (
 
 // LoadCSPConfig loads CSP header configuration from a yaml file.
 func LoadCSPConfig(proxyCfg *config.Config) (*config.CSP, error) {
+	serviceName := proxyCfg.Service.Name
 	yamlContent, err := loadCSPYaml(proxyCfg)
 	if err != nil {
 		return nil, err
 	}
-	return loadCSPConfig(yamlContent)
+	return loadCSPConfig(serviceName, yamlContent)
 }
 
 // LoadCSPConfig loads CSP header configuration from a yaml file.
-func loadCSPConfig(yamlContent []byte) (*config.CSP, error) {
+func loadCSPConfig(svcName string, yamlContent []byte) (*config.CSP, error) {
+	// The LoadCSPConfig (public) is expected to be called once, so
+	// creating a new gookit config instance each time here is fine.
 	// substitute env vars and load to struct
-	gofig.WithOptions(gofig.ParseEnv)
-	gofig.AddDriver(yaml.Driver)
+	cfg := gofig.NewWithOptions(svcName, gofig.ParseEnv)
+	cfg.AddDriver(yaml.Driver)
 
-	err := gofig.LoadSources("yaml", yamlContent)
+	err := cfg.LoadSources("yaml", yamlContent)
 	if err != nil {
 		return nil, err
 	}
 
 	// read yaml
 	cspConfig := config.CSP{}
-	err = gofig.BindStruct("", &cspConfig)
+	err = cfg.BindStruct("", &cspConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/services/proxy/pkg/middleware/security_test.go
+++ b/services/proxy/pkg/middleware/security_test.go
@@ -20,7 +20,7 @@ directives:
     - 'https://${COLLABORA_DOMAIN|collabora.owncloud.test}/'
 `
 
-	config, err := loadCSPConfig([]byte(yaml))
+	config, err := loadCSPConfig("proxy", []byte(yaml))
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Using the global instance was causing a panic when the service was restarted. That panic won't happen now.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Using the global gookit config instance was causing a panic when the service was restarted. This PR fixes that panic. Note that the original problem that caused the service restart will remain.

## Related Issue
https://github.com/owncloud/ocis/issues/12574

## Motivation and Context
Some of the problems might be recoverable, but the panic might prevent that from happening. Fixing the panic make the expected behavior to happen, even if that behavior is restarting the service again.

## How Has This Been Tested?
Checking logs.
The new logs (with this PR) don't have the panic:
```
{"level":"debug","service":"proxy","selector_config":{"Static":{"Policy":"ocis"},"Claims":null,"Regex":null},"time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/router/router.go:51","message":"loading policy-selector"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/server/http/server.go:21","message":"No tls certificate provided, using a generated one"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:229","message":"starting service proxy"}
{"level":"error","service":"proxy","error":"runner proxy.debug failed: listen tcp 127.0.0.1:9205: bind: address already in use\nrunner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:233","message":"service proxy stopped with error"}
{"level":"info","service":"ocis","event":"ocis: Failed service 'service.SutureService{exec:(func(context.Context) error)(0x2fa9da0)}' (1.000000 failures of 5.000000), restarting: true, error: runner proxy.debug failed: listen tcp 127.0.0.1:9205: bind: address already in use\nrunner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/ocis/pkg/runtime/service/service.go:401","message":"supervisor: ocis"}
{"level":"debug","service":"nats","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/nats/pkg/logging/nats.go:45","message":"127.0.0.1:45282 - cid:84 - Client connection created"}
{"level":"debug","service":"proxy","selector_config":{"Static":{"Policy":"ocis"},"Claims":null,"Regex":null},"time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/router/router.go:51","message":"loading policy-selector"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/server/http/server.go:21","message":"No tls certificate provided, using a generated one"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:229","message":"starting service proxy"}
{"level":"error","service":"proxy","error":"runner proxy.debug failed: listen tcp 127.0.0.1:9205: bind: address already in use\nrunner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:233","message":"service proxy stopped with error"}
{"level":"info","service":"ocis","event":"ocis: Failed service 'service.SutureService{exec:(func(context.Context) error)(0x2fa9da0)}' (1.999839 failures of 5.000000), restarting: true, error: runner proxy.debug failed: listen tcp 127.0.0.1:9205: bind: address already in use\nrunner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/ocis/pkg/runtime/service/service.go:401","message":"supervisor: ocis"}
{"level":"debug","service":"nats","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/nats/pkg/logging/nats.go:45","message":"127.0.0.1:45286 - cid:85 - Client connection created"}
{"level":"debug","service":"proxy","selector_config":{"Static":{"Policy":"ocis"},"Claims":null,"Regex":null},"time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/router/router.go:51","message":"loading policy-selector"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/server/http/server.go:21","message":"No tls certificate provided, using a generated one"}
{"level":"warn","service":"proxy","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:229","message":"starting service proxy"}
{"level":"error","service":"proxy","error":"runner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/services/proxy/pkg/command/server.go:233","message":"service proxy stopped with error"}
{"level":"info","service":"ocis","event":"ocis: Failed service 'service.SutureService{exec:(func(context.Context) error)(0x2fa9da0)}' (2.999498 failures of 5.000000), restarting: true, error: runner proxy.http failed: listen tcp 0.0.0.0:9200: bind: address already in use","time":"2026-08-10T12:17:58Z","line":"/home/juan/src/ocis/ocisfork/ocis/pkg/runtime/service/service.go:401","message":"supervisor: ocis"}
```
In this particular case, there is a recurring error (from the retries) about the port being taken, but there is no panic.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
