### PR TITLE
[tests-only][full-ci] test(collaboration): cover WOPI lock modes

### DIFF
--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -36,6 +36,7 @@ class CollaborationHelper {
 	 * @param string $password
 	 * @param string $baseUrl
 	 * @param string|null $viewMode
+	 * @param array|null $headers
 	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
@@ -47,6 +48,7 @@ class CollaborationHelper {
 		string $password,
 		string $baseUrl,
 		?string $viewMode = null,
+		?array $headers = null,
 	): ResponseInterface {
 		$url = $baseUrl . "/app/open?app_name=$app&file_id=$fileId";
 		if ($viewMode) {
@@ -57,7 +59,7 @@ class CollaborationHelper {
 			$url,
 			$username,
 			$password,
-			['Content-Type' => 'application/json'],
+			$headers ?? ['Content-Type' => 'application/json'],
 		);
 	}
 

--- a/tests/acceptance/TestHelpers/CollaborationHelper.php
+++ b/tests/acceptance/TestHelpers/CollaborationHelper.php
@@ -59,7 +59,7 @@ class CollaborationHelper {
 			$url,
 			$username,
 			$password,
-			$headers ?? ['Content-Type' => 'application/json'],
+			['Content-Type' => 'application/json'] + ($headers ?? []),
 		);
 	}
 

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\CollaborationHelper;
@@ -309,6 +310,7 @@ class CollaborationContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$this->featureContext->getBaseUrl(),
+			$rows['view_mode'] ?? null,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $appResponse);
 		$this->setLastAppOpenData($appResponse->getBody()->getContents());
