### PR TITLE
[tests-only][full-ci] test: wait until qr is fully loaded

### DIFF
--- a/tests/acceptance/TestHelpers/WebUIHelper.php
+++ b/tests/acceptance/TestHelpers/WebUIHelper.php
@@ -77,6 +77,16 @@ class WebUIHelper {
 			$page->waitForSelector(self::$qrCode, ['timeout' => self::$defaultTimeout]);
 			$qrLocator = $page->locator(self::$qrCode);
 
+			// Wait until QR actually finished loading
+			$page->waitForFunction(
+				"(sel) => {\n" .
+				"    const img = document.querySelector(sel);\n" .
+				"    return img && img.complete && img.naturalWidth > 0;\n" .
+				"}",
+				self::$qrCode,
+				['timeout' => self::$defaultTimeout],
+			);
+
 			// setup mfa
 			$qrLocator->screenshot($screenshotPath);
 			if (!file_exists($screenshotPath)) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
waitForSelector only waits for the element to attach/be visible. It does NOT wait for the img's base64 src to actually finish loading. Explicitly wait until the image is fully loaded before screenshotting it. This will fix the test being flaky during reading the qr.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- OCISDEV-1248
