### PR TITLE
fix(deployments): support Collabora Online 26.x in ocis_full example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ go.work
 go.work.sum
 .env
 .envrc
+
+# generated secrets for deployment examples (e.g. Collabora WOPI proof key)
+deployments/examples/*/config/collabora/
 CLAUDE.md
 .claude/
 GEMINI.md

--- a/changelog/unreleased/bugfix-collabora-26-proof-key.md
+++ b/changelog/unreleased/bugfix-collabora-26-proof-key.md
@@ -1,0 +1,10 @@
+Bugfix: Support Collabora Online 26.x in the ocis_full deployment example
+
+collabora/code 26.x ships without a shell and without the `coolconfig` helper the
+ocis_full example relied on to start the container and generate its WOPI proof
+key, so the example failed to start and, once running, would reject every
+document open with a 500. The example now uses the image's default entrypoint
+and a one-shot init container that generates and persists the WOPI proof key
+before Collabora starts.
+
+https://github.com/owncloud/ocis/pull/12794

--- a/deployments/examples/ocis_full/.env
+++ b/deployments/examples/ocis_full/.env
@@ -212,7 +212,7 @@ TIKA_DOCKER_TAG=latest-full
 COLLABORA=:collabora.yml
 # The recommended (and tested) version to pull. If no version is used, it pulls "latest"
 # release notes: https://www.collaboraonline.com/release-notes/
-COLLABORA_DOCKER_TAG=25.04.9.3.1
+COLLABORA_DOCKER_TAG=26.04.3.1.1
 # Domain of Collabora, where you can find the frontend.
 # Defaults to "collabora.owncloud.test"
 COLLABORA_DOMAIN=
@@ -229,6 +229,9 @@ COLLABORA_SSL_ENABLE=false
 # If you're on an internet-facing server, enable SSL verification for Collabora Online.
 # Please comment out the following line:
 COLLABORA_SSL_VERIFICATION=false
+# Path to persist the Collabora Online WOPI proof key across container restarts (auto-generated on first start).
+# Leaving it default stores it in ./config/collabora relative to this compose project.
+# COLLABORA_CONFIG_DIR=/your/local/collabora/config
 
 
 ## Supplemental Configurations ##

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -48,10 +48,29 @@ services:
       driver: ${LOG_DRIVER:-local}
     restart: always
 
+  # Since collabora/code 26.x, the image ships without a shell (no /bin/bash, no /bin/sh) and
+  # without the "coolconfig" helper that used to generate the WOPI proof key on startup.
+  # This one-shot container generates and persists that key on the host before "collabora" starts.
+  collabora-proof-key-init:
+    image: alpine/openssl:latest
+    user: root
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        if [ ! -f /keys/proof_key ]; then
+          openssl genrsa -out /keys/proof_key 2048
+          chmod 644 /keys/proof_key
+        fi
+    volumes:
+      - ${COLLABORA_CONFIG_DIR:-./config/collabora}:/keys
+
   collabora:
     image: collabora/code:${COLLABORA_DOCKER_TAG}
     networks:
       ocis-net:
+    depends_on:
+      collabora-proof-key-init:
+        condition: service_completed_successfully
     environment:
       DONT_GEN_SSL_CERT: "YES"
       extra_params: |
@@ -62,6 +81,8 @@ services:
         --o:net.frame_ancestors=${OCIS_DOMAIN:-ocis.owncloud.test}
       username: ${COLLABORA_ADMIN_USER:-admin}
       password: ${COLLABORA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - ${COLLABORA_CONFIG_DIR:-./config/collabora}/proof_key:/etc/coolwsd/proof_key:ro
     cap_add:
       - MKNOD
     labels:
@@ -74,7 +95,5 @@ services:
     logging:
       driver: ${LOG_DRIVER:-local}
     restart: always
-    entrypoint: ['/bin/bash', '-c']
-    command: ['coolconfig generate-proof-key && /start-collabora-online.sh']
     healthcheck:
-      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/9980 && echo -e 'GET /hosting/discovery HTTP/1.1\r\nHost: localhost:9980\r\n\r\n' >&3 && head -n 1 <&3 | grep '200 OK'"]
+      test: ["CMD", "/usr/bin/coolwsd", "--probe"]

--- a/deployments/examples/ocis_full/collabora.yml
+++ b/deployments/examples/ocis_full/collabora.yml
@@ -57,6 +57,10 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
+        if [ -e /keys/proof_key ] && ! openssl rsa -in /keys/proof_key -check -noout >/dev/null 2>&1; then
+          echo "/keys/proof_key is missing, not a regular file, or invalid; regenerating" >&2
+          rm -rf /keys/proof_key
+        fi
         if [ ! -f /keys/proof_key ]; then
           openssl genrsa -out /keys/proof_key 2048
           chmod 644 /keys/proof_key


### PR DESCRIPTION
## Summary
- collabora/code 26.x ships without a shell (`/bin/bash` and `/bin/sh` are both gone) and dropped the `coolconfig` helper, so the ocis_full example's custom entrypoint (`coolconfig generate-proof-key && /start-collabora-online.sh`) fails with `stat /bin/bash: no such file or directory`.
- Even after removing that entrypoint, Collabora no longer generates a WOPI proof key on startup at all. Since `services/collaboration` enforces WOPI proof-key signature verification by default (independent of `COLLABORATION_APP_INSECURE`, which only skips TLS verification when fetching the discovery document), every document open would fail with HTTP 500.
- This PR drops the bash entrypoint override (the image's default entrypoint already runs `coolwsd --use-env-vars ...`, which honors the existing `extra_params`/`username`/`password` env vars), replaces the bash-based healthcheck with the built-in `coolwsd --probe`, and adds a one-shot `collabora-proof-key-init` container that generates and persists an RSA proof key on the host before `collabora` starts.
- Bumps `COLLABORA_DOCKER_TAG` to `26.04.3.1.1` and documents the new `COLLABORA_CONFIG_DIR` variable, and gitignores the generated key.

## Test plan
- [x] Pulled `collabora/code:26.04.3.1.1` and confirmed the image has no shell and no `coolconfig` binary
- [x] Verified `docker compose config` resolves the updated `collabora.yml` cleanly
- [x] Brought up the full `ocis_full` example locally with the changes; `collabora` reports healthy with no bash/proof-key errors
- [x] Manually created and edited a document through Collabora end-to-end