### PR TITLE
fix(web): [OCISDEV-1128] app drawer leaks menu items to public link visitors

### DIFF
--- a/changelog/unreleased/bugfix-app-menu-items-leak-to-public-link-visitors.md
+++ b/changelog/unreleased/bugfix-app-menu-items-leak-to-public-link-visitors.md
@@ -1,0 +1,22 @@
+Bugfix: Hide app menu items from anonymous public link visitors
+
+The app drawer in the top bar offered "Activities" and "Library" to anonymous
+visitors following a public link. Both apps registered their app menu item
+unconditionally at bootstrap, before any authentication context exists, and the
+extension registry is shared between the authenticated and the public link
+context. Because the public link file view renders the full application layout,
+the top bar and its app drawer came along with it - even though the sibling top
+bar elements (notification bell, sidebar toggle, home link) already gate
+themselves on the authentication context.
+
+Following the leaked entries did not expose any data: both apps route with
+`authContext: 'user'`, so the visitor was redirected to the login page. What
+leaked was the fact that these apps are enabled on the instance.
+
+Both apps now contribute their menu item only when a user is signed in, matching
+what the files, text editor, app store, admin settings and ScienceMesh apps
+already do. With no menu items left to show, the existing top bar condition
+hides the app drawer on public links by itself.
+
+https://github.com/owncloud/ocis/pull/TODO-PR-NUMBER
+

--- a/changelog/unreleased/bugfix-app-menu-items-leak-to-public-link-visitors.md
+++ b/changelog/unreleased/bugfix-app-menu-items-leak-to-public-link-visitors.md
@@ -18,5 +18,5 @@ what the files, text editor, app store, admin settings and ScienceMesh apps
 already do. With no menu items left to show, the existing top bar condition
 hides the app drawer on public links by itself.
 
-https://github.com/owncloud/ocis/pull/TODO-PR-NUMBER
+https://github.com/owncloud/ocis/pull/12842
 

--- a/web/packages/web-app-activities/src/index.ts
+++ b/web/packages/web-app-activities/src/index.ts
@@ -1,7 +1,12 @@
 import translations from '../l10n/translations.json'
 import { useGettext } from 'vue3-gettext'
 import { computed } from 'vue'
-import { AppMenuItemExtension, defineWebApplication, Extension } from '@ownclouders/web-pkg'
+import {
+  AppMenuItemExtension,
+  defineWebApplication,
+  Extension,
+  useUserStore
+} from '@ownclouders/web-pkg'
 import { urlJoin } from '@ownclouders/web-client'
 import { RouteRecordRaw } from 'vue-router'
 import { APPID } from './appid'
@@ -9,6 +14,7 @@ import { APPID } from './appid'
 export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