@@ -324,7 +326,55 @@ class CollaborationContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function userGetsTheInformationOfTheLastOpenedFileUsingWopiEndpoint(string $user): void {
-		$response = json_decode($this->getLastAppOpenData());
+		[$wopiSrc, $accessToken] = $this->getWopiSrcAndAccessTokenFromLastAppOpenData();
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::get(
+				$wopiSrc . "?access_token=$accessToken",
+			),
+		);
+	}
+
+	/**
+	 * @When user :user sends a lock request to the last opened file using wopi endpoint
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function userSendsALockRequestToTheLastOpenedFileUsingWopiEndpoint(string $user): void {
+		$this->featureContext->setResponse(
+			$this->sendLockRequestToLastOpenedFile(),
+		);
+	}
+
+	/**
+	 * Send a WOPI LOCK request using the last opened file's endpoint.
+	 *
+	 * @return ResponseInterface
+	 * @throws GuzzleException
+	 */
+	private function sendLockRequestToLastOpenedFile(): ResponseInterface {
+		[$wopiSrc, $accessToken] = $this->getWopiSrcAndAccessTokenFromLastAppOpenData();
+		return HttpRequestHelper::post(
+			$wopiSrc . "?access_token=$accessToken",
+			null,
+			null,
+			[
+				'X-WOPI-Override' => 'LOCK',
+				'X-WOPI-Lock' => 'abcdef123',
+			],
+		);
+	}
+
+	/**
+	 * Extract the WOPISrc and the access token from the last app-open response.
+	 *
+	 * @return array{0: string, 1: string} the WOPISrc URL and the access token
+	 */
+	private function getWopiSrcAndAccessTokenFromLastAppOpenData(): array {
+		$response = \json_decode($this->getLastAppOpenData());
 		$accessToken = $response->form_parameters->access_token;
 
 		// Extract the WOPISrc from the app_url
@@ -332,10 +382,46 @@ class CollaborationContext implements Context {
 		parse_str($parsedUrl['query'], $queryParams);
 		$wopiSrc = $queryParams['WOPISrc'];
 
+		return [$wopiSrc, $accessToken];
+	}
+
+	/**
+	 * @Given the public has sent the following app-open request:
+	 *
+	 * @param TableNode $properties
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function thePublicHasSentTheFollowingAppOpenRequest(TableNode $properties): void {
+		$rows = $properties->getRowsHash();
+		$token = $this->featureContext->shareNgGetLastCreatedLinkShareToken();
+		$password = $this->featureContext->getActualPassword("%public%");
+
+		$fileId = $this->spacesContext->getFileId($rows['owner'], $rows['space'], $rows['resource']);
+
+		$appResponse = CollaborationHelper::sendPOSTRequestToAppOpen(
+			$fileId,
+			$rows['app'],
+			'public',
+			$password,
+			$this->featureContext->getBaseUrl(),
+			$rows['view_mode'] ?? null,
+			['Public-Token' => $token],
+		);
+		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $appResponse);
+		$this->setLastAppOpenData($appResponse->getBody()->getContents());
+	}
+
+	/**
+	 * @When the public sends a lock request to the last opened file using wopi endpoint
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function thePublicSendsALockRequestToTheLastOpenedFileUsingWopiEndpoint(): void {
 		$this->featureContext->setResponse(
-			HttpRequestHelper::get(
-				$wopiSrc . "?access_token=$accessToken",
-			),
+			$this->sendLockRequestToLastOpenedFile(),
 		);
 	}
 

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -336,26 +336,32 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When user :user sends a lock request to the last opened file using wopi endpoint
+	 * @When user :user sends a lock request with lock id :lockId to the last opened file using wopi endpoint
 	 *
 	 * @param string $user
+	 * @param string $lockId
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function userSendsALockRequestToTheLastOpenedFileUsingWopiEndpoint(string $user): void {
+	public function userSendsALockRequestWithLockIdToTheLastOpenedFileUsingWopiEndpoint(
+		string $user,
+		string $lockId,
+	): void {
 		$this->featureContext->setResponse(
-			$this->sendLockRequestToLastOpenedFile(),
+			$this->sendLockRequestToLastOpenedFile($lockId),
 		);
 	}
 
 	/**
 	 * Send a WOPI LOCK request using the last opened file's endpoint.
 	 *
+	 * @param string $lockId
+	 *
 	 * @return ResponseInterface
 	 * @throws GuzzleException
 	 */
-	private function sendLockRequestToLastOpenedFile(): ResponseInterface {
+	private function sendLockRequestToLastOpenedFile(string $lockId): ResponseInterface {
 		[$wopiSrc, $accessToken] = $this->getWopiSrcAndAccessTokenFromLastAppOpenData();
 		return HttpRequestHelper::post(
 			$wopiSrc . "?access_token=$accessToken",
@@ -363,7 +369,7 @@ class CollaborationContext implements Context {
 			null,
 			[
 				'X-WOPI-Override' => 'LOCK',
-				'X-WOPI-Lock' => 'abcdef123',
+				'X-WOPI-Lock' => $lockId,
 			],
 		);
 	}
@@ -414,14 +420,16 @@ class CollaborationContext implements Context {
 	}
 
 	/**
-	 * @When the public sends a lock request to the last opened file using wopi endpoint
+	 * @When the public sends a lock request with lock id :lockId to the last opened file using wopi endpoint
+	 *
+	 * @param string $lockId
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function thePublicSendsALockRequestToTheLastOpenedFileUsingWopiEndpoint(): void {
+	public function thePublicSendsALockRequestWithLockIdToTheLastOpenedFileUsingWopiEndpoint(string $lockId): void {
 		$this->featureContext->setResponse(
-			$this->sendLockRequestToLastOpenedFile(),
+			$this->sendLockRequestToLastOpenedFile($lockId),
 		);
 	}
 

--- a/tests/acceptance/bootstrap/CollaborationContext.php
+++ b/tests/acceptance/bootstrap/CollaborationContext.php
@@ -310,7 +310,7 @@ class CollaborationContext implements Context {
 			$this->featureContext->getActualUsername($user),
 			$this->featureContext->getPasswordForUser($user),
 			$this->featureContext->getBaseUrl(),
-			$rows['view_mode'] ?? null,
+			$rows['viewMode'] ?? null,
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $appResponse);
 		$this->setLastAppOpenData($appResponse->getBody()->getContents());
@@ -412,7 +412,7 @@ class CollaborationContext implements Context {
 			'public',
 			$password,
 			$this->featureContext->getBaseUrl(),
-			$rows['view_mode'] ?? null,
+			$rows['viewMode'] ?? null,
 			['Public-Token' => $token],
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe(200, '', $appResponse);

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -1144,12 +1144,26 @@ Feature: collaboration (wopi)
       | space     | Personal   |
       | app       | FakeOffice |
       | view_mode | <mode>     |
-    When user "Alice" sends a lock request to the last opened file using wopi endpoint
+    When user "Alice" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"
     Examples:
       | mode  |
       | view  |
+      | read  |
       | write |
+
+
+  Scenario: lock request with different lock id on locked file returns conflict
+    Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And user "Alice" has sent the following app-open request:
+      | resource  | simple.odt |
+      | space     | Personal   |
+      | app       | FakeOffice |
+      | view_mode | write      |
+    When user "Alice" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
+    Then the HTTP status code should be "200"
+    When user "Alice" sends a lock request with lock id "different-lock-id" to the last opened file using wopi endpoint
+    Then the HTTP status code should be "409"
 
 
   Scenario: viewer sharee sends lock request on shared file
@@ -1164,7 +1178,7 @@ Feature: collaboration (wopi)
       | resource | simple.odt |
       | space    | Shares     |
       | app      | FakeOffice |
-    When user "Brian" sends a lock request to the last opened file using wopi endpoint
+    When user "Brian" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"
 
 
@@ -1183,7 +1197,7 @@ Feature: collaboration (wopi)
       | resource | testFolder/simple.odt |
       | space    | new-space             |
       | app      | FakeOffice            |
-    When user "Brian" sends a lock request to the last opened file using wopi endpoint
+    When user "Brian" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"
 
 
@@ -1199,5 +1213,5 @@ Feature: collaboration (wopi)
       | resource | simple.odt |
       | space    | Personal   |
       | app      | FakeOffice |
-    When the public sends a lock request to the last opened file using wopi endpoint
+    When the public sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -1140,33 +1140,38 @@ Feature: collaboration (wopi)
   Scenario Outline: lock request on file opened with different view modes
     Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
     And user "Alice" has sent the following app-open request:
-      | resource  | simple.odt |
-      | space     | Personal   |
-      | app       | FakeOffice |
-      | view_mode | <mode>     |
+      | resource  | simple.odt  |
+      | space     | Personal    |
+      | app       | FakeOffice  |
+      | viewMode  | <view-mode> |
     When user "Alice" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"
     Examples:
-      | mode  |
-      | view  |
-      | read  |
-      | write |
+      | view-mode |
+      | view      |
+      | read      |
+      | write     |
 
 
-  Scenario: lock request with different lock id on locked file returns conflict
+  Scenario Outline:  lock request with different lock id on file opened with different view modes
     Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
     And user "Alice" has sent the following app-open request:
-      | resource  | simple.odt |
-      | space     | Personal   |
-      | app       | FakeOffice |
-      | view_mode | write      |
+      | resource  | simple.odt  |
+      | space     | Personal    |
+      | app       | FakeOffice  |
+      | viewMode  | <view-mode> |
     When user "Alice" sends a lock request with lock id "abcdef123" to the last opened file using wopi endpoint
     Then the HTTP status code should be "200"
     When user "Alice" sends a lock request with lock id "different-lock-id" to the last opened file using wopi endpoint
-    Then the HTTP status code should be "409"
+    Then the HTTP status code should be "<http-status-code>"
+    Examples:
+      | view-mode | http-status-code |
+      | view      | 200              |
+      | read      | 200              |
+      | write     | 409              |
 
 
-  Scenario: viewer sharee sends lock request on shared file
+  Scenario: sharee with viewer permissions role sends lock request on shared file
     Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
     And user "Alice" has sent the following resource share invitation:
       | resource        | simple.odt |

--- a/tests/acceptance/features/apiCollaboration/wopi.feature
+++ b/tests/acceptance/features/apiCollaboration/wopi.feature
@@ -1135,3 +1135,69 @@ Feature: collaboration (wopi)
       | app-endpoint                                                                                | template      | target        |
       | /app/open?file_id=<<FILEID>>&app_name=Collabora&view_mode=write&template_id=<<TEMPLATEID>>  | template.ott  | template.odt  |
       | /app/open?file_id=<<FILEID>>&app_name=OnlyOffice&view_mode=write&template_id=<<TEMPLATEID>> | template.dotx | template.docx |
+
+
+  Scenario Outline: lock request on file opened with different view modes
+    Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And user "Alice" has sent the following app-open request:
+      | resource  | simple.odt |
+      | space     | Personal   |
+      | app       | FakeOffice |
+      | view_mode | <mode>     |
+    When user "Alice" sends a lock request to the last opened file using wopi endpoint
+    Then the HTTP status code should be "200"
+    Examples:
+      | mode  |
+      | view  |
+      | write |
+
+
+  Scenario: viewer sharee sends lock request on shared file
+    Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And user "Alice" has sent the following resource share invitation:
+      | resource        | simple.odt |
+      | space           | Personal   |
+      | sharee          | Brian      |
+      | shareType       | user       |
+      | permissionsRole | Viewer     |
+    And user "Brian" has sent the following app-open request:
+      | resource | simple.odt |
+      | space    | Shares     |
+      | app      | FakeOffice |
+    When user "Brian" sends a lock request to the last opened file using wopi endpoint
+    Then the HTTP status code should be "200"
+
+
+  Scenario: space viewer sends lock request on shared file
+    Given using spaces DAV path
+    And the administrator has assigned the role "Space Admin" to user "Alice" using the Graph API
+    And user "Alice" has created a space "new-space" with the default quota using the Graph API
+    And user "Alice" has created a folder "testFolder" in space "new-space"
+    And user "Alice" creates a file "simple.odt" inside folder "testFolder" in space "new-space" using wopi endpoint
+    And user "Alice" has sent the following space share invitation:
+      | space           | new-space    |
+      | sharee          | Brian        |
+      | shareType       | user         |
+      | permissionsRole | Space Viewer |
+    And user "Brian" has sent the following app-open request:
+      | resource | testFolder/simple.odt |
+      | space    | new-space             |
+      | app      | FakeOffice            |
+    When user "Brian" sends a lock request to the last opened file using wopi endpoint
+    Then the HTTP status code should be "200"
+
+
+  Scenario: public link viewer sends lock request on shared file
+    Given user "Alice" has uploaded file "filesForUpload/simple.odt" to "simple.odt"
+    And user "Alice" has created the following resource link share:
+      | resource        | simple.odt |
+      | space           | Personal   |
+      | permissionsRole | View       |
+      | password        | %public%   |
+    And the public has sent the following app-open request:
+      | owner    | Alice      |
+      | resource | simple.odt |
+      | space    | Personal   |
+      | app      | FakeOffice |
+    When the public sends a lock request to the last opened file using wopi endpoint
+    Then the HTTP status code should be "200"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds acceptance test coverage for https://github.com/owncloud/ocis/pull/12257:
- Add acceptance coverage for WOPI `LOCK` requests after app-open.
- Verify `200 OK` for view/write modes, Viewer sharees, Space Viewers, and public-link Viewers.
- Add public app-open support using the public-link token.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of: https://github.com/owncloud/ocis/issues/12472

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
