### PR TITLE
fix: [OCISDEV-868] search for username if group attribute is memberUid

### DIFF
--- a/changelog/unreleased/bugfix-ldap-groups-with-memberuid.md
+++ b/changelog/unreleased/bugfix-ldap-groups-with-memberuid.md
@@ -1,0 +1,11 @@
+Bugfix: Search for usernames if memberUid is used for group membership
+
+Ldap group membership usually use "member" or "uniqueMember" for groups,
+which contains a DN as a value. For the case of "memberUid", the value isn't
+a DN but just a username / uid. As such, getting the members of a group
+didn't work because we expected the values to be DNs.
+
+Using "memberUid" as group membership attribute is now supported, and it
+will show the group members as expected.
+
+https://github.com/owncloud/ocis/pull/12814

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -1381,15 +1381,13 @@ func (i *LDAP) expandLDAPAttributeEntriesByDN(ctx context.Context, e *ldap.Entry
 	return result
 }
 
-// expandLDAPAttributeEntriesByDN will assume the attribute contains usernames
+// expandLDAPAttributeEntriesByUsername will assume the attribute contains usernames
 // values, and it will expand them appropriately.
 // Attributes such as "memberUid" are candidates.
 func (i *LDAP) expandLDAPAttributeEntriesByUsername(ctx context.Context, e *ldap.Entry, attribute, searchTerm string) []*ldap.Entry {
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("ExpandLDAPAttributeEntries")
 	result := []*ldap.Entry{}
-
-	baseFilter := fmt.Sprintf("(objectClass=%s)", i.userObjectClass)
 
 	searchFilter := ""
 	if searchTerm != "" {
@@ -1408,8 +1406,9 @@ func (i *LDAP) expandLDAPAttributeEntriesByUsername(ctx context.Context, e *ldap
 		}
 
 		entryFilter := fmt.Sprintf("(%s=%s)", i.userAttributeMap.userName, ldap.EscapeFilter(entryUid))
+		// filter for objectClass is added inside the getLDAPUserByFilter
 
-		finalFilter := fmt.Sprintf("(&%s%s%s)", baseFilter, searchFilter, entryFilter)
+		finalFilter := fmt.Sprintf("(&%s%s)", searchFilter, entryFilter)
 		logger.Debug().Str("entryUid", entryUid).Msg("lookup")
 		ue, err := i.getLDAPUserByFilter(finalFilter, i.userFilter)
 		if err != nil {

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -70,14 +70,14 @@ type LDAP struct {
 	disableUserMechanism    DisableUserMechanismType
 	localUserDisableGroupDN string
 
-	groupBaseDN          string
-	groupCreateBaseDN    string
-	groupFilter          string
-	groupObjectClass                string
-	groupAdditionalObjectClasses    []string
-	groupIDisOctetString            bool
-	groupScope           int
-	groupAttributeMap    groupAttributeMap
+	groupBaseDN                  string
+	groupCreateBaseDN            string
+	groupFilter                  string
+	groupObjectClass             string
+	groupAdditionalObjectClasses []string
+	groupIDisOctetString         bool
+	groupScope                   int
+	groupAttributeMap            groupAttributeMap
 
 	educationConfig educationConfig
 
@@ -1346,6 +1346,20 @@ func (i *LDAP) removeEntryByDNAndAttributeFromEntry(entry *ldap.Entry, dn string
 
 // expandLDAPAttributeEntries reads an attribute from a ldap entry and expands to users
 func (i *LDAP) expandLDAPAttributeEntries(ctx context.Context, e *ldap.Entry, attribute, searchTerm string) ([]*ldap.Entry, error) {
+	var result []*ldap.Entry
+	if strings.ToLower(attribute) == "memberuid" {
+		result = i.expandLDAPAttributeEntriesByUsername(ctx, e, attribute, searchTerm)
+	} else {
+		result = i.expandLDAPAttributeEntriesByDN(ctx, e, attribute, searchTerm)
+	}
+
+	return result, nil
+}
+
+// expandLDAPAttributeEntriesByDN will assume the attribute contains DN-like
+// values, and it will expand them appropriately.
+// Attributes such as "member" and "uniqueMember" are candidates.
+func (i *LDAP) expandLDAPAttributeEntriesByDN(ctx context.Context, e *ldap.Entry, attribute, searchTerm string) []*ldap.Entry {
 	logger := i.logger.SubloggerWithRequestID(ctx)
 	logger.Debug().Str("backend", "ldap").Msg("ExpandLDAPAttributeEntries")
 	result := []*ldap.Entry{}
@@ -1358,13 +1372,55 @@ func (i *LDAP) expandLDAPAttributeEntries(ctx context.Context, e *ldap.Entry, at
 		ue, err := i.getUserByDN(entryDN, searchTerm)
 		if err != nil {
 			// Ignore errors when reading a specific entry fails, just log them and continue
-			logger.Debug().Err(err).Str("entry", entryDN).Msg("error reading attribute member entry")
+			logger.Debug().Err(err).Str("attr", attribute).Str("entry", entryDN).Msg("error reading attribute member entry")
 			continue
 		}
 		result = append(result, ue)
 	}
 
-	return result, nil
+	return result
+}
+
+// expandLDAPAttributeEntriesByDN will assume the attribute contains usernames
+// values, and it will expand them appropriately.
+// Attributes such as "memberUid" are candidates.
+func (i *LDAP) expandLDAPAttributeEntriesByUsername(ctx context.Context, e *ldap.Entry, attribute, searchTerm string) []*ldap.Entry {
+	logger := i.logger.SubloggerWithRequestID(ctx)
+	logger.Debug().Str("backend", "ldap").Msg("ExpandLDAPAttributeEntries")
+	result := []*ldap.Entry{}
+
+	baseFilter := fmt.Sprintf("(objectClass=%s)", i.userObjectClass)
+
+	searchFilter := ""
+	if searchTerm != "" {
+		searchTerm = ldap.EscapeFilter(searchTerm)
+		searchFilter = fmt.Sprintf(
+			"(|(%s=*%s*)(%s=*%s*)(%s=*%s*))",
+			i.userAttributeMap.userName, searchTerm,
+			i.userAttributeMap.mail, searchTerm,
+			i.userAttributeMap.displayName, searchTerm,
+		)
+	}
+
+	for _, entryUid := range e.GetEqualFoldAttributeValues(attribute) {
+		if entryUid == "" {
+			continue
+		}
+
+		entryFilter := fmt.Sprintf("(%s=%s)", i.userAttributeMap.userName, ldap.EscapeFilter(entryUid))
+
+		finalFilter := fmt.Sprintf("(&%s%s%s)", baseFilter, searchFilter, entryFilter)
+		logger.Debug().Str("entryUid", entryUid).Msg("lookup")
+		ue, err := i.getLDAPUserByFilter(finalFilter, i.userFilter)
+		if err != nil {
+			// Ignore errors when reading a specific entry fails, just log them and continue
+			logger.Debug().Err(err).Str("attr", attribute).Str("entry", entryUid).Msg("error reading attribute member entry")
+			continue
+		}
+		result = append(result, ue)
+	}
+
+	return result
 }
 
 func replaceDN(fullDN *ldap.DN, newDN string) (string, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Group membership assumed LDAP always used either "member" or "uniqueMember" attributes (whose values are DNs), so errors happens when "memberUid" is used.

https://github.com/owncloud/reva/pull/719 might be required because it fixes a related bug.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
memberUid can be used as a valid group membership attribute.

## How Has This Been Tested?
Manually tested with posixGroups

## Screenshots (if appropriate):

<img width="1844" height="824" alt="Screenshot from 2026-08-18 11-20-37" src="https://github.com/user-attachments/assets/550389c6-fe44-42bf-9bd2-afea60d38311" />

Side note: the web UI shows the "cn" or displayname of the user, not the "uid"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
