### PR TITLE
fix(web): [OCISDEV-1367] public link blocked by brute-force protection (429) shown as Unknown error

### DIFF
--- a/changelog/unreleased/bugfix-public-link-brute-force-429-message.md
+++ b/changelog/unreleased/bugfix-public-link-brute-force-429-message.md
@@ -1,0 +1,22 @@
+Bugfix: Tell public link visitors the link is temporarily blocked
+
+After a handful of wrong password entries, the brute-force protection temporarily
+blocks a password-protected public link. Visitors opening the link were told
+"The resource could not be located, it may not exist anymore." or simply
+"Unknown error" - including visitors, and owners, typing the *correct* password,
+because the block is checked before the password is looked at. Both messages
+were false, and they led link owners to delete and recreate links that were
+never broken, forcing them to redistribute the URL.
+
+The resolve page now says "Too many failed password attempts for this link. It
+has been temporarily blocked, please try again later." both when landing on a
+blocked link and when submitting a password to one. No password field is
+offered, because a further wrong password is still counted and pushes the
+unblock time out.
+
+Unrelated failures on that page no longer claim the resource is gone either:
+they show the message the server sent, or a neutral "An unexpected error
+occurred, please try again later." when it sent none. The not-found wording is
+now reserved for an actual not-found.
+
+https://github.com/owncloud/ocis/pull/12841

