### PR TITLE
fix: [OCISDEV-1230] long username overflows in admin settings users list

### DIFF
--- a/changelog/unreleased/bugfix-admin-settings-long-username-overflow.md
+++ b/changelog/unreleased/bugfix-admin-settings-long-username-overflow.md
@@ -1,0 +1,11 @@
+Bugfix: Truncate long user names in the admin settings users list
+
+In the admin settings users list, a long user name or display name would
+overflow its table column, pushing the columns after it, including the
+action buttons, out of place or off screen.
+
+Long values in the user name and display name columns are now truncated
+with an ellipsis so the table layout stays intact regardless of value
+length.
+
+https://github.com/owncloud/ocis/pull/12816

--- a/web/packages/web-app-admin-settings/src/components/Users/UsersList.vue
+++ b/web/packages/web-app-admin-settings/src/components/Users/UsersList.vue
@@ -49,6 +49,16 @@
         <template #avatar="{ item }">
           <avatar-image :width="32" :userid="item.id" :user-name="item.displayName" />
         </template>
+        <template #onPremisesSamAccountName="{ item }">
+          <div
+            v-oc-tooltip="item.onPremisesSamAccountName"
+            class="oc-text-truncate"
+            v-text="item.onPremisesSamAccountName"
+          />
+        </template>
+        <template #displayName="{ item }">
+          <div v-oc-tooltip="item.displayName" class="oc-text-truncate" v-text="item.displayName" />
+        </template>
         <template #role="{ item }">
           <template v-if="item.appRoleAssignments">{{ getRoleDisplayNameByUser(item) }}</template>
         </template>
@@ -351,12 +361,16 @@ const fields = computed(() => {
     {
       name: 'onPremisesSamAccountName',
       title: $gettext('User name'),
-      sortable: true
+      type: 'slot',
+      sortable: true,
+      wrap: 'truncate'
     },
     {
       name: 'displayName',
       title: $gettext('First and last name'),
+      type: 'slot',
       sortable: true,
+      wrap: 'truncate',
       tdClass: 'mark-element'
     },
     {

--- a/web/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/web/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -127,8 +127,12 @@ exports[`Users view > list view > renders list initially 1`] = `
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-avatar">
                   <avatar-image width="32" userid="1" user-name="Admin"></avatar-image>
                 </td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName"></td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-displayName mark-element">Admin</td>
+                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-truncate oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName">
+                  <div class="oc-text-truncate"></div>
+                </td>
+                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-truncate oc-td oc-table-data-cell oc-table-data-cell-displayName mark-element">
+                  <div class="oc-text-truncate">Admin</div>
+                </td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-mail">admin@example.org</td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-role">Admin</td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-accountEnabled"><span class="oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-s"><!----></span><span>Allowed</span></span></td>


### PR DESCRIPTION
## Description

In the admin settings users list, a long value in the **User name** or **First and last name** column would overflow its table column instead of wrapping or truncating. This pushed all following columns sideways, including the action buttons, making them partially or fully inaccessible.

Both columns are now rendered through table slots with an inner truncating element (`oc-text-truncate`), so long values are clipped with an ellipsis and the table layout stays stable regardless of value length.

## Related Issue

- Fixes OCISDEV-1230

## Motivation and Context

A long user name or display name broke the table layout in the admin settings users list, shifting other columns and the row actions out of place/view.

## How Has This Been Tested?

- test environment: local dev setup
- test case 1: created/viewed a user with a very long user name and display name in the admin settings users list, confirmed both columns truncate with an ellipsis and the following columns (mail, role, login, actions) stay in place
- test case 2: existing unit test snapshot updated to reflect the new slot-based markup

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>