### PR TITLE
fix(deployment): downgrade drawio image to 0.4.1 in ocis_full example

### DIFF
--- a/deployments/examples/ocis_full/web_extensions/drawio.yml
+++ b/deployments/examples/ocis_full/web_extensions/drawio.yml
@@ -6,7 +6,7 @@ services:
         condition: service_completed_successfully
 
   drawio-init:
-    image: owncloud/web-extensions:draw-io-0.4.4
+    image: owncloud/web-extensions:draw-io-0.4.1
     user: root
     volumes:
       - ocis-apps:/apps


### PR DESCRIPTION
## Summary
- Downgrade the `drawio-init` image tag in the `ocis_full` deployment example from `draw-io-0.4.4` to `draw-io-0.4.1`, since `0.4.1` is the latest available version of the draw-io web-extensions image.

## Test plan
- [x] Verified the diff only changes the image tag in `deployments/examples/ocis_full/web_extensions/drawio.yml`