### PR TITLE
fix: [OCISDEV-134] enforce password for password protected folders in Shared via link

### DIFF
--- a/changelog/unreleased/bugfix-password-protected-folder-shared-via-link.md
+++ b/changelog/unreleased/bugfix-password-protected-folder-shared-via-link.md
@@ -1,0 +1,13 @@
+Bugfix: Password protection is enforced in the "Shared via link" list
+
+Creating a password-protected folder also creates a hidden folder which holds the
+actual content and carries the password-protected link. That hidden folder is
+listed under Shares / Shared via link, but its entry pointed straight at the
+content in the owner's personal space instead of at the link. Anyone looking at
+that list could therefore open the folder without being asked for the password.
+
+The entry now opens the password-protected link, so the password is requested
+just like it is when opening the folder from the regular file list. If the link
+cannot be determined, the entry is no longer clickable at all.
+
+https://github.com/owncloud/ocis/pull/12835

--- a/web/packages/web-client/src/helpers/share/functions.ts
+++ b/web/packages/web-client/src/helpers/share/functions.ts
@@ -217,6 +217,9 @@ export function buildOutgoingShareResource({
       return { ...(p.grantedToV2.user || p.grantedToV2.group), shareType }
     }),
     shareTypes: driveItem.permissions.map(getShareTypeFromPermission),
+    shareLinks: driveItem.permissions
+      .filter(({ link }) => !!link)
+      .map((graphPermission) => buildLinkShare({ graphPermission, resourceId: driveItem.id })),
     isFolder: !!driveItem.folder,
     type: !!driveItem.folder ? 'folder' : 'file',
     mimeType: driveItem.file?.mimeType || 'httpd/unix-directory',

--- a/web/packages/web-client/src/helpers/share/types.ts
+++ b/web/packages/web-client/src/helpers/share/types.ts
@@ -34,7 +34,13 @@ export interface ShareResource extends Resource {
   outgoing: boolean
   driveId: string
 }
-export interface OutgoingShareResource extends ShareResource {}
+export interface OutgoingShareResource extends ShareResource {
+  /**
+   * The links the resource is shared by. Needed to be able to link to a share via its public
+   * link instead of linking to the resource itself.
+   */
+  shareLinks: LinkShare[]
+}
 
 export interface IncomingShareResource extends ShareResource {
   hidden: boolean

--- a/web/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/web/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -476,6 +476,12 @@ const isResourceClickable = (resource: Resource) => {
     return false
   }
 
+  // a folder without a target must not fall back to the default action, which would navigate
+  // to the folder itself
+  if (resource.isFolder && !getResourceLink(resource)) {
+    return false
+  }
+
   if (!resource.isFolder && !isPasswordProtectedFolderFileResource(resource.name)) {
     if (!resource.canDownload() && !canBeOpenedWithSecureView(resource)) {
       return false

--- a/web/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
+++ b/web/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
@@ -1,6 +1,7 @@
-import { Resource } from '@ownclouders/web-client'
+import { OutgoingShareResource, Resource } from '@ownclouders/web-client'
 import {
   extractParentFolderName,
+  isOutgoingShareResource,
   isProjectSpaceResource,
   isShareRoot,
   isShareSpaceResource
@@ -36,7 +37,29 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
     return space.name
   }
 
+  /**
+   * A password-protected folder keeps its content in a hidden folder in the owner's personal
+   * space, guarded by an auto-created password-protected link. Linking to that folder directly
+   * would open it via the user's own credentials, without ever asking for the password, so in
+   * share listings we send the user to the public link instead. If the link cannot be determined
+   * we rather render no link at all than one which bypasses the password.
+   */
+  const getPasswordProtectedFolderLink = (resource: OutgoingShareResource) => {
+    const shareLink =
+      resource.shareLinks?.find(({ hasPassword }) => hasPassword) || resource.shareLinks?.[0]
+    const token = shareLink?.webUrl?.split('/').pop()
+
+    return token ? { name: 'resolvePublicLink', params: { token } } : null
+  }
+
   const getFolderLink = (resource: Resource) => {
+    if (
+      isOutgoingShareResource(resource) &&
+      resource.path.startsWith('/.PasswordProtectedFolders/projects/')
+    ) {
+      return getPasswordProtectedFolderLink(resource)
+    }
+
     return createFolderLink({
       path: resource.path,
       fileId: resource.fileId,

--- a/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/web/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -540,6 +540,27 @@ describe('ResourceTable', () => {
         wrapper.emitted<{ resources: Resource[] }[]>('fileClick')[0][0].resources[0].name
       ).toMatch('psec-file.psec')
     })
+
+    it('does not link a password-protected folder without a resolvable link', async () => {
+      const resource = mock<OutgoingShareResource>({
+        id: 'secret',
+        name: 'secret',
+        path: '/.PasswordProtectedFolders/projects/Personal/secret',
+        isFolder: true,
+        type: 'folder',
+        getDomSelector: () => extractDomSelector('secret')
+      })
+      resource.outgoing = true
+      resource.sharedWith = []
+      resource.shareLinks = []
+
+      const { wrapper } = getMountedWrapper({ resources: [resource] })
+      const row = wrapper.find('.oc-tbody-tr-secret')
+      await row.find('.oc-resource-name').trigger('click')
+
+      expect(row.find('.oc-resource-link').exists()).toBeFalsy()
+      expect(wrapper.emitted().fileClick).toBeUndefined()
+    })
   })
 
   describe('resource details', () => {

--- a/web/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
+++ b/web/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
@@ -1,6 +1,6 @@
 import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
 import { CapabilityStore, useFolderLink } from '../../../../src/composables'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { OutgoingShareResource, Resource, SpaceResource } from '@ownclouders/web-client'
 
 describe('useFolderLink', () => {
   it('getFolderLink should return the correct folder link', () => {
@@ -18,6 +18,52 @@ describe('useFolderLink', () => {
       name: 'files-spaces-generic',
       params: { driveAliasAndItem: 'personal/admin' },
       query: { fileId: '2' }
+    })
+  })
+
+  describe('getFolderLink for a password-protected folder shared via link', () => {
+    const passwordProtectedFolder = {
+      path: '/.PasswordProtectedFolders/projects/Personal/secret',
+      id: '2',
+      fileId: '2',
+      storageId: '1',
+      spaceId: '1',
+      outgoing: true,
+      sharedWith: [],
+      shareLinks: [{ hasPassword: true, webUrl: 'https://ocis.test/s/sHareToken' }]
+    } as unknown as OutgoingShareResource
+
+    it('should point at the public link so that the password is enforced', () => {
+      const wrapper = createWrapper()
+
+      expect(wrapper.vm.getFolderLink(passwordProtectedFolder)).toEqual({
+        name: 'resolvePublicLink',
+        params: { token: 'sHareToken' }
+      })
+    })
+
+    it('should return no link at all if the public link cannot be determined', () => {
+      const wrapper = createWrapper()
+
+      const withoutShareLinks: OutgoingShareResource = {
+        ...passwordProtectedFolder,
+        shareLinks: []
+      }
+
+      expect(wrapper.vm.getFolderLink(withoutShareLinks)).toBeNull()
+    })
+
+    it('should keep linking to the folder itself outside of a share listing', () => {
+      const wrapper = createWrapper()
+      const { path, id, fileId, storageId, spaceId } = passwordProtectedFolder
+
+      expect(
+        wrapper.vm.getFolderLink({ path, id, fileId, storageId, spaceId } as Resource)
+      ).toEqual({
+        name: 'files-spaces-generic',
+        params: { driveAliasAndItem: 'personal/admin' },
+        query: { fileId: '2' }
+      })
     })
   })
 


### PR DESCRIPTION
## Description

Creating a password protected folder also creates a hidden folder which holds the actual content and carries the auto-created, password protected link. That hidden folder is listed under `Shares > Shared via link`, but its entry linked to the folder in the owner's personal space instead of to the link — so activating it opened the content through the user's own credentials, without ever asking for the link password.

Outgoing share resources now expose their link shares, and in share listings the hidden folder of a password protected folder links to its password protected public link instead. The password is requested just like it is when opening the folder from the regular file list. If no link can be determined, the entry is rendered without a link at all rather than falling back to the folder itself.

The hidden folder stays visible and navigable in the owner's personal space — this change is limited to the share listing.

## Related Issue

- Fixes OCISDEV-134

## Motivation and Context

The list that exists to manage links was the one place where the password protection of a password protected folder was silently skipped.

## How Has This Been Tested?

- test environment: local unit tests (`pnpm vitest`), `vue-tsc --noEmit`, `eslint`, `prettier`
- test case 1: `useFolderLink` links a password protected folder in a share listing to its public link (`resolvePublicLink` with the link's token)
- test case 2: `useFolderLink` returns no link when the public link cannot be determined, and keeps linking to the folder itself outside of share listings
- test case 3: `ResourceTable` renders such an entry as plain text — no link and no default action — when the link cannot be determined
- test case 4: full `web-pkg` and `web-client` unit suites pass (1261 passed, 2 skipped)

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
