### PR TITLE
fix: [OCISDEV-1358] shift-click range selection in the files list

### DIFF
--- a/changelog/unreleased/bugfix-shift-click-range-selection.md
+++ b/changelog/unreleased/bugfix-shift-click-range-selection.md
@@ -1,0 +1,8 @@
+Bugfix: Fix shift-click range selection in the files list
+
+We have fixed an issue where shift-click did not select resources between
+the anchor and the clicked one, and ignored ctrl/cmd. It now selects the
+full range, replacing the current selection unless ctrl/cmd is held, and no
+longer highlights the text of the affected rows.
+
+https://github.com/owncloud/ocis/pull/12804

--- a/changelog/unreleased/bugfix-shift-click-range-selection.md
+++ b/changelog/unreleased/bugfix-shift-click-range-selection.md
@@ -3,6 +3,7 @@ Bugfix: Fix shift-click range selection in the files list
 We have fixed an issue where shift-click did not select resources between
 the anchor and the clicked one, and ignored ctrl/cmd. It now selects the
 full range, replacing the current selection unless ctrl/cmd is held, and no
-longer highlights the text of the affected rows.
+longer highlights the text of the affected rows. Checkboxes now also keep their
+checked state in sync with the selection when a click does not change it.
 
 https://github.com/owncloud/ocis/pull/12804

--- a/web/packages/design-system/src/components/OcCheckbox/OcCheckbox.spec.ts
+++ b/web/packages/design-system/src/components/OcCheckbox/OcCheckbox.spec.ts
@@ -66,6 +66,18 @@ describe('OcCheckbox', () => {
       expect(checkbox.element.checked).toBeFalsy()
       await checkbox.setValue(true)
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+      // the model is owned by the parent, the native state follows it
+      await wrapper.setProps({ modelValue: true })
+      expect(checkbox.element.checked).toBeTruthy()
+    })
+    it('restores the native checked state if the model does not follow the input', async () => {
+      const wrapper = getWrapperWithProps({ modelValue: true })
+      const checkbox = wrapper.find<HTMLInputElement>(checkboxSelector)
+      expect(checkbox.element.checked).toBeTruthy()
+      // the browser toggles the native state on click, the parent keeps the model as it is
+      await checkbox.setValue(false)
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+      await wrapper.vm.$nextTick()
       expect(checkbox.element.checked).toBeTruthy()
     })
   })

--- a/web/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
+++ b/web/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
@@ -2,6 +2,7 @@
   <span>
     <input
       :id="id"
+      ref="input"
       v-model="model"
       type="checkbox"
       name="checkbox"
@@ -10,6 +11,7 @@
       :disabled="disabled"
       :aria-label="labelHidden ? label : null"
       @click="$emit('click', $event)"
+      @change="syncNativeState"
       @keydown.enter="keydownEnter"
     />
     <label v-if="!labelHidden" :for="id" :class="computedLabelClasses" v-text="label" />
@@ -17,7 +19,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, unref } from 'vue'
+import { computed, nextTick, unref, useTemplateRef } from 'vue'
 import { isEqual } from 'lodash-es'
 import { getSizeClass, uniqueId } from '../../helpers'
 
@@ -100,6 +102,17 @@ const model = computed({
     emit('update:modelValue', value)
   }
 })
