### PR TITLE
fix(web): [OCISDEV-1243] admin-uploaded logo overrides theme-specific logo

### DIFF
--- a/changelog/unreleased/bugfix-web-branding-logo-overrides-theme-logo.md
+++ b/changelog/unreleased/bugfix-web-branding-logo-overrides-theme-logo.md
@@ -1,0 +1,11 @@
+Bugfix: Admin-uploaded logo now overrides theme-specific logos
+
+Previously, a theme's own per-variant logo defined under
+`clients.web.themes[].logo` would keep showing even after an admin uploaded a
+custom logo via the admin settings web app, because the upload only patched
+the `clients.web.defaults.logo` keys. This affected the built-in "owncloud"
+theme too, since most of its variants (dark, high contrast, ...) already
+define their own logo. The admin-uploaded logo now always overrides a
+theme's own per-variant logo.
+
+https://github.com/owncloud/ocis/pull/12847

--- a/services/web/pkg/theme/service.go
+++ b/services/web/pkg/theme/service.go
@@ -82,6 +82,9 @@ func (s Service) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// an admin-uploaded logo must always win over a theme's own per-variant logo
+	applyLogoOverride(mergedTheme, brandingTheme)
+
 	b, err := json.Marshal(mergedTheme)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -143,11 +146,11 @@ func (s Service) LogoUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), KV{
-		"common.logo":                      filepathx.JailJoin("themes", fp),
-		"clients.web.defaults.logo.topbar": filepathx.JailJoin("themes", fp),
-		"clients.web.defaults.logo.login":  filepathx.JailJoin("themes", fp),
-	})
+	values := KV{"common.logo": filepathx.JailJoin("themes", fp)}
+	for _, key := range _brandingLogoKeys {
+		values["clients.web.defaults.logo."+key] = filepathx.JailJoin("themes", fp)
+	}
+	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), values)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -183,11 +186,11 @@ func (s Service) LogoReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), KV{
-		"common.logo":                      nil,
-		"clients.web.defaults.logo.topbar": nil,
-		"clients.web.defaults.logo.login":  nil,
-	})
+	values := KV{"common.logo": nil}
+	for _, key := range _brandingLogoKeys {
+		values["clients.web.defaults.logo."+key] = nil
+	}
+	err = UpdateKV(s.themeFS, filepathx.JailJoin(_brandingRoot, _themeFileName), values)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/services/web/pkg/theme/service_test.go
+++ b/services/web/pkg/theme/service_test.go
@@ -72,3 +72,133 @@ func TestService_Get(t *testing.T) {
 	// themeDefaults
 	assert.Equal(t, jsonData.Get("common.shareRoles."+unifiedrole.UnifiedRoleViewerID+".label").String(), "Viewer")
 }
