### PR TITLE
fix: [OCISDEV-1230] long username/name overflows access details popup and user details panel

### DIFF
--- a/changelog/unreleased/bugfix-share-access-details-long-username-overflow.md
+++ b/changelog/unreleased/bugfix-share-access-details-long-username-overflow.md
@@ -1,0 +1,11 @@
+Bugfix: Wrap long values in share and user details views
+
+In the "Access details" popup of a share, and in the admin settings user
+details panel, a long user name, display name, email or domain would
+overflow the popup or sidebar instead of wrapping, hiding parts of the
+value and breaking the layout.
+
+Long values are now wrapped onto multiple lines so these views stay
+within their bounds regardless of value length.
+
+https://github.com/owncloud/ocis/pull/12839

--- a/changelog/unreleased/bugfix-share-access-details-long-username-overflow.md
+++ b/changelog/unreleased/bugfix-share-access-details-long-username-overflow.md
@@ -8,4 +8,4 @@ value and breaking the layout.
 Long values are now wrapped onto multiple lines so these views stay
 within their bounds regardless of value length.
 
-https://github.com/owncloud/ocis/pull/12839
+https://github.com/owncloud/ocis/pull/12840

--- a/web/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
+++ b/web/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
@@ -160,6 +160,7 @@ const listItems = computed(() => {
     font-weight: bold;
     margin-bottom: var(--oc-space-xsmall);
     margin-top: var(--oc-space-small);
+    overflow-wrap: break-word;
     dt {
       &:first-child {
         margin-top: 0;

--- a/web/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
+++ b/web/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
@@ -140,6 +140,8 @@ const loginDisplayValue = computed(() => {
 <style lang="scss">
 .details-table {
   text-align: left;
+  width: 100%;
+  table-layout: fixed;
 
   tr {
     height: 1.5rem;
@@ -147,6 +149,11 @@ const loginDisplayValue = computed(() => {
 
   th {
     font-weight: 600;
+    width: 40%;
+  }
+
+  td {
+    overflow-wrap: break-word;
   }
 }
 </style>

--- a/web/packages/web-app-admin-settings/src/components/Users/SideBar/UserInfoBox.vue
+++ b/web/packages/web-app-admin-settings/src/components/Users/SideBar/UserInfoBox.vue
@@ -17,6 +17,12 @@ const { user } = defineProps<Props>()
 .user-info {
   align-items: center;
   flex-direction: column;
+
+  span {
+    max-width: 100%;
+    overflow-wrap: break-word;
+    text-align: center;
+  }
 }
 .user-info-display-name {
   font-size: 1.5rem;

--- a/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/web/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -266,7 +266,7 @@ const isRemoveExpirationPossible = computed(() => {
 .share-access-details-drop {
   dl {
     display: grid;
-    grid-template-columns: max-content auto;
+    grid-template-columns: max-content minmax(0, 1fr);
     column-gap: var(--oc-space-medium);
     row-gap: var(--oc-space-xsmall);
   }


### PR DESCRIPTION
## Description

Two more spots affected by long user names/values overflowing their containers, part of the same issue as #12816:

- The share **Access details** popup (opened from the "more" icon on a collaborator/share row): a long name, display name or domain would overflow the popup instead of wrapping.
- The admin settings users page details panel/info box for the selected user: a long user name, display name or email would overflow the sidebar instead of wrapping, breaking the layout.

Both are fixed by making the value cells/columns wrap (`overflow-wrap: break-word`) instead of forcing their fixed-width containers to overflow. The share popup's two-column grid layout was also changed from `max-content auto` to `max-content minmax(0, 1fr)` so the value column can actually shrink to allow wrapping, and the user details table now uses `table-layout: fixed` with explicit column widths for the same reason.

## Related Issue

- Fixes OCISDEV-1230

## Motivation and Context

A long user name, display name, email or domain broke the layout of the share "Access details" popup and the admin settings user details panel, hiding content or pushing it out of view.

## How Has This Been Tested?

- test environment: local dev setup
- test case 1: opened the "Access details" popup for a share with a collaborator/invited-by name and external domain containing a long unbroken string, confirmed values wrap and the popup stays within its bounds
- test case 2: selected a user with a long user name/display name/email in the admin settings users page, confirmed the details panel and info box wrap the value instead of overflowing the sidebar
- test case 3: existing unit tests for `OcInfoDrop`, `EditDropdown` and `DetailsPanel` still pass

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>