### PR TITLE
[tests-only][full-ci] add retry logic for file copy requests

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2606,11 +2606,13 @@ class SpacesContext implements Context {
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
 		if ($actionType === 'copied') {
-			// Retry the request up to 3 times in case of failure
+			// while performing copy operation,
+			// sometime it will return 500 error.
+			// So we need to retry the copy operation.
 			$maxAttempts = 3;
 			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
 				$response = $this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
-				if ($response->getStatusCode() === 201) {
+				if ($response->getStatusCode() !== 500) {
 					break;
 				}
 				if ($attempt < $maxAttempts) {

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2605,10 +2605,22 @@ class SpacesContext implements Context {
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
-		if ($actionType === 'copied') {
-			$response = $this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
-		} else {
-			$response = $this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
+		// Retry the request up to 3 times in case of failure
+		$maxAttempts = 3;
+		for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+			if ($actionType === 'copied') {
+				$response = $this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
+			} else {
+				$response = $this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
+			}
+
+			if ($response->getStatusCode() === 201) {
+				break;
+			}
+
+			if ($attempt < $maxAttempts) {
+				\sleep(1);
+			}
 		}
 		Assert::assertEquals(
 			201,

--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -2605,22 +2605,20 @@ class SpacesContext implements Context {
 			);
 		}
 		$fullUrl = "$baseUrl/$sourceDavPath/$fileId";
-		// Retry the request up to 3 times in case of failure
-		$maxAttempts = 3;
-		for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-			if ($actionType === 'copied') {
+		if ($actionType === 'copied') {
+			// Retry the request up to 3 times in case of failure
+			$maxAttempts = 3;
+			for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
 				$response = $this->copyFilesAndFoldersRequest($user, $fullUrl, $headers);
-			} else {
-				$response = $this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
+				if ($response->getStatusCode() === 201) {
+					break;
+				}
+				if ($attempt < $maxAttempts) {
+					\sleep(1);
+				}
 			}
-
-			if ($response->getStatusCode() === 201) {
-				break;
-			}
-
-			if ($attempt < $maxAttempts) {
-				\sleep(1);
-			}
+		} else {
+			$response = $this->moveFilesAndFoldersRequest($user, $fullUrl, $headers);
 		}
 		Assert::assertEquals(
 			201,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
As I understand from the log, while calling the copy endpoint, it has multiple services, and while performing the copy, one of the services sometimes returns a 425 error, causing the endpoint to return 500. 

So in this PR, retries of the copy operation(i.e copy endpoint calling) are done when this error occurs, allowing the copy to complete successfully.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/12764

## Failure
<!--- Why is this change required? What problem does it solve? -->

```feature
Scenario: check activities of destination resources after copying file into same folder by renaming the destination file # /home/runner/work/ocis/ocis/tests/acceptance/features/apiActivities/activitiesByFileId.feature:1739
{"level":"error","service":"search","error":"error: not found: stat: error: not found: ","time":"2026-08-07T11:55:54Z","message":"error walking the tree"}
{"level":"error","service":"search","error":"error: not found: stat: error: not found: ","spaceID":{"opaque_id":"9ffef4e6-8cec-4e94-8c98-c01f1f7aa17e$a486b030-d07b-49b5-a17f-120c044242a2"},"time":"2026-08-07T11:55:54Z","message":"error while indexing a space"}
    Given user "Alice" has created folder "/FOLDER"                                                                        # FeatureContext::userHasCreatedFolder()
{"level":"error","service":"proxy","time":"2026-08-07T11:55:55Z","message":"no user in context"}
    And user "Alice" has uploaded file with content "ownCloud test text file" to "FOLDER/textfile.txt"                     # FeatureContext::userHasUploadedAFileWithContentTo()
    And we save it into "FILEID"                                                                                           # FeatureContext::saveItInto()
{"level":"error","service":"proxy","time":"2026-08-07T11:55:55Z","message":"no user in context"}
{"level":"error","service":"ocdav","name":"com.owncloud.web.ocdav","traceid":"67e41f12d78838c7341288d0131287f8","request-id":"apiActivities/activitiesByFileId.feature:1739-1743","spaceid":"9ffef4e6-8cec-4e94-8c98-c01f1f7aa17e$3832f75c-a939-4789-82d7-20f8b041200a!3bb0a995-2bfd-45ed-8a67-1f87980fdc77","path":"/","destination":"/9ffef4e6-8cec-4e94-8c98-c01f1f7aa17e$3832f75c-a939-4789-82d7-20f8b041200a/FOLDER/renamed.txt","error":"status code 425","depth":"infinity","time":"2026-08-07T11:55:55Z","message":"error descending directory"}
2026/08/07 11:55:55 http: superfluous response.WriteHeader call from github.com/owncloud/reva/v2/internal/http/interceptors/log.(*responseLogger).WriteHeader (log.go:155)
    And user "Alice" has copied file with id "<<FILEID>>" as "renamed.txt" into folder "FOLDER" inside space "Personal"    # SpacesContext::userHasCopiedOrMovedFileInsideSpaceUsingFileId()
      Expected response status code should be 201
      Failed asserting that 500 matches expected 201.
    When user "Alice" lists the activities of file "FOLDER/renamed.txt" from space "Personal" using the Graph API          # GraphContext::userListsTheActivitiesForResourceOfSpaceUsingTheGraphAPI()
    Then the HTTP status code should be "200" 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