--- a/web/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/web/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -128,6 +128,19 @@ const item = computed(() => queryItemAsString(unref(route)?.params?.driveAliasAn
 const detailsQuery = useRouteQuery('details')
 const details = computed(() => queryItemAsString(unref(detailsQuery)))
 
+const publicLinkErrorMessage = (err: DavHttpError): string => {
+  if (err.statusCode === 429) {
+    return $gettext(
+      'Too many failed password attempts for this link. It has been temporarily blocked, please try again later.'
+    )
+  }
+  if (err.statusCode === 404) {
+    return $gettext('The resource could not be located, it may not exist anymore.')
+  }
+  const serverMessage = err.statusCode && err.message !== 'Unknown error' ? err.message : ''
+  return serverMessage || $gettext('An unexpected error occurred, please try again later.')
+}
+
 const loadedSpace = ref<PublicSpaceResource>()
 const isPasswordRequired = ref(false)
 const isInternalLink = ref(false)
@@ -153,30 +166,16 @@ const loadPublicSpaceTask = useTask(function* (signal) {
 
       return
     }
-    if (err.statusCode === 404) {
-      throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
-    }
     throw err
   }
 })
 
 const verifyPasswordTask = useTask(function* (signal) {
-  try {
-    loadedSpace.value = yield clientService.webdav.getFileInfo(
-      unref(publicLinkSpace),
-      {},
-      { signal }
-    )
-    if (!isPublicSpaceResource(unref(loadedSpace))) {
-      const e: any = new Error($gettext('The resource is not a public link.'))
-      e.resource = unref(loadedSpace)
-      throw e
-    }
-  } catch (e) {
-    if (e.statusCode === 401) {
-      throw e
-    }
-    throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
+  loadedSpace.value = yield clientService.webdav.getFileInfo(unref(publicLinkSpace), {}, { signal })
+  if (!isPublicSpaceResource(unref(loadedSpace))) {
+    const e: any = new Error($gettext('The resource is not a public link.'))
+    e.resource = unref(loadedSpace)
+    throw e
   }
 })
 const wrongPassword = computed(() => {
@@ -262,11 +261,11 @@ const resolvePublicLinkTask = useTask(function* (signal, passwordRequired: boole
 
 const errorMessage = computed<string>(() => {
   if (resolvePublicLinkTask.isError && resolvePublicLinkTask.last.error.statusCode !== 401) {
-    return resolvePublicLinkTask.last.error.message
+    return publicLinkErrorMessage(resolvePublicLinkTask.last.error)
   }
 
   if (loadPublicSpaceTask.isError) {
-    return loadPublicSpaceTask.last.error.message
+    return publicLinkErrorMessage(loadPublicSpaceTask.last.error)
   }
   return null
 })

--- a/web/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/web/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -103,6 +103,75 @@ describe('resolvePublicLink', () => {
         'The resource could not be located, it may not exist anymore.'
       )
     })
+    it('should display the blocked message if the link is temporarily blocked', async () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper({ getFileInfoErrorStatusCode: 429 })
+
+      try {
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+      } catch {}
+
+      expect(wrapper.find('.oc-link-resolve-error-message').text()).toContain(
+        'Too many failed password attempts for this link. It has been temporarily blocked, please try again later.'
+      )
+    })
+    it('should display the blocked message and no password form if blocked after entering password', async () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper({
+        passwordRequired: true,
+        getFileInfoErrorStatusCode: 429
+      }) as any
+      await wrapper.vm.loadPublicSpaceTask.last
+      await expect(wrapper.vm.resolvePublicLinkTask.perform(true)).rejects.toThrow()
+
+      expect(wrapper.find('.oc-link-resolve-error-message').text()).toContain(
+        'Too many failed password attempts for this link. It has been temporarily blocked, please try again later.'
+      )
+      expect(wrapper.find('form').exists()).toBe(false)
+    })
+    it('should display the server message for an unknown failure after entering password', async () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper({
+        passwordRequired: true,
+        getFileInfoErrorStatusCode: 500,
+        getFileInfoErrorMessage: 'Internal server error'
+      }) as any
+      await wrapper.vm.loadPublicSpaceTask.last
+      await expect(wrapper.vm.resolvePublicLinkTask.perform(true)).rejects.toThrow()
+
+      const message = wrapper.find('.oc-link-resolve-error-message').text()
+      expect(message).toContain('Internal server error')
+      expect(message).not.toContain('The resource could not be located, it may not exist anymore.')
+    })
+    it('should display a neutral message if the server sent no message', async () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper({
+        getFileInfoErrorStatusCode: 502,
+        getFileInfoErrorMessage: 'Unknown error'
+      })
+
+      try {
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+      } catch {}
+
+      const message = wrapper.find('.oc-link-resolve-error-message').text()
+      expect(message).toContain('An unexpected error occurred, please try again later.')
+      expect(message).not.toContain('Unknown error')
+    })
+    it('should display a neutral message if the request failed without a status', async () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper({
+        getFileInfoError: new TypeError("Cannot read properties of undefined (reading 'status')")
+      })
+
+      try {
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+      } catch {}
+
+      const message = wrapper.find('.oc-link-resolve-error-message').text()
+      expect(message).toContain('An unexpected error occurred, please try again later.')
+      expect(message).not.toContain('Cannot read properties of undefined')
+    })
   })
   describe('internal link', () => {
     it('redirects the user to the login page', async () => {
@@ -120,11 +189,15 @@ describe('resolvePublicLink', () => {
 function getWrapper({
   passwordRequired = false,
   isInternalLink = false,
-  getFileInfoErrorStatusCode = null
+  getFileInfoErrorStatusCode = null,
+  getFileInfoErrorMessage = '',
+  getFileInfoError = null
 }: {
   passwordRequired?: boolean
   isInternalLink?: boolean
   getFileInfoErrorStatusCode?: number
+  getFileInfoErrorMessage?: string
+  getFileInfoError?: Error
 } = {}) {
   const $clientService = mockDeep<ClientService>()
   const spaceResource = mockDeep<SpaceResource>({ driveType: 'public' })
@@ -140,9 +213,16 @@ function getWrapper({
     )
   }
 
-  if (getFileInfoErrorStatusCode) {
+  if (getFileInfoError) {
+    $clientService.webdav.getFileInfo.mockRejectedValueOnce(getFileInfoError)
+  } else if (getFileInfoErrorStatusCode) {
     $clientService.webdav.getFileInfo.mockRejectedValueOnce(
-      new DavHttpError('', 'ERR_UNKNOWN' as DavErrorCode, undefined, getFileInfoErrorStatusCode)
+      new DavHttpError(
+        getFileInfoErrorMessage,
+        'ERR_UNKNOWN' as DavErrorCode,
+        undefined,
+        getFileInfoErrorStatusCode
+      )
     )
   } else {
     $clientService.webdav.getFileInfo.mockResolvedValueOnce(spaceResource)


### PR DESCRIPTION
### Summary

Fixes [#12824](https://github.com/owncloud/ocis/issues/12824).

After a handful of wrong password entries, the storage-publiclink brute-force protection temporarily **blocks** a password-protected public link and returns `429` for *every* request to that token — including requests carrying the *correct* password, because the block is checked before the password is looked at.

The resolve page previously turned that `429` (and other non-401 errors) into either **"The resource could not be located, it may not exist anymore."** or a bare **"Unknown error"**. Both are false, and they led link owners to delete and recreate links that were never broken.

### Changes

- `resolvePublicLink.vue` now maps the error at the render site (`publicLinkErrorMessage`), keyed on `statusCode`:
  - **429** → *"Too many failed password attempts for this link. It has been temporarily blocked, please try again later."*
  - **404** → the not-found wording (now reserved for actual not-found).
  - otherwise → the server's message, or a neutral *"An unexpected error occurred, please try again later."* when none was sent.
- The blocked state is a **terminal error card** — no password field is re-offered, because a further wrong password is still counted and pushes the unblock time out.
- Removed the catch-all in `verifyPasswordTask` that rewrote every non-401 error into the not-found message and discarded `statusCode`/server message; the task now propagates the original error untouched.
- 5 new unit tests covering the 429 message, the 404 path, the two fallback cases, and the absence of the password form while blocked.

### Notes

- **Web-only**, keyed on `statusCode === 429` (not a server error code) so it works against servers already in the field — the reporter is on oCIS 8.0.4, which sends an empty-bodied `429`.
- Deliberately scoped to `resolvePublicLink.vue`. `FilesDrop.vue` and the uppy upload path have separate, related issues that are being tracked as follow-ups.