+    const userStore = useUserStore()
 
     const appInfo = {
       name: $gettext('Activities'),
@@ -52,7 +58,9 @@ export default defineWebApplication({
     const extensions = computed(() => {
       const result: Extension[] = []
 
-      result.push(menuItemExtension)
+      if (userStore.user) {
+        result.push(menuItemExtension)
+      }
 
       return result
     })

--- a/web/packages/web-app-epub-reader/src/index.ts
+++ b/web/packages/web-app-epub-reader/src/index.ts
@@ -1,11 +1,17 @@
 import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import translations from '../l10n/translations.json'
-import { AppMenuItemExtension, AppWrapperRoute, defineWebApplication } from '@ownclouders/web-pkg'
+import {
+  AppMenuItemExtension,
+  AppWrapperRoute,
+  defineWebApplication,
+  useUserStore
+} from '@ownclouders/web-pkg'
 
 export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
+    const userStore = useUserStore()
 
     const appId = 'epub-reader'
 
@@ -53,17 +59,21 @@ export default defineWebApplication({
       ]
     }
 
-    const extensions = computed<AppMenuItemExtension[]>(() => [
-      {
-        id: `app.${appId}.menuItem`,
-        type: 'appMenuItem',
-        label: () => $gettext('Library'),
-        color: appInfo.color,
-        icon: 'book',
-        priority: 50,
-        path: `/${appId}`
-      }
-    ])
+    const extensions = computed<AppMenuItemExtension[]>(() =>
+      userStore.user
+        ? [
+            {
+              id: `app.${appId}.menuItem`,
+              type: 'appMenuItem',
+              label: () => $gettext('Library'),
+              color: appInfo.color,
+              icon: 'book',
+              priority: 50,
+              path: `/${appId}`
+            }
+          ]
+        : []
+    )
 
     return {
       appInfo,

--- a/web/packages/web-runtime/tests/unit/appMenuItemAuthGate.spec.ts
+++ b/web/packages/web-runtime/tests/unit/appMenuItemAuthGate.spec.ts
@@ -1,0 +1,93 @@
+import { Ref, unref } from 'vue'
+import { User } from '@ownclouders/web-client/graph/generated'
+import { ApplicationInformation, Extension, useUserStore } from '@ownclouders/web-pkg'
+import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+
+import activities from '../../../web-app-activities/src/index'
+import adminSettings from '../../../web-app-admin-settings/src/index'
+import appStore from '../../../web-app-app-store/src/index'
+import epubReader from '../../../web-app-epub-reader/src/index'
+import textEditor from '../../../web-app-text-editor/src/index'
+import { extensions as filesExtensions } from '../../../web-app-files/src/extensions'
+import { extensions as ocmExtensions } from '../../../web-app-ocm/src/extensions'
+
+/**
+ * Every app that contributes an entry to the top bar app drawer must withhold it
+ * from anonymous visitors. The app drawer renders inside the full application
+ * layout, which a public link file view also gets, and the extension registry is
+ * shared between the authenticated and the public link context - so an
+ * unguarded registration is visible to anyone holding a link.
+ *
+ * The apps expose their extensions in two shapes: most return them from
+ * `setup()`, while files and ocm export an `extensions(appInfo)` composable.
+ */
+const APPS: Array<{ name: string; getExtensions: () => Ref<Extension[]> }> = [
+  {
+    name: 'activities',
+    getExtensions: () => activities.setup({ applicationConfig: {} }).extensions
+  },
+  {
+    name: 'admin-settings',
+    getExtensions: () => adminSettings.setup({ applicationConfig: {} }).extensions
+  },
+  { name: 'app-store', getExtensions: () => appStore.setup({ applicationConfig: {} }).extensions },
+  {
+    name: 'epub-reader',
+    getExtensions: () => epubReader.setup({ applicationConfig: {} }).extensions
+  },
+  {
+    name: 'text-editor',
+    getExtensions: () => textEditor.setup({ applicationConfig: {} }).extensions
+  },
+  {
+    name: 'files',
+    getExtensions: () => filesExtensions(mock<ApplicationInformation>({ id: 'files' }))
+  },
+  { name: 'ocm', getExtensions: () => ocmExtensions(mock<ApplicationInformation>({ id: 'ocm' })) }
+]
+
+/**
+ * Apps gated on nothing but a signed-in user. admin-settings and app-store are
+ * absent on purpose: they additionally require permissions, so "a user is signed
+ * in" is not enough to expect their menu item.
+ */
+const USER_ONLY_GATED = ['activities', 'epub-reader', 'files', 'ocm', 'text-editor']
+
+const getAppMenuItems = (
+  getExtensions: () => Ref<Extension[]>,
+  { user }: { user: User | null }
+) => {
+  let items: Extension[]
+  // Some apps reach for the router while building their extensions, so the
+  // wrapper has to supply one.
+  const mocks = defaultComponentMocks()
+  getComposableWrapper(
+    () => {
+      // The shared pinia mock always seeds a user, so an anonymous visitor has to
+      // be expressed by writing the store directly.
+      const userStore = useUserStore()
+      userStore.user = user
+
+      items = unref(getExtensions()).filter((e) => e.type === 'appMenuItem')
+    },
+    { mocks, provide: mocks }
+  )
+  return items
+}
+
+describe('app menu item auth gate', () => {
+  it.each(APPS)(
+    'the $name app contributes no app menu item for an anonymous visitor',
+    ({ getExtensions }) => {
+      expect(getAppMenuItems(getExtensions, { user: null })).toHaveLength(0)
+    }
+  )
+  // The counterpart: the gate must not swallow the menu item for real users.
+  it.each(APPS.filter(({ name }) => USER_ONLY_GATED.includes(name)))(
+    'the $name app contributes its app menu item for a signed-in user',
+    ({ getExtensions }) => {
+      expect(getAppMenuItems(getExtensions, { user: mock<User>({ id: '1' }) })).toHaveLength(1)
+    }
+  )
+})


### PR DESCRIPTION
## Description

The top bar app drawer offered "Activities" and "Library" to anonymous visitors following a public link. Both apps registered their `appMenuItem` extension unconditionally at bootstrap, before any authentication context exists, and the extension registry is shared between the authenticated and the public link context. Because the public link file view renders the full application layout, the top bar and its app drawer came along with it — even though sibling top bar elements (notification bell, sidebar toggle, home link) already gate themselves on the authentication context.

No data was exposed: both apps route with `authContext: 'user'`, so following an entry redirected to login. What leaked was the fact that these apps are enabled on the instance.

Both apps now contribute their menu item only when a user is signed in, matching the files, text editor, app store, admin settings and ScienceMesh apps. A cross-package spec pins the invariant for all seven apps that contribute a drawer entry.

The ticket recommends gating `TopBar.vue:9` instead. Not taken: `appMenuExtensions` there also carries the static Software License / Help Pages items, which should stay visible.

## Notes

- The drawer disappears entirely only when no static items exist. If an operator sets `softwareLicense` or `helpPage` in `theme.json`, the drawer still renders for anonymous visitors showing just those theme links — no app-catalog disclosure, so the finding is closed either way.
- `extensionRegistry.requestExtensions` applies no auth filter, so an eighth app could reintroduce the leak. Not fixed here, because: a blanket filter is impossible — `folderView`, `action` and `sidebarPanel` must serve public links — so the class fix is a declarative `authContext` on `Extension`, an API change to `web-pkg` touching all eight extension types and third-party app authors; its default would have to stay permissive for compatibility, so it wouldn't close the gap by itself; and bundling it would hold this security fix behind a design review, with a revert taking the fix down too. Follow-up ticket to come.

## Related Issue

OCISDEV-1128

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