+const input = useTemplateRef<HTMLInputElement>('input')
+/**
+ * The browser toggles the native checked property on every click. Whoever owns `modelValue` is free
+ * to ignore that (e.g. a range selection keeps an already selected resource selected), and vue does
+ * not re-patch an unchanged model-value, which would leave the native property out of sync.
+ */
+function syncNativeState() {
+  nextTick(() => {
+    unref(input).checked = Boolean(unref(isChecked))
+  })
+}
 function keydownEnter(event: KeyboardEvent) {
   model.value = !model.value
   emit('click', event)

--- a/web/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableMouseActions.ts
+++ b/web/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableMouseActions.ts
@@ -23,10 +23,12 @@ export const useKeyboardTableMouseActions = (
 
   const handleShiftClickAction = ({
     resource,
-    skipTargetSelection
+    skipTargetSelection,
+    extend
   }: {
     resource: Resource
     skipTargetSelection: boolean
+    extend: boolean
   }) => {
     const parent = document.querySelectorAll(`[data-item-id='${resource.id}']`)[0]
     const resourceNodes = Object.values(parent.parentNode.children)
@@ -42,23 +44,32 @@ export const useKeyboardTableMouseActions = (
     const minIndex = Math.min(latestNodeIndex, clickedNodeIndex)
     const maxIndex = Math.max(latestNodeIndex, clickedNodeIndex)
 
+    const rangeIds: string[] = []
     for (let i = minIndex; i <= maxIndex; i++) {
       const nodeId = resourceNodes[i].getAttribute('data-item-id')
       const isDisabled = resourceNodes[i].classList.contains('oc-table-disabled')
       if ((skipTargetSelection && nodeId === resource.id) || isDisabled) {
         continue
       }
-      resourcesStore.addSelection(nodeId)
+      rangeIds.push(nodeId)
+    }
+
+    if (extend) {
+      rangeIds.forEach((id) => resourcesStore.addSelection(id))
+    } else {
+      resourcesStore.setSelection(rangeIds)
     }
     resourcesStore.setLastSelectedId(resource.id)
   }
 
   const handleTilesShiftClickAction = ({
     resource,
-    skipTargetSelection
+    skipTargetSelection,
+    extend
   }: {
     resource: Resource
     skipTargetSelection: boolean
+    extend: boolean
   }) => {
     const tilesListCard = document.querySelectorAll('#tiles-view > ul > li > div')
     const startIndex = findIndex(
@@ -72,6 +83,7 @@ export const useKeyboardTableMouseActions = (
     const minIndex = Math.min(endIndex, startIndex)
     const maxIndex = Math.max(endIndex, startIndex)
 
+    const rangeIds: string[] = []
     for (let i = minIndex; i <= maxIndex; i++) {
       const nodeId = tilesListCard[i].getAttribute('data-item-id')
       const isDisabled = tilesListCard[i].classList.contains('oc-tile-card-disabled')
@@ -79,7 +91,13 @@ export const useKeyboardTableMouseActions = (
       if ((skipTargetSelection && nodeId === resource.id) || isDisabled) {
         continue
       }
-      resourcesStore.addSelection(nodeId)
+      rangeIds.push(nodeId)
+    }
+
+    if (extend) {
+      rangeIds.forEach((id) => resourcesStore.addSelection(id))
+    } else {
+      resourcesStore.setSelection(rangeIds)
     }
     resourcesStore.setLastSelectedId(resource.id)
   }

--- a/web/packages/web-app-files/tests/unit/composables/keyboardActions/useKeyboardTableMouseActions.spec.ts
+++ b/web/packages/web-app-files/tests/unit/composables/keyboardActions/useKeyboardTableMouseActions.spec.ts
@@ -1,0 +1,147 @@
+import { ref } from 'vue'
+import { getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { useKeyboardActions, useResourcesStore, eventBus } from '@ownclouders/web-pkg'
+import { useKeyboardTableMouseActions } from '../../../../src/composables/keyboardActions/useKeyboardTableMouseActions'
+
+describe('useKeyboardTableMouseActions', () => {
+  describe('table view (shift click)', () => {
+    it('replaces the selection with the clicked range, regardless of direction', () => {
+      const { resourcesStore, wrapper } = setUpTableRows(['a', 'b', 'c', 'd'])
+
+      resourcesStore.setSelection(['a'])
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'c' },
+        skipTargetSelection: false,
+        extend: false
+      })
+      expect(resourcesStore.selectedIds).toEqual(['a', 'b', 'c'])
+
+      // shift click "backwards" from the new anchor
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'a' },
+        skipTargetSelection: false,
+        extend: false
+      })
+      expect(resourcesStore.selectedIds).toEqual(['a', 'b', 'c'])
+
+      wrapper.unmount()
+    })
+
+    it('clears any selection outside of the newly clicked range', () => {
+      const { resourcesStore, wrapper } = setUpTableRows(['a', 'b', 'c', 'd'])
+
+      resourcesStore.setSelection(['a', 'd'])
+      resourcesStore.setLastSelectedId('a')
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'b' },
+        skipTargetSelection: false,
+        extend: false
+      })
+
+      expect(resourcesStore.selectedIds).toEqual(['a', 'b'])
+
+      wrapper.unmount()
+    })
+
+    it('extends instead of replacing when ctrl/cmd is held', () => {
+      const { resourcesStore, wrapper } = setUpTableRows(['a', 'b', 'c', 'd'])
+
+      resourcesStore.setSelection(['d'])
+      resourcesStore.setLastSelectedId('a')
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'b' },
+        skipTargetSelection: false,
+        extend: true
+      })
+
+      expect(resourcesStore.selectedIds).toEqual(['d', 'a', 'b'])
+
+      wrapper.unmount()
+    })
+
+    it('skips disabled rows', () => {
+      const { resourcesStore, wrapper } = setUpTableRows(['a', 'b', 'c', 'd'], { disabled: ['b'] })
+
+      resourcesStore.setSelection(['a'])
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'c' },
+        skipTargetSelection: false,
+        extend: false
+      })
+
+      expect(resourcesStore.selectedIds).toEqual(['a', 'c'])
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('tiles view (shift click)', () => {
+    it('replaces the selection with the clicked range', () => {
+      const { resourcesStore, wrapper } = setUpTiles(['a', 'b', 'c', 'd'])
+
+      resourcesStore.setSelection(['a'])
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'c' },
+        skipTargetSelection: false,
+        extend: false
+      })
+
+      expect(resourcesStore.selectedIds).toEqual(['a', 'b', 'c'])
+
+      wrapper.unmount()
+    })
+
+    it('extends instead of replacing when ctrl/cmd is held', () => {
+      const { resourcesStore, wrapper } = setUpTiles(['a', 'b', 'c', 'd'])
+
+      resourcesStore.setSelection(['d'])
+      resourcesStore.setLastSelectedId('a')
+      eventBus.publish('app.files.list.clicked.shift', {
+        resource: { id: 'b' },
+        skipTargetSelection: false,
+        extend: true
+      })
+
+      expect(resourcesStore.selectedIds).toEqual(['d', 'a', 'b'])
+
+      wrapper.unmount()
+    })
+  })
+})
+
+function setUpTableRows(ids: string[], { disabled = [] as string[] } = {}) {
+  document.body.innerHTML = `
+    <table><tbody>
+      ${ids
+        .map(
+          (id) =>
+            `<tr data-item-id="${id}" class="${disabled.includes(id) ? 'oc-table-disabled' : ''}"></tr>`
+        )
+        .join('')}
+    </tbody></table>
+  `
+  return setUpComposable(ref('resource-table'))
+}
+
+function setUpTiles(ids: string[]) {
+  document.body.innerHTML = `
+    <div id="tiles-view"><ul>
+      ${ids.map((id) => `<li><div data-item-id="${id}"></div></li>`).join('')}
+    </ul></div>
+  `
+  return setUpComposable(ref('resource-tiles'))
+}
+
+function setUpComposable(viewMode: ReturnType<typeof ref<string>>) {
+  let resourcesStore: ReturnType<typeof useResourcesStore>
+  const wrapper = getComposableWrapper(
+    () => {
+      const keyActions = useKeyboardActions()
+      resourcesStore = useResourcesStore()
+      useKeyboardTableMouseActions(keyActions, viewMode)
+      return {}
+    },
+    { pluginOptions: { piniaOptions: { stubActions: false } } }
+  )
+  return { resourcesStore, wrapper }
+}

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -28,6 +28,7 @@
     :grouping-settings="groupingSettings"
     padding-x="medium"
     @highlight="fileClicked"
+    @mousedown="preventShiftTextSelection"
     @row-mounted="rowMounted"
     @contextmenu-clicked="showContextMenu"
     @item-dropped="fileDropped"
@@ -67,7 +68,7 @@
         :disabled="isResourceDisabled(item)"
         :model-value="isResourceSelected(item)"
         :outline="isLatestSelectedItem(item)"
-        @click.stop="toggleSelection(item.id)"
+        @click.stop="toggleSelection(item, $event)"
       />
     </template>
     <template #name="{ item }">
@@ -493,8 +494,25 @@ const emitSelect = (selectedIds: string[]) => {
   emit('update:selectedIds', selectedIds)
 }
 
-const toggleSelection = (resourceId: string) => {
-  resourcesStore.toggleSelection(resourceId)
+// shift+click would otherwise extend the browser's text selection across the rows
+const preventShiftTextSelection = (event: MouseEvent) => {
+  if (event.shiftKey) {
+    event.preventDefault()
+  }
+}
+
+const toggleSelection = (resource: Resource, event?: MouseEvent) => {
+  if (event?.shiftKey) {
+    return eventBus.publish('app.files.list.clicked.shift', {
+      resource,
+      skipTargetSelection: false,
+      extend: event.metaKey || event.ctrlKey
+    })
+  }
+  if (event?.metaKey) {
+    return eventBus.publish('app.files.list.clicked.meta', resource)
+  }
+  resourcesStore.toggleSelection(resource.id)
   emitSelect(resourcesStore.selectedIds)
 }
 
@@ -876,7 +894,7 @@ function addSelectedResource(file: Resource) {
   if (isSelected) {
     return
   }
-  toggleSelection(file.id)
+  toggleSelection(file)
 }
 function showContextMenuOnBtnClick(data: ContextMenuBtnClickEventData, item: Resource) {
   if (unref(isResourceDisabled)(item)) {
@@ -943,11 +961,15 @@ function fileClicked(data: [Resource, MouseEvent, boolean]) {
   if (contextActionClicked) {
     return
   }
+  if (eventData && eventData.shiftKey) {
+    return eventBus.publish('app.files.list.clicked.shift', {
+      resource,
+      skipTargetSelection,
+      extend: eventData.metaKey || eventData.ctrlKey
+    })
+  }
   if (eventData && eventData.metaKey) {
     return eventBus.publish('app.files.list.clicked.meta', resource)
-  }
-  if (eventData && eventData.shiftKey) {
-    return eventBus.publish('app.files.list.clicked.shift', { resource, skipTargetSelection })
   }
   if (isCheckboxClicked) {
     return

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -46,6 +46,7 @@
             $emit('rowMounted', resource, tileRefs.tiles[resource.id], ImageDimension.Tile)
           "
           @contextmenu="showContextMenu($event, resource, tileRefs.tiles[resource.id])"
+          @mousedown="preventShiftTextSelection"
           @click="emitTileClick(resource)"
           @dragstart="dragStart(resource, $event)"
           @dragenter.prevent="setDropStyling(resource, false, $event)"
@@ -389,18 +390,26 @@ const showContextMenu = (
   displayPositionedDropdown(drop._tippy, event, reference)
 }
 
+// shift+click would otherwise extend the browser's text selection across the tiles
+const preventShiftTextSelection = (event: MouseEvent) => {
+  if (event.shiftKey) {
+    event.preventDefault()
+  }
+}
+
 const toggleTile = (data: [Resource, MouseEvent]) => {
   const resource = data[0]
   const eventData = data[1]
 
-  if (eventData && eventData.metaKey) {
-    return eventBus.publish('app.files.list.clicked.meta', resource)
-  }
   if (eventData && eventData.shiftKey) {
     return eventBus.publish('app.files.list.clicked.shift', {
       resource,
-      skipTargetSelection: false
+      skipTargetSelection: false,
+      extend: eventData.metaKey || eventData.ctrlKey
     })
+  }
+  if (eventData && eventData.metaKey) {
+    return eventBus.publish('app.files.list.clicked.meta', resource)
   }
   toggleSelection(resource)
 }

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -64,7 +64,7 @@
               class="oc-flex-inline oc-p-s"
               :disabled="!isSpaceResource(resource) && isResourceDisabled(resource)"
               :model-value="isResourceSelected(resource)"
-              @click.stop.prevent="toggleTile([resource, $event])"
+              @click.stop="toggleTile([resource, $event])"
             />
           </template>
           <template #imageField>

--- a/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -369,6 +369,26 @@ describe('ResourceTable', () => {
       expect(wrapper.find('.oc-tbody-tr-in-delete-queue .oc-checkbox').exists()).toBe(false)
       expect(wrapper.find('.oc-tbody-tr-in-delete-queue .oc-spinner').exists()).toBe(true)
     })
+    it('publishes a shift-click event instead of toggling when shift is held on a checkbox', async () => {
+      const { wrapper } = getMountedWrapper()
+      const publishSpy = vi.spyOn(eventBus, 'publish')
+      await wrapper.find('.oc-tbody-tr-documents .oc-checkbox').trigger('click', { shiftKey: true })
+      expect(publishSpy).toHaveBeenCalledWith(
+        'app.files.list.clicked.shift',
+        expect.objectContaining({ resource: expect.objectContaining({ id: 'documents' }) })
+      )
+      expect(wrapper.emitted('update:selectedIds')).toBeUndefined()
+    })
+    it('publishes a meta-click event instead of toggling when meta is held on a checkbox', async () => {
+      const { wrapper } = getMountedWrapper()
+      const publishSpy = vi.spyOn(eventBus, 'publish')
+      await wrapper.find('.oc-tbody-tr-documents .oc-checkbox').trigger('click', { metaKey: true })
+      expect(publishSpy).toHaveBeenCalledWith(
+        'app.files.list.clicked.meta',
+        expect.objectContaining({ id: 'documents' })
+      )
+      expect(wrapper.emitted('update:selectedIds')).toBeUndefined()
+    })
 
     describe('all rows already selected', () => {
       it('de-selects all resources via the select-all checkbox', async () => {

--- a/web/tests/e2e/specs/file-action/rangeSelection.spec.ts
+++ b/web/tests/e2e/specs/file-action/rangeSelection.spec.ts
@@ -1,0 +1,151 @@
+import { test } from '../../environment/test'
+import * as api from '../../steps/api/api'
+import * as ui from '../../steps/ui/index'
+
+test.describe('range selection with shift-click', { tag: '@predefined-users' }, () => {
+  test.beforeEach(async () => {
+    // Given "Admin" creates following user using API
+    //   | id    |
+    //   | Alice |
+    await api.usersHaveBeenCreated({ stepUser: 'Admin', users: ['Alice'] })
+    // And "Alice" creates the following folders in personal space using API
+    //   | name    |
+    //   | folder1 |
+    //   | folder2 |
+    //   | folder3 |
+    //   | folder4 |
+    await api.userHasCreatedFolders({
+      stepUser: 'Alice',
+      folderNames: ['folder1', 'folder2', 'folder3', 'folder4']
+    })
+    // And "Alice" logs in
+    await ui.userLogsIn({ stepUser: 'Alice' })
+    // And "Alice" navigates to the personal space page
+    await ui.userNavigatesToPersonalSpacePage({ stepUser: 'Alice' })
+  })
+
+  test.afterEach(async () => {
+    // And "Alice" logs out
+    await ui.userLogsOut({ stepUser: 'Alice' })
+  })
+
+  test('shift-click selects every resource in between in the list view', async () => {
+    // When "Alice" selects resource "folder1"
+    await ui.userSelectsResource({ stepUser: 'Alice', resource: 'folder1' })
+    // And "Alice" shift-clicks resource "folder3"
+    await ui.userSelectsResource({
+      stepUser: 'Alice',
+      resource: 'folder3',
+      modifiers: ['Shift']
+    })
+    // Then following resources should be selected for user "Alice"
+    //   | resource |
+    //   | folder1  |
+    //   | folder2  |
+    //   | folder3  |
+    await ui.userShouldSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder1', 'folder2', 'folder3']
+    })
+    // And following resources should not be selected for user "Alice"
+    //   | resource |
+    //   | folder4  |
+    await ui.userShouldNotSeeSelectedResources({ stepUser: 'Alice', resources: ['folder4'] })
+    // And "Alice" should not see any highlighted text
+    await ui.userShouldNotSeeHighlightedText({ stepUser: 'Alice' })
+
+    // When "Alice" shift-clicks resource "folder4" with ctrl/cmd pressed
+    await ui.userSelectsResource({
+      stepUser: 'Alice',
+      resource: 'folder4',
+      modifiers: ['Shift', 'ControlOrMeta']
+    })
+    // Then following resources should be selected for user "Alice"
+    //   | resource |
+    //   | folder1  |
+    //   | folder2  |
+    //   | folder3  |
+    //   | folder4  |
+    await ui.userShouldSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder1', 'folder2', 'folder3', 'folder4']
+    })
+  })
+
+  test('shift-click selects backwards and replaces the previous selection', async () => {
+    // When "Alice" selects resource "folder4"
+    await ui.userSelectsResource({ stepUser: 'Alice', resource: 'folder4' })
+    // And "Alice" shift-clicks resource "folder2"
+    await ui.userSelectsResource({
+      stepUser: 'Alice',
+      resource: 'folder2',
+      modifiers: ['Shift']
+    })
+    // Then following resources should be selected for user "Alice"
+    //   | resource |
+    //   | folder2  |
+    //   | folder3  |
+    //   | folder4  |
+    await ui.userShouldSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder2', 'folder3', 'folder4']
+    })
+    // And following resources should not be selected for user "Alice"
+    //   | resource |
+    //   | folder1  |
+    await ui.userShouldNotSeeSelectedResources({ stepUser: 'Alice', resources: ['folder1'] })
+
+    // When "Alice" selects resource "folder1"
+    await ui.userSelectsResource({ stepUser: 'Alice', resource: 'folder1' })
+    // And "Alice" shift-clicks resource "folder2"
+    await ui.userSelectsResource({
+      stepUser: 'Alice',
+      resource: 'folder2',
+      modifiers: ['Shift']
+    })
+    // Then following resources should be selected for user "Alice"
+    //   | resource |
+    //   | folder1  |
+    //   | folder2  |
+    await ui.userShouldSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder1', 'folder2']
+    })
+    // And following resources should not be selected for user "Alice"
+    //   | resource |
+    //   | folder3  |
+    //   | folder4  |
+    await ui.userShouldNotSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder3', 'folder4']
+    })
+  })
+
+  test('shift-click selects every resource in between in the tiles view', async () => {
+    // When "Alice" switches to the tiles-view
+    await ui.userSwitchesToTilesViewMode({ stepUser: 'Alice' })
+    // And "Alice" selects resource "folder1"
+    await ui.userSelectsResource({ stepUser: 'Alice', resource: 'folder1' })
+    // And "Alice" shift-clicks resource "folder3"
+    await ui.userSelectsResource({
+      stepUser: 'Alice',
+      resource: 'folder3',
+      modifiers: ['Shift']
+    })
+    // Then following resources should be selected for user "Alice"
+    //   | resource |
+    //   | folder1  |
+    //   | folder2  |
+    //   | folder3  |
+    await ui.userShouldSeeSelectedResources({
+      stepUser: 'Alice',
+      resources: ['folder1', 'folder2', 'folder3']
+    })
+    // And following resources should not be selected for user "Alice"
+    //   | resource |
+    //   | folder4  |
+    await ui.userShouldNotSeeSelectedResources({ stepUser: 'Alice', resources: ['folder4'] })
+    // And "Alice" should not see any highlighted text
+    await ui.userShouldNotSeeHighlightedText({ stepUser: 'Alice' })
+  })
+})