+
+// A theme (including the built-in "owncloud" one, whose dark and high-contrast
+// variants each define their own logo) can define its own logo per variant
+// under clients.web.themes[].logo. An admin-uploaded logo (branding) must
+// override those variant-specific logos too, not just the clients.web.defaults
+// ones, otherwise the active theme's own logo silently wins over the admin's
+// upload.
+func TestService_Get_BrandingLogoOverridesThemeVariants(t *testing.T) {
+	primaryFS := fsx.NewMemMapFs()
+	fallbackFS := fsx.NewFallbackFS(primaryFS, fsx.NewMemMapFs())
+
+	add := func(filename string, content interface{}) {
+		b, err := json.Marshal(content)
+		assert.Nil(t, err)
+
+		assert.Nil(t, afero.WriteFile(primaryFS, filename, b, 0644))
+	}
+
+	// baseTheme: a theme with its own per-variant logo, as set by the theme author.
+	// The first variant has no logo of its own, mirroring the built-in "owncloud"
+	// theme's default variant, which falls back to clients.web.defaults.logo.
+	add("base/theme.json", map[string]interface{}{
+		"clients": map[string]interface{}{
+			"web": map[string]interface{}{
+				"themes": []interface{}{
+					map[string]interface{}{
+						"isDark": false,
+						"name":   "Light Theme",
+					},
+					map[string]interface{}{
+						"isDark": true,
+						"name":   "Dark Theme",
+						"logo": map[string]interface{}{
+							"topbar":  "themes/base/assets/logo.svg",
+							"favicon": "themes/base/assets/favicon.jpg",
+							"login":   "themes/base/assets/login.svg",
+						},
+					},
+				},
+			},
+		},
+	})
+	// brandingTheme: an admin-uploaded logo
+	add("_branding/theme.json", map[string]interface{}{
+		"common": map[string]interface{}{
+			"logo": "themes/_branding/custom-logo.svg",
+		},
+		"clients": map[string]interface{}{
+			"web": map[string]interface{}{
+				"defaults": map[string]interface{}{
+					"logo": map[string]interface{}{
+						"topbar": "themes/_branding/custom-logo.svg",
+						"login":  "themes/_branding/custom-logo.svg",
+					},
+				},
+			},
+		},
+	})
+
+	service, _ := theme.NewService(
+		theme.ServiceOptions{}.
+			WithThemeFS(fallbackFS).
+			WithGatewaySelector(mocks.NewSelectable[gateway.GatewayAPIClient](t)),
+	)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetPathValue("id", "base")
+
+	w := httptest.NewRecorder()
+	service.Get(w, r)
+
+	jsonData := gjson.Parse(w.Body.String())
+	// variant without its own logo: untouched, still absent, no crash
+	assert.False(t, jsonData.Get("clients.web.themes.0.logo").Exists())
+	// variant with its own logo: overridden by the admin upload
+	assert.Equal(t, "themes/_branding/custom-logo.svg", jsonData.Get("clients.web.themes.1.logo.topbar").String())
+	assert.Equal(t, "themes/_branding/custom-logo.svg", jsonData.Get("clients.web.themes.1.logo.login").String())
+	// favicon is not part of the admin logo upload, so the theme's own favicon must be left untouched
+	assert.Equal(t, "themes/base/assets/favicon.jpg", jsonData.Get("clients.web.themes.1.logo.favicon").String())
+	// the defaults themselves also carry the admin upload
+	assert.Equal(t, "themes/_branding/custom-logo.svg", jsonData.Get("clients.web.defaults.logo.topbar").String())
+}
+
+// Without an admin-uploaded logo, a theme's own per-variant logo must be left
+// exactly as the theme author defined it.
+func TestService_Get_NoBrandingLogoPreservesThemeVariants(t *testing.T) {
+	primaryFS := fsx.NewMemMapFs()
+	fallbackFS := fsx.NewFallbackFS(primaryFS, fsx.NewMemMapFs())
+
+	add := func(filename string, content interface{}) {
+		b, err := json.Marshal(content)
+		assert.Nil(t, err)
+
+		assert.Nil(t, afero.WriteFile(primaryFS, filename, b, 0644))
+	}
+
+	// baseTheme only, no _branding/theme.json at all (admin never uploaded a logo)
+	add("base/theme.json", map[string]interface{}{
+		"clients": map[string]interface{}{
+			"web": map[string]interface{}{
+				"themes": []interface{}{
+					map[string]interface{}{
+						"isDark": true,
+						"name":   "Dark Theme",
+						"logo": map[string]interface{}{
+							"topbar":  "themes/base/assets/logo.svg",
+							"favicon": "themes/base/assets/favicon.jpg",
+							"login":   "themes/base/assets/login.svg",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	service, _ := theme.NewService(
+		theme.ServiceOptions{}.
+			WithThemeFS(fallbackFS).
+			WithGatewaySelector(mocks.NewSelectable[gateway.GatewayAPIClient](t)),
+	)
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.SetPathValue("id", "base")
+
+	w := httptest.NewRecorder()
+	service.Get(w, r)
+
+	jsonData := gjson.Parse(w.Body.String())
+	assert.Equal(t, "themes/base/assets/logo.svg", jsonData.Get("clients.web.themes.0.logo.topbar").String())
+	assert.Equal(t, "themes/base/assets/login.svg", jsonData.Get("clients.web.themes.0.logo.login").String())
+	assert.Equal(t, "themes/base/assets/favicon.jpg", jsonData.Get("clients.web.themes.0.logo.favicon").String())
+}

--- a/services/web/pkg/theme/theme.go
+++ b/services/web/pkg/theme/theme.go
@@ -1,6 +1,7 @@
 package theme
 
 import (
+	"maps"
 	"path"
 
 	"github.com/owncloud/ocis/v2/ocis-pkg/capabilities"
@@ -10,6 +11,13 @@ import (
 var (
 	_brandingRoot  = "_branding"
 	_themeFileName = "theme.json"
+
+	// _brandingLogoKeys are the clients.web.defaults.logo sub-keys the admin
+	// logo upload endpoint controls. LogoUpload, LogoReset, and
+	// applyLogoOverride all derive their keys from this single list so they
+	// can't drift apart — anything added here automatically also overrides a
+	// theme's own per-variant logo.
+	_brandingLogoKeys = []string{"topbar", "login"}
 )
 
 // themeDefaults contains the default values for the theme.
@@ -90,4 +98,76 @@ func isFiletypePermitted(filename string, givenMime string) bool {
 	// Check if we allow that extension and if the mediatype matches the extension
 	extensionMime, ok := capabilities.Default().Theme.Logo.PermittedFileTypes[path.Ext(filename)]
 	return ok && extensionMime == givenMime
+}
+
+// asMap returns v as a map[string]any, regardless of whether its concrete
+// type is KV or map[string]any (both occur depending on whether a KV tree
+// was built in code or decoded from JSON).
+func asMap(v any) (map[string]any, bool) {
+	switch t := v.(type) {
+	case map[string]any:
+		return t, true
+	case KV:
+		return map[string]any(t), true
+	default:
+		return nil, false
+	}
+}
+
+// getPath looks up a dotted path of keys in a nested KV/map tree.
+func getPath(v any, path ...string) (any, bool) {
+	cur := v
+	for _, p := range path {
+		m, ok := asMap(cur)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[p]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// applyLogoOverride forces any admin-uploaded logo (branding) onto every
+// theme variant's own logo entries. Without this, a theme that defines
+// clients.web.themes[].logo itself would keep showing its own logo instead
+// of the one the admin explicitly uploaded, since that per-variant value
+// lives outside the clients.web.defaults.logo keys the upload patches.
+//
+// This mutates merged in place, which is only safe because clients.* is
+// per-request data coming from baseTheme/brandingTheme, never from the
+// shared, package-level themeDefaults tree that MergeKV also aliases in.
+func applyLogoOverride(merged KV, branding KV) {
+	overrides := map[string]any{}
+	for _, key := range _brandingLogoKeys {
+		if val, ok := getPath(branding, "clients", "web", "defaults", "logo", key); ok {
+			overrides[key] = val
+		}
+	}
+	if len(overrides) == 0 {
+		return
+	}
+
+	themes, ok := getPath(merged, "clients", "web", "themes")
+	if !ok {
+		return
+	}
+	variants, ok := themes.([]any)
+	if !ok {
+		return
+	}
+
+	for _, item := range variants {
+		variant, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		logo, ok := asMap(variant["logo"])
+		if !ok {
+			continue
+		}
+		maps.Copy(logo, overrides)
+	}
 }


### PR DESCRIPTION
## Summary
- A theme can define its own logo per UI variant under `clients.web.themes[].logo`, including the built-in "owncloud" theme (most of its variants — dark, high contrast, ...) already do this.
- The admin logo upload endpoint (admin settings web app) only ever patched `clients.web.defaults.logo`, so the active theme's own per-variant logo kept winning over a logo an admin explicitly uploaded.
- The admin-uploaded (branding) logo is now forced onto every theme variant's own logo entries after the theme merge, so it always takes precedence.

Jira: OCISDEV-1243

## Test plan
- [x] Added `TestService_Get_BrandingLogoOverridesThemeVariants` (fails on pre-fix code, passes after)
- [x] Added `TestService_Get_NoBrandingLogoPreservesThemeVariants` (no admin upload → theme's own per-variant logo untouched)
- [x] `go test ./services/web/pkg/theme/...`
- [x] `go vet ./services/web/pkg/theme/...`
- [x] `go build ./services/web/...`