### PR TITLE
[tests-only] test: [OCISDEV-861] pin public-link visibility in unfiltered share listings

### DIFF
--- a/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature
@@ -3940,15 +3940,15 @@ Feature: resources shared by user
       """
 
 
-  Scenario: space member sees link shares created by another member in sharedByMe
+  Scenario Outline: space member sees link shares created by another member in sharedByMe
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "TeamSpace" with the default quota using the Graph API
     And user "Alice" has sent the following space share invitation:
-      | space           | TeamSpace |
-      | sharee          | Brian     |
-      | shareType       | user      |
-      | permissionsRole | Manager   |
+      | space           | TeamSpace     |
+      | sharee          | Brian         |
+      | shareType       | user          |
+      | permissionsRole | <space-role>  |
     And user "Alice" has uploaded a file inside space "TeamSpace" with content "hello" to "shared.txt"
     And user "Alice" has created the following resource link share:
       | resource        | shared.txt |
@@ -3967,11 +3967,15 @@ Feature: resources shared by user
         }
       }
       """
+    Examples:
+      | space-role   |
+      | Manager      |
+      | Space Editor |
+      | Space Viewer |
 
 
   Scenario: non-member does not see link shares of a space in sharedByMe
     Given using spaces DAV path
-    And user "Carol" has been created with default attributes
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And user "Alice" has created a space "TeamSpace" with the default quota using the Graph API
     And user "Alice" has uploaded a file inside space "TeamSpace" with content "hello" to "shared.txt"
@@ -3980,7 +3984,7 @@ Feature: resources shared by user
       | space           | TeamSpace  |
       | permissionsRole | View       |
       | password        | %public%   |
-    When user "Carol" lists the shares shared by her using the Graph API
+    When user "Brian" lists the shares shared by him using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should not contain resource "shared.txt" with the following data:
       """
@@ -3996,7 +4000,6 @@ Feature: resources shared by user
   @env-config
   Scenario: non-member with ListGrants role on a resource sees link shares created by another user on that resource in sharedByMe
     Given using spaces DAV path
-    And user "Carol" has been created with default attributes
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
     And the administrator has enabled the following share permissions roles:
       | permissions-role       |
@@ -4011,10 +4014,10 @@ Feature: resources shared by user
     And user "Alice" has sent the following resource share invitation:
       | resource        | shared.txt             |
       | space           | TeamSpace              |
-      | sharee          | Carol                  |
+      | sharee          | Brian                  |
       | shareType       | user                   |
       | permissionsRole | Viewer With ListGrants |
-    When user "Carol" lists the shares shared by her using the Graph API
+    When user "Brian" lists the shares shared by him using the Graph API
     Then the HTTP status code should be "200"
     And the JSON data of the response should contain resource "shared.txt" with the following data:
       """