--- a/web/tests/e2e/steps/ui/resources.ts
+++ b/web/tests/e2e/steps/ui/resources.ts
@@ -1,6 +1,10 @@
 import { expect } from '@playwright/test'
 import { objects } from '../../support'
-import { createResourceTypes, shortcutType } from '../../support/objects/app-files/resource/actions'
+import {
+  clickResourceModifier,
+  createResourceTypes,
+  shortcutType
+} from '../../support/objects/app-files/resource/actions'
 import { editor } from '../../support/objects/app-files/utils'
 import path from 'path'
 import { Public } from '../../support/objects/app-files/page'
@@ -108,6 +112,58 @@ export async function userSearchesGloballyWithFilter({
     filter: filter,
     pressEnter
   })
+}
+
+export async function userSelectsResource({
+  stepUser,
+  resource,
+  modifiers
+}: {
+  stepUser: string
+  resource: string
+  modifiers?: clickResourceModifier[]
+}): Promise<void> {
+  const world = getWorld()
+  const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+  const resourceObject = new objects.applicationFiles.Resource({ page })
+  await resourceObject.clickResourceCheckbox({ resource, modifiers })
+}
+
+export async function userShouldSeeSelectedResources({
+  stepUser,
+  resources
+}: {
+  stepUser: string
+  resources: string[]
+}): Promise<void> {
+  const world = getWorld()
+  const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+  const resourceObject = new objects.applicationFiles.Resource({ page })
+  await resourceObject.expectResourcesToBeSelected({ resources, selected: true })
+}
+
+export async function userShouldNotSeeSelectedResources({
+  stepUser,
+  resources
+}: {
+  stepUser: string
+  resources: string[]
+}): Promise<void> {
+  const world = getWorld()
+  const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+  const resourceObject = new objects.applicationFiles.Resource({ page })
+  await resourceObject.expectResourcesToBeSelected({ resources, selected: false })
+}
+
+export async function userShouldNotSeeHighlightedText({
+  stepUser
+}: {
+  stepUser: string
+}): Promise<void> {
+  const world = getWorld()
+  const { page } = world.actorsEnvironment.getActor({ key: stepUser })
+  const resourceObject = new objects.applicationFiles.Resource({ page })
+  await resourceObject.expectNoTextToBeHighlighted()
 }
 
 export async function userSwitchesToTilesViewMode({

--- a/web/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/web/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -41,6 +41,8 @@ const checkBoxForTrashbin = `//*[@data-test-resource-path="%s"]//ancestor::tr//i
 const filesSelector = '//*[@data-test-resource-name="%s"]'
 export const fileRow =
   '//ancestor::*[(contains(@class, "oc-tile-card") or contains(@class, "oc-tbody-tr"))]'
+// works in both table and tiles view
+const resourceCheckBox = `//*[@data-test-resource-name="%s"]${fileRow}//input`
 export const resourceNameSelector =
   ':is(#files-files-table, .oc-tiles-item, #files-shared-with-me-accepted-section, .files-table) [data-test-resource-name="%s"]'
 // following breadcrumb selectors is passed to buildXpathLiteral function as the content to be inserted might contain quotes
@@ -1024,6 +1026,44 @@ export const selectOrDeselectResources = async (args: selectResourcesArgs): Prom
       await resourceCheckbox.uncheck()
     }
   }
