### PR TITLE
fix: remove trailing period from changelog title

### DIFF
--- a/changelog/8.2.0_2026-08-10/bugfix-config-mountId-reva.md
+++ b/changelog/8.2.0_2026-08-10/bugfix-config-mountId-reva.md
@@ -1,4 +1,4 @@
-Bugfix: Fix the empty mount ID for reva config.
+Bugfix: Fix the empty mount ID for reva config
 
 We fixed the empty mount ID for storage-users
 


### PR DESCRIPTION
The `v8.2.0` release pipeline failed in the `generate-changelog` job:

```
file changelog/8.2.0_2026-08-10/bugfix-config-mountId-reva.md: title ends with punctuation, e.g. a character out of ".!?"
make: *** [Makefile:329: changelog] Error 1
```

calens rejects changelog titles ending in `.`, `!` or `?`. This entry was added while backporting the fix from #12492 to the 8.2.0 release branch, and the title was copied verbatim from that PR — where it still ended with a period. The version that shipped in `changelog/8.1.0_2026-07-03/` had the period stripped afterwards, so only the 8.2.0 copy carries it.

Note that `make changelog-lint` does not catch this: it only validates title length (<= 80 chars). The punctuation rule is enforced by calens itself, i.e. only by `make changelog`.

## Change

```diff
-Bugfix: Fix the empty mount ID for reva config.
+Bugfix: Fix the empty mount ID for reva config
```

## Verification

Reproduced the CI command locally:

```
$ make changelog CHANGELOG_VERSION=8.2.0
exit 0
```

- Renders 790 lines (the pipeline requires >= 5, otherwise it substitutes a dev-release placeholder)
- Entry renders as `Bugfix - Fix the empty mount ID for reva config: [#12492]`
- All 53 entries in `changelog/8.2.0_2026-08-10/` were additionally validated against the full rule set (category prefix, trailing punctuation, title length, blank line after title, PR/issue URL present) — no remaining problems

Only `generate-changelog` failed in the release run; `security-scan-trivy` and `determine-release-type` passed.

Once this is merged, the `v8.2.0` tag will be deleted and recreated on the new `stable-8.2` HEAD so the release pipeline re-runs.