### PR TITLE
ci: add job timeouts to all GitHub workflows

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -8,6 +8,7 @@ jobs:
   detect-changes:
     name: detect-changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
     steps:
@@ -52,6 +53,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.docs-only != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -171,6 +173,7 @@ jobs:
     name: ${{ matrix.suite }}
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -284,6 +287,7 @@ jobs:
     needs: [build-and-test]
     name: ${{ matrix.suite }}
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -319,6 +323,7 @@ jobs:
     needs: [build-and-test]
     name: ldapPool-${{ matrix.suite }}
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -354,6 +359,7 @@ jobs:
     name: ${{ matrix.suite }}
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -437,6 +443,7 @@ jobs:
     name: e2e-${{ matrix.suite }}
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -638,6 +645,7 @@ jobs:
     name: litmus
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -662,6 +670,7 @@ jobs:
     name: cs3api
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -686,6 +695,7 @@ jobs:
     name: wopi-builtin
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -710,6 +720,7 @@ jobs:
     name: wopi-cs3
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -734,6 +745,7 @@ jobs:
     name: external-ldap-smoke
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -766,6 +778,7 @@ jobs:
     name: external-ldap-distributed-smoke
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -795,6 +808,7 @@ jobs:
   all-acceptance-tests:
     needs: [detect-changes, local-api-tests, cli-tests, ldap-pool-tests, core-api-tests, litmus, cs3api, wopi-builtin, wopi-cs3, e2e-tests, external-ldap-tests, external-ldap-distributed-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Check all jobs passed

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     strategy:
       fail-fast: false

--- a/.github/workflows/k6-load-test.yml
+++ b/.github/workflows/k6-load-test.yml
@@ -18,6 +18,7 @@ jobs:
   k6-load-test:
     name: k6-load-test
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     container:
       image: owncloudci/alpine:latest
     if: >-

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -19,6 +19,7 @@ jobs:
   api-tests:
     name: ${{ matrix.suite }}-k8s
     runs-on: ubuntu-26.04
+    timeout-minutes: 120
 
     if: >-
       github.event_name == 'schedule' ||

--- a/.github/workflows/release-npm-packages.yml
+++ b/.github/workflows/release-npm-packages.yml
@@ -17,6 +17,7 @@ jobs:
   release-npm:
     name: Publish NPM package
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   determine-release-type:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version:       ${{ steps.info.outputs.version }}
       is_production: ${{ steps.info.outputs.is_production }}
@@ -80,6 +81,7 @@ jobs:
 
   generate-code:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [determine-release-type]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -116,6 +118,7 @@ jobs:
     if: false
     name: docker-build (${{ matrix.arch }}, ${{ matrix.repo }})
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    timeout-minutes: 120
     needs: [determine-release-type, generate-code, security-scan-trivy]
     strategy:
       matrix:
@@ -191,6 +194,7 @@ jobs:
   docker-scan:
     name: docker-scan (${{ matrix.arch }}, ${{ matrix.repo }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [determine-release-type, docker-build]
     strategy:
       matrix:
@@ -222,6 +226,7 @@ jobs:
     if: false
     name: docker-manifest (${{ matrix.repo }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [determine-release-type, docker-build, docker-scan]
     strategy:
       matrix:
@@ -248,6 +253,7 @@ jobs:
     if: false
     name: docker-readme (${{ matrix.repo }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [determine-release-type, docker-manifest]
     strategy:
       matrix:
@@ -264,6 +270,7 @@ jobs:
   build-binaries:
     name: build-binaries (${{ matrix.os }})
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [determine-release-type, generate-code]
     strategy:
       matrix:
@@ -291,6 +298,7 @@ jobs:
 
   security-scan-trivy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -303,6 +311,7 @@ jobs:
 
   license-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [determine-release-type, generate-code]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -332,6 +341,7 @@ jobs:
 
   generate-changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [determine-release-type]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -355,6 +365,7 @@ jobs:
 
   create-github-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [determine-release-type, build-binaries, license-check, generate-changelog, security-scan-trivy]
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -383,6 +394,7 @@ jobs:
 
   audit-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - determine-release-type
       - generate-code

--- a/.github/workflows/remove_stale_branches.yml
+++ b/.github/workflows/remove_stale_branches.yml
@@ -16,6 +16,7 @@ jobs:
   remove-stale-branches:
     name: Remove Stale Branches
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: fpicalausa/remove-stale-branches@9b829bc2975ade0c61e64e9613def53ec0732440 # v2.6.1
         with:

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -9,6 +9,7 @@ jobs:
   detect-web-changes:
     name: detect-web-changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       web-changed: ${{ steps.check.outputs.web-changed }}
     steps:
@@ -49,6 +50,7 @@ jobs:
     needs: [detect-web-changes]
     if: needs.detect-web-changes.outputs.web-changed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: web
@@ -96,6 +98,7 @@ jobs:
     name: web-tests-passed
     needs: [detect-web-changes, web-build-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     steps:
       - name: Check web-build-test passed or was skipped

--- a/.github/workflows/weekly_pipeline_report.yml
+++ b/.github/workflows/weekly_pipeline_report.yml
@@ -15,6 +15,7 @@ jobs:
   generate-report:
     name: Generate Pipeline Report
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container: golang:1.25-alpine
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

We've recently had GHA jobs hang until the default 6-hour timeout — e.g. acceptance-test suites stuck in `apt-get` during the "Install libcurl 8.12.0 build dependencies" step, blocking a runner for the full 360 minutes.

This adds an explicit `timeout-minutes` to every job in the repo's workflows, sized by workload:

| Timeout | Jobs |
|---------|------|
| 120 min | acceptance/e2e/k8s/deployment/k6 test suites, release `docker-build`, `build-binaries` |
| 30–60 min | web build, code generation, license checks, security scans, npm/GitHub release publishing, weekly pipeline report |
| 5–15 min | change-detection gates, aggregate status jobs, changelog, docker manifest/readme, stale-branch cleanup |

Notes:

- The timeout counts only the job's own runtime — queue time and waiting on `needs:` dependencies are excluded — and applies per matrix entry, so each suite gets its own budget.
- On timeout the job is cancelled and marked failed; steps guarded with `always()` / `!cancelled()` (report/artifact uploads) still run.
- Not covered: the jobs in `commit-message.yml` and `translation-sync.yml` call reusable workflows via job-level `uses:`, which doesn't accept `timeout-minutes`. Those would need timeouts inside `owncloud/reusable-workflows` (follow-up there if needed).

## Related Issue

- Example of a hung run: https://github.com/owncloud/ocis/actions/runs/32210973227/job/95944956878

## Motivation and Context

Hung jobs waste runner capacity for 6 hours and delay feedback on PRs. With explicit timeouts a wedged job fails within its expected time budget instead.

## How Has This Been Tested?

- Validated all workflow files with `actionlint` and a YAML parser (only pre-existing warnings remain).
- Verified every `runs-on:` in the repo is now followed by a `timeout-minutes`.
- CI-only change; the workflows on this PR exercise the new config directly.

## Types of changes

- [x] Technical debt

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