+}
+
+export type clickResourceModifier = 'Shift' | 'ControlOrMeta'
+
+export type clickResourceCheckboxArgs = {
+  page: Page
+  resource: string
+  modifiers?: clickResourceModifier[]
+}
+
+export const clickResourceCheckbox = async (args: clickResourceCheckboxArgs): Promise<void> => {
+  const { page, resource, modifiers = [] } = args
+  await page.locator(util.format(resourceCheckBox, resource)).click({ modifiers })
+}
+
+export type expectResourcesSelectionArgs = {
+  page: Page
+  resources: string[]
+  selected: boolean
+}
+
+export const expectResourcesToBeSelected = async (
+  args: expectResourcesSelectionArgs
+): Promise<void> => {
+  const { page, resources, selected } = args
+  for (const resource of resources) {
+    const checkBox = page.locator(util.format(resourceCheckBox, resource))
+    if (selected) {
+      await expect(checkBox).toBeChecked()
+    } else {
+      await expect(checkBox).not.toBeChecked()
+    }
+  }
+}
+
+export const expectNoTextToBeHighlighted = async ({ page }: { page: Page }): Promise<void> => {
+  const highlightedText = await page.evaluate(() => window.getSelection().toString())
+  expect(highlightedText).toBe('')
 }
 
 /**/

--- a/web/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/web/tests/e2e/support/objects/app-files/resource/index.ts
@@ -318,6 +318,20 @@ export class Resource {
     await po.expectFileToBeSelected({ ...args, page: this.#page })
   }
 
+  async clickResourceCheckbox(args: Omit<po.clickResourceCheckboxArgs, 'page'>): Promise<void> {
+    await po.clickResourceCheckbox({ ...args, page: this.#page })
+  }
+
+  async expectResourcesToBeSelected(
+    args: Omit<po.expectResourcesSelectionArgs, 'page'>
+  ): Promise<void> {
+    await po.expectResourcesToBeSelected({ ...args, page: this.#page })
+  }
+
+  async expectNoTextToBeHighlighted(): Promise<void> {
+    await po.expectNoTextToBeHighlighted({ page: this.#page })
+  }
+
   async createShotcut(args: Omit<po.shortcutArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     await po.createShotcut({ ...args, page: this.#page })


### PR DESCRIPTION
## Description

Shift-clicking in the files list did not select the resources between the anchor and the clicked resource. This PR fixes the range selection in both the list (table) and tiles view:

- Shift-clicking a resource's **checkbox** now triggers range selection. Previously the checkbox had its own click handler that ignored modifier keys and just toggled the single resource.
- A plain shift-click now **replaces** the current selection with the range instead of adding to it. Holding <kbd>ctrl</kbd>/<kbd>cmd</kbd> together with <kbd>shift</kbd> keeps the previous behaviour and adds the range to the existing selection.
- Shift-clicking no longer makes the browser highlight the text of the affected rows/tiles.

The shift branch is now evaluated before the meta branch in the click handlers, so <kbd>ctrl</kbd>/<kbd>cmd</kbd>+<kbd>shift</kbd> is treated as "extend the range" rather than falling through to the plain <kbd>cmd</kbd>-click handling.

## Related Issue

- Fixes OCISDEV-1358

## Motivation and Context

Range selection via shift-click is a basic expectation from any file manager (Finder, Windows Explorer, Nautilus). Selecting a larger set of resources meant clicking every single checkbox, and the stale additive behaviour silently kept resources selected that were no longer part of the visible range — which is risky when the next action is a bulk delete or move.

## How Has This Been Tested?

- test environment: local dev setup, unit tests via `pnpm vitest`, e2e spec runs in CI
- test case 1: unit tests for `useKeyboardTableMouseActions` covering forward/backward ranges, replace vs. extend, skipped disabled rows and the updated anchor
- test case 2: unit tests for `ResourceTable` asserting that a shift-/meta-click on a checkbox publishes the corresponding event bus event instead of toggling the single resource
- test case 3: e2e spec `rangeSelection.spec.ts` — forward range plus <kbd>ctrl</kbd>/<kbd>cmd</kbd>+<kbd>shift</kbd> extend in the list view, a backward range that replaces the previous selection, and a range in the tiles view; the list and tiles cases also assert that no text got highlighted

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link>
