### PR TITLE
[tests-only][full-ci] test: fix flaky login error assertion in userFailsToLogin

### DIFF
--- a/web/tests/e2e/steps/ui/session.ts
+++ b/web/tests/e2e/steps/ui/session.ts
@@ -153,7 +153,9 @@ export async function userFailsToLogin({ stepUser }: { stepUser: string }): Prom
 
   await page.goto(config.baseUrl)
   await sessionObject.signIn(user.id, user.password)
-  expect(page.locator('#oc-login-error-message')).toBeVisible({ timeout: config.timeout })
+  await expect(page.locator('#oc-login-error-message')).toBeVisible({
+    timeout: config.timeout * 1000
+  })
   await objects.a11y.Accessibility.assertNoSevereA11yViolations(
     page,
     ['loginErrorMessageLocator'],


### PR DESCRIPTION
`userFailsToLogin` asserts that a user whose login has been disabled is shown the login error message. Two things on that one line make the assertion race the sign-in round-trip.

### 1. `config.timeout` is seconds, and it was passed to Playwright as milliseconds

`web/tests/e2e/config.js` declares `timeout: parseInt(process.env.TIMEOUT) || 180`. Every other place that hands it to Playwright converts it first:

| call site | |
| --- | --- |
| `web/tests/e2e/playwright.config.ts:13` | `timeout: config.timeout * 1000` |
| `web/tests/e2e/support/objects/account/actions.ts:71` | `{ timeout: config.timeout * 1000 }` |
| `web/tests/e2e/support/api/share/share.ts:187` | `{ timeout: (config.timeout / 2) * 1000 }` |
| `web/tests/e2e/steps/ui/resources.ts:748` | `{ timeout: config.timeout * 1000 }` |
| **`web/tests/e2e/steps/ui/session.ts:156`** | `{ timeout: config.timeout }` ← the only one that did not |

So the assertion had **180 ms**, not 180 s, to observe a message that only renders once sign-in has come back from the server. On a developer machine that is usually enough; on a loaded CI runner it is not. The run reports the effective value itself:

```
Locator:  locator('#oc-login-error-message')
Expected: visible
Received: hidden
Timeout:  180ms

Call log:
  - Expect "toBeVisible" with timeout 180ms
    2 × locator resolved to <p hidden="" role="alert" aria-live="assertive" class="oc-error-message" id="oc-login-error-message"></p>
```

The element is found each time — it is simply still `hidden`, and only two polls fit inside the 180 ms window.

### 2. The web-first assertion was not awaited

`expect` in this file is `@playwright/test`'s, so `toBeVisible()` returns a Promise. Unawaited, control fell straight through to `assertNoSevereA11yViolations(...)`, which audits that same error message before the assertion that it is visible has settled. That is the second error in the same failure:

```
Error: page.waitForTimeout: Target page, context or browser has been closed
   at ../support/objects/runtime/application.ts:33
```

Adding the `await` also means the a11y audit now runs against a message that is actually on screen, which is what it was meant to check.

### Observed

`tests/e2e/specs/admin-settings/users.spec.ts:14:3 › users management › user login can be managed in the admin settings` failed on the initial attempt and all three retries, with 29 passing alongside it:

- https://github.com/owncloud/ocis/actions/runs/32731054020/job/97534980083 (`e2e-part-1`)

```
  1 failed
    [chromium] › tests/e2e/specs/admin-settings/users.spec.ts:14:3 › users management › user login can be managed in the admin settings
  29 passed (8.5m)
```

### The change

One statement: `await` added, `* 1000` added. No production code, no other test touched.

### What I ran, and what I did not

- `prettier --check` against `@ownclouders/prettier-config`'s settings (`printWidth: 100`, `singleQuote`, `semi: false`, `trailingComma: 'none'`) on the changed file — passes, and the wrapped form above is byte-identical to what prettier emits, so this should not fight the formatter.
- **I did not run the e2e suite.** It needs a running oCIS instance, which I have no way to stand up. `[full-ci]` is in the title so this PR's own run exercises the changed step.

### Related, deliberately not changed here

`web/tests/e2e/steps/ui/resources.ts:748` has the same missing `await` on a web-first assertion (its units are already correct). I have left it alone rather than widen a flake fix past the line that is failing — happy to fold it in here or leave it for a follow-up, whichever you prefer.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. The evidence above is read rather than inferred: the call-site table is `grep -rn "config.timeout" web/tests/e2e`, the quoted `Timeout: 180ms` and the retry counts are from the linked job log, and the prettier claim is a run of `prettier --check` with that config on the changed file. What was not run is listed as not run.
</details>
