### PR TITLE
[tests-only][full-ci] test: enable secure viewer role before upload in moveReceivedShare scenarios

### DIFF
--- a/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature
@@ -90,9 +90,9 @@ Feature: sharing
 
   @issue-8242 @env-config
   Scenario Outline: share receiver renames the shared item (old/new webdav)
-    Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
+    Given using <dav-path-version> DAV path
     And the administrator has enabled the permissions role "Secure Viewer"
-    And using <dav-path-version> DAV path
+    And user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt      |
       | space           | Personal           |
@@ -133,8 +133,9 @@ Feature: sharing
 
   @issue-8242 @env-config
   Scenario Outline: share receiver renames the shared item (spaces webdav)
-    Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
+    Given using spaces DAV path
     And the administrator has enabled the permissions role "Secure Viewer"
+    And user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | sharefile.txt      |
       | space           | Personal           |
@@ -154,7 +155,6 @@ Feature: sharing
     And as "Carol" file "Shares/renamedsharefile.txt" should exist
     And as "Brian" file "Shares/sharefile.txt" should exist
     And as "Alice" file "sharefile.txt" should exist
-    And using spaces DAV path
     When user "Carol" sends HTTP method "PROPFIND" to URL "<dav-path>"
     Then the HTTP status code should be "207"
     And as user "Carol" the value of the item "//oc:name" of path "<dav-path>/renamedsharefile.txt" in the response should be "renamedsharefile.txt"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Fixes the "share receiver renames the shared item" scenarios in `moveReceivedShare.feature`, which failed with HTTP 500 `add grant: error: resource is processing` on the share invitation step. The role-enabling step restarts the oCIS server, and files uploaded before that restart stay stuck in the postprocessing "processing" state, so the fix reorders the steps to enable the role before the upload. No server code changes, test-only fix.
 
FAILED LOGS: https://github.com/owncloud/ocis/actions/runs/31172955664/job/92851549893#step:10:3888
```bash
 @issue-8242 @env-config
  Scenario Outline: share receiver renames the shared item (old/new webdav)                                                                                       # /home/runner/work/ocis/ocis/tests/acceptance/features/coreApiShareManagementToShares/moveReceivedShare.feature:92

.............

| new              | /dav/files/%username% | Viewer           |
        Failed step: And user "Alice" has sent the following resource share invitation:
        HTTP status code 500 is not the expected value 200
        Failed asserting that 500 matches expected 200.
{"level":"error","service":"proxy","time":"2026-08-07T11:51:04Z","message":"no user in context"}
2026/08/07 11:51:04 [ociswrapper] Stopping oCIS server...
2026/08/07 11:51:06 [ociswrapper] ocis service port 9250 is no longer reachable
2026/08/07 11:51:06 [ociswrapper] Starting oCIS service...
{"level":"error","event":"PostprocessingFinished","uploadid":"70d319b7-2db2-405e-adef-53b0d458c993","error":"ERR_UPLOAD_NOT_FOUND: upload not found","time":"2026-08-07T11:51:06Z","caller":"/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771","message":"Failed to get upload"}
{"level":"error","event":"PostprocessingFinished","uploadid":"70d319b7-2db2-405e-adef-53b0d458c993","error":"ERR_UPLOAD_NOT_FOUND: upload not found","time":"2026-08-07T11:51:06Z","caller":"/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771","message":"Failed to get upload"}
2026/08/07 11:51:07 [ociswrapper] oCIS server is ready to accept requests
2026/08/07 11:51:07 [ociswrapper] gateway service is ready (readyz port 9143)
2026/08/07 11:51:07 [ociswrapper] sharing service is ready (readyz port 9151)

```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
