### PR TITLE
[tests-only][full-ci] test: add retry once for space creation wherever required

### DIFF
--- a/tests/acceptance/bootstrap/SpacesContext.php
+++ b/tests/acceptance/bootstrap/SpacesContext.php
@@ -1929,11 +1929,12 @@ class SpacesContext implements Context {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has created a space "([^"]*)"(| in vault)? with the default quota using the Graph API$/
+	 * @Given /^user "([^"]*)" has created a space "([^"]*)"(| in vault)?(| with retry) with the default quota using the Graph API$/
 	 *
 	 * @param string $user
 	 * @param string $spaceName
 	 * @param string $isVault
+	 * @param string $withRetry
 	 *
 	 * @return void
 	 *
@@ -1944,10 +1945,22 @@ class SpacesContext implements Context {
 		string $user,
 		string $spaceName,
 		string $isVault,
+		string $withRetry,
 	): void {
 		$space = ["name" => $spaceName];
 		$isVault = trim($isVault) === "in vault";
+		$withRetry = trim($withRetry) === "with retry";
+
+		// The user role may take some time to update
+		// This can cause an unauthorized error
+		// Retry once after 1 second
 		$response = $this->createSpace($user, $space, $isVault);
+
+		if ($withRetry && $response->getStatusCode() === 401) {
+			sleep(1); // Wait 1 second before retrying.
+			$response = $this->createSpace($user, $space, $isVault);
+		}
+
 		$this->featureContext->theHTTPStatusCodeShouldBe(
 			201,
 			"Expected response status code should be 201 (Created)",

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -834,7 +834,7 @@ Feature: collaboration (wopi)
   Scenario: user with Viewer role tries to create a odt file inside shared project space using wopi endpoint
     Given using spaces DAV path
     And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
-    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a space "new-space" with retry with the default quota using the Graph API
     And user "Alice" has created a folder "testFolder" in space "new-space"
     And user "Alice" has sent the following space share invitation:
       | space           | new-space    |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The user role may take some time to update; due to this, an unauthorized error occurs while creating a space. So this PR adds a retry once after 1 second

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/12764

## CI failure log

```bash
Scenario: user with Viewer role tries to create a odt file inside shared project space using wopi endpoint                  # /home/runner/work/ocis/ocis/tests/acceptance/features/apiCollaboration/wopi.feature:834
{"level":"error","service":"search","error":"error: not found: stat: error: not found: ","time":"2026-08-07T11:50:25Z","message":"error walking the tree"}
{"level":"error","service":"search","error":"error: not found: stat: error: not found: ","spaceID":{"opaque_id":"9bc75138-9ce3-49d0-b127-622038939571$dc311652-016f-45a3-b19f-6c1f9015f177"},"time":"2026-08-07T11:50:25Z","message":"error while indexing a space"}
    Given using spaces DAV path                                                                                               # FeatureContext::usingOldOrNewOrSpacesDavPath()
    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API                             # GraphContext::theAdministratorHasGivenTheRoleUsingTheGraphApi()
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.OnlyOffice","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.OnlyOffice-4f5a5f59-c0dd-4e1c-9f51-0ea2d8fa0ae6","address":"10.1.0.216:9311"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.FakeOffice","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.FakeOffice-6b7cf940-b70e-4d0a-8077-0d731fc060f5","address":"10.1.0.216:9321"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.Collabora","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.Collabora-2c83f06f-1e26-4642-b3e8-3063f263d5d6","address":"10.1.0.216:9301"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.OnlyOffice","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.OnlyOffice-4f5a5f59-c0dd-4e1c-9f51-0ea2d8fa0ae6","address":"10.1.0.216:9311"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.FakeOffice","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.FakeOffice-6b7cf940-b70e-4d0a-8077-0d731fc060f5","address":"10.1.0.216:9321"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"debug","service":"collaboration","service":{"name":"com.owncloud.api.collaboration.Collabora","version":"8.0.0+b28469ff","metadata":null,"endpoints":[],"nodes":[{"metadata":{"protocol":"grpc","registry":"cache","server":"grpc","transport":"tcp"},"id":"com.owncloud.api.collaboration.Collabora-2c83f06f-1e26-4642-b3e8-3063f263d5d6","address":"10.1.0.216:9301"}]},"time":"2026-08-07T11:51:09Z","line":"/home/runner/work/ocis/ocis/ocis-pkg/registry/register.go:43","message":"refreshing external service-registration"}
{"level":"error","service":"proxy","error":"could not authenticate with username and password user: Alice, got code: 15","authenticator":"basic","path":"/graph/v1.0/drives","time":"2026-08-07T11:51:09Z","message":"failed to authenticate request"}
    And user "Alice" has created a space "new-space" with the default quota using the Graph API                               # SpacesContext::theUserHasCreatedASpaceByDefaultUsingTheGraphApi()
      Expected response status code should be 201 (Created)
      Failed asserting that 401 matches expected 201.
    And user "Alice" has created a folder "testFolder" in space "new-space"  
``` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