--- a/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature
+++ b/tests/acceptance/features/apiSharingNgShares/sharedByMe.feature
@@ -3938,3 +3938,91 @@ Feature: resources shared by user
         }
       }
       """
+
+
+  Scenario: space member sees link shares created by another member in sharedByMe
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "TeamSpace" with the default quota using the Graph API
+    And user "Alice" has sent the following space share invitation:
+      | space           | TeamSpace |
+      | sharee          | Brian     |
+      | shareType       | user      |
+      | permissionsRole | Manager   |
+    And user "Alice" has uploaded a file inside space "TeamSpace" with content "hello" to "shared.txt"
+    And user "Alice" has created the following resource link share:
+      | resource        | shared.txt |
+      | space           | TeamSpace  |
+      | permissionsRole | View       |
+      | password        | %public%   |
+    When user "Brian" lists the shares shared by him using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "shared.txt" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "const": "shared.txt" }
+        }
+      }
+      """
+
+
+  Scenario: non-member does not see link shares of a space in sharedByMe
+    Given using spaces DAV path
+    And user "Carol" has been created with default attributes
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "TeamSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "TeamSpace" with content "hello" to "shared.txt"
+    And user "Alice" has created the following resource link share:
+      | resource        | shared.txt |
+      | space           | TeamSpace  |
+      | permissionsRole | View       |
+      | password        | %public%   |
+    When user "Carol" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should not contain resource "shared.txt" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "const": "shared.txt" }
+        }
+      }
+      """
+
+  @env-config
+  Scenario: non-member with ListGrants role on a resource sees link shares created by another user on that resource in sharedByMe
+    Given using spaces DAV path
+    And user "Carol" has been created with default attributes
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And the administrator has enabled the following share permissions roles:
+      | permissions-role       |
+      | Viewer With ListGrants |
+    And user "Alice" has created a space "TeamSpace" with the default quota using the Graph API
+    And user "Alice" has uploaded a file inside space "TeamSpace" with content "hello" to "shared.txt"
+    And user "Alice" has created the following resource link share:
+      | resource        | shared.txt |
+      | space           | TeamSpace  |
+      | permissionsRole | View       |
+      | password        | %public%   |
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | shared.txt             |
+      | space           | TeamSpace              |
+      | sharee          | Carol                  |
+      | shareType       | user                   |
+      | permissionsRole | Viewer With ListGrants |
+    When user "Carol" lists the shares shared by her using the Graph API
+    Then the HTTP status code should be "200"
+    And the JSON data of the response should contain resource "shared.txt" with the following data:
+      """
+      {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "const": "shared.txt" }
+        }
+      }
+      """

--- a/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/coreApiSharePublicLink1/createPublicLinkShare.feature
@@ -428,3 +428,25 @@ Feature: create a public link share
       | ocs-api-version | http-status-code |
       | 1               | 200              |
       | 2               | 404              |
+
+
+  Scenario Outline: user does not see public links created by another user when listing all shares
+    Given using OCS API version "<ocs-api-version>"
+    And user "Brian" has been created with default attributes
+    And user "Alice" has uploaded file with content "alice data" to "/alice.txt"
+    And user "Brian" has uploaded file with content "brian data" to "/brian.txt"
+    And user "Alice" has created a public link share with settings
+      | path     | /alice.txt |
+      | password | %public%   |
+    And user "Brian" has created a public link share with settings
+      | path     | /brian.txt |
+      | password | %public%   |
+    When user "Alice" gets all shares shared by her using the sharing API
+    Then the OCS status code should be "<ocs-status-code>"
+    And the HTTP status code should be "200"
+    And file "/alice.txt" should be included in the response
+    But file "/brian.txt" should not be included in the response
+    Examples:
+      | ocs-api-version | ocs-status-code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Summary

Acceptance coverage for [OCISDEV-861](https://kiteworks.atlassian.net/browse/OCISDEV-861), pinning **who can see public links when shares are listed without a resource filter**. The fix itself is a separate reva PR; this is tests only, no product code.

**These scenarios encode existing behaviour, not new behaviour.** They are expected to pass on current `master` as well as against the patched reva — their value is as a regression guard, because none of this was pinned anywhere before.

## Background

reva's json/jsoncs3 public-share manager issued one gateway `Stat` per public link **not created by the calling user**, purely to read the `ListGrants` permission bit. On tenants with a few thousand links this exceeded the ~10s gateway deadline: the sharing service logged thousands of `listshares: an error occurred during stat on the resource` errors with `code = Canceled`, and the Web "Shares" page span forever.

The reva fix resolves visibility for unfiltered requests from a **single** `ListStorageSpaces` call instead of N stats. Requests carrying a resource or storage filter keep the existing per-resource `Stat` path, so PROPFIND link indicators, quicklink lookups and space purges are untouched.

## The contract being pinned

This is the behaviour **before and after** the fix — the fix changes the mechanism, not the outcome:

| Lister | Sees a foreign link? | Why |
|---|---|---|
| The link's creator | yes | always |
| A member of the space the link lives in | yes | space membership grants `ListGrants` |
| A non-member holding `ListGrants` on that individual resource | yes | resource-level grant |
| A user with no relationship to the resource or space | no | no `ListGrants` |

Row 3 is the interesting one. Several drafts of the reva fix tried to replace the per-resource permission check with a cheaper precomputed lookup, and every one of them changed this row — two even leaked public-link tokens across a space. The merged approach keeps the original check untouched and only bounds how often it runs, so all four rows behave exactly as they do today. The scenarios below exist so that any future attempt to replace the check cannot silently change who sees what.

## Scenarios added

**`coreApiSharePublicLink1/createPublicLinkShare.feature`** — OCS, deliberately **untagged**

Alice and Brian each create a public link on their own file; Alice lists all shares with no `path`/`space` parameter — the exact endpoint call that regressed — and must see only her own. Untagged on purpose: reva's CI runs the `coreApi*` suites with `BEHAT_FILTER_TAGS="~@skip&&~@skipOnReva&&~@env-config"`, so this scenario guards the fix on reva PRs too, not only here.

**`apiSharingNgShares/sharedByMe.feature`** — Graph, three scenarios

`/me/drive/sharedByMe` is the one genuinely unfiltered caller in ocis (`sharedbyme.go` passes `nil` filters straight through). Nothing pinned its behaviour before: all 32 pre-existing `sharedByMe` scenarios have Alice listing her own shares.

1. Space member (Brian, `Manager`) **sees** a co-member's link.
2. Non-member (Carol) **does not** see it.
3. `@env-config` — non-member holding `Viewer With ListGrants` **on the individual file** still **sees** it. Tagged `@env-config` because the `*-list-grants` roles are disabled by default; the scenario enables them at runtime via `the administrator has enabled the following share permissions roles:` (which reconfigures `GRAPH_AVAILABLE_ROLES` through the ocis wrapper).


## Verification

- `make test-gherkin-lint` → `PASS 0 problem (0 error, 0 warning)`
- Every Gherkin step traced to an existing step definition on this branch; no new step definitions needed
- Every data-table value checked against its resolver: space role `Manager` and `Viewer With ListGrants` via `GraphHelper`'s role maps, link role `View` via `SHARING_LINK_TYPE_MAPPINGS` (a separate namespace from space roles)
