### PR TITLE
fix: [OCISDEV-128] recover login page after the current user was deleted

### DIFF
--- a/changelog/unreleased/bugfix-login-after-user-deleted.md
+++ b/changelog/unreleased/bugfix-login-after-user-deleted.md
@@ -12,4 +12,4 @@ The identity provider now detects this stuck authorization loop, expires the
 stale logon session on the server side and restarts a clean login, so the sign-in
 form is shown again and a different user can sign in right away.
 
-https://github.com/owncloud/ocis/pull/TODO
+https://github.com/owncloud/ocis/pull/12851

--- a/changelog/unreleased/bugfix-login-after-user-deleted.md
+++ b/changelog/unreleased/bugfix-login-after-user-deleted.md
@@ -1,0 +1,15 @@
+Bugfix: Recover the login page after the current user was deleted
+
+When a user account was deleted while its session was still stored in the
+browser, opening the web interface redirected to an authentication error page
+and looped there. The identity provider kept accepting the stale logon session
+but could no longer resolve the deleted user, so the sign-in flow ended up
+re-issuing the authorization request without its parameters and the browser was
+sent back to the same error over and over. The only way out was to clear the
+browser data manually before a different user could sign in.
+
+The identity provider now detects this stuck authorization loop, expires the
+stale logon session on the server side and restarts a clean login, so the sign-in
+form is shown again and a different user can sign in right away.
+
+https://github.com/owncloud/ocis/pull/TODO

--- a/services/idp/pkg/middleware/recoverstalesession.go
+++ b/services/idp/pkg/middleware/recoverstalesession.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
+)
+
+const (
+	// logonCookieName is the name lico uses for the encrypted logon session
+	// cookie (see the vendored identifier bootstrap). It is cleared here to
+	// recover from a stale session pointing at a deleted user.
+	logonCookieName = "__Secure-KKT"
+	// logonCookiePath mirrors the path lico sets the logon cookie with
+	// (pathPrefix + "/identifier/_/"); it must match for the browser to drop it.
+	logonCookiePath = "/signin/v1/identifier/_/"
+	// authorizeSuffix is the path suffix of the OIDC authorization endpoint as
+	// mounted by lico.
+	authorizeSuffix = "/identifier/_/authorize"
+)
+
+// RecoverStaleSession breaks the infinite authorization redirect loop that
+// happens when the logon session cookie points at a user that no longer exists
+// (OCISDEV-128). When the current user has been deleted, lico still accepts its
+// encrypted logon cookie but cannot resolve the user, and the sign-in SPA ends
+// up re-issuing the authorization request with only an OAuth2 `error` parameter.
+// lico answers that with a relative, self-referential redirect back to the same
+// endpoint, so the browser follows `?error=...` forever and the user is stuck
+// until the browser data is cleared manually.
+//
+// An `error` parameter is an OAuth2 response field; a legitimate inbound
+// authorization request never carries one. So its presence on the authorize
+// endpoint is an unambiguous signal that the flow is stuck. In that case we
+// expire the stale logon cookie (the server-side equivalent of clearing the
+// browser data) and send the browser back to the issuer to start a clean login,
+// where the now-missing session makes the identity provider show the sign-in
+// form again and a different user can log in.
+func RecoverStaleSession(cfg *config.Config, logger log.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasSuffix(r.URL.Path, authorizeSuffix) || r.URL.Query().Get("error") == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			logger.Warn().
+				Str("error", r.URL.Query().Get("error")).
+				Msg("recovering from stale logon session: clearing logon cookie and restarting login")
+
+			// Expire the logon cookie using the same name/path/attributes lico
+			// set it with, so the browser drops the stale (deleted-user) session.
+			http.SetCookie(w, &http.Cookie{
+				Name:     logonCookieName,
+				Value:    "",
+				Path:     logonCookiePath,
+				Secure:   true,
+				HttpOnly: true,
+				Expires:  time.Unix(0, 0),
+				MaxAge:   -1,
+			})
+
+			http.Redirect(w, r, cfg.IDP.Iss, http.StatusFound)
+		})
+	}
+}

--- a/services/idp/pkg/middleware/recoverstalesession_test.go
+++ b/services/idp/pkg/middleware/recoverstalesession_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/owncloud/ocis/v2/ocis-pkg/log"
+	"github.com/owncloud/ocis/v2/services/idp/pkg/config"
+)
+
+var _ = Describe("recover stale session", func() {
+	cfg := &config.Config{
+		IDP: config.Settings{Iss: "https://cloud.example.test"},
+	}
+
+	newHandler := func(nextCalled *bool) http.Handler {
+		middle := RecoverStaleSession(cfg, log.NopLogger())
+		return middle(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			*nextCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+
+	It("breaks the authorize error loop by clearing the logon cookie and restarting login", func() {
+		req, _ := http.NewRequest(http.MethodGet,
+			"https://cloud.example.test/signin/v1/identifier/_/authorize?error=unsupported_response_type", nil)
+		req.AddCookie(&http.Cookie{Name: logonCookieName, Value: "stale-deleted-user-token"})
+
+		nextCalled := false
+		rr := httptest.NewRecorder()
+		newHandler(&nextCalled).ServeHTTP(rr, req)
+
+		Expect(nextCalled).To(BeFalse())
+		Expect(rr).To(HaveHTTPStatus(http.StatusFound))
+		Expect(rr.Header().Get("Location")).To(Equal(cfg.IDP.Iss))
+
+		// the stale logon cookie must be expired so the browser drops it
+		var cleared *http.Cookie
+		for _, c := range rr.Result().Cookies() {
+			if c.Name == logonCookieName {
+				cleared = c
+			}
+		}
+		Expect(cleared).NotTo(BeNil())
+		Expect(cleared.MaxAge).To(BeNumerically("<", 0))
+	})
+
+	It("lets a regular authorization request through", func() {
+		req, _ := http.NewRequest(http.MethodGet,
+			"https://cloud.example.test/signin/v1/identifier/_/authorize?response_type=code&client_id=web", nil)
+
+		nextCalled := false
+		rr := httptest.NewRecorder()
+		newHandler(&nextCalled).ServeHTTP(rr, req)
+
+		Expect(nextCalled).To(BeTrue())
+		Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+	})
+
+	It("ignores an error parameter on a non-authorize route", func() {
+		req, _ := http.NewRequest(http.MethodGet,
+			"https://cloud.example.test/signin/v1/identifier?error=unsupported_response_type", nil)
+
+		nextCalled := false
+		rr := httptest.NewRecorder()
+		newHandler(&nextCalled).ServeHTTP(rr, req)
+
+		Expect(nextCalled).To(BeTrue())
+		Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+	})
+})

--- a/services/idp/pkg/service/v0/service.go
+++ b/services/idp/pkg/service/v0/service.go
@@ -315,6 +315,7 @@ func (idp *IDP) initMux(ctx context.Context, r []server.WithRoutes, h http.Handl
 
 	idp.mux.Group(func(r chi.Router) {
 		// routes handled by lico
+		r.Use(middleware.RecoverStaleSession(options.Config, options.Logger))
 		r.Use(middleware.CheckRedirect(options.Config, options.Logger))
 		r.Mount("/", gm)
 	})


### PR DESCRIPTION
## Description
When a user account was deleted while its session was still stored in the browser, opening the web interface redirected to an authentication error page and looped there indefinitely — the only escape was to clear the browser data manually before a different user could sign in.

Root cause: lico still accepts the deleted user's encrypted logon cookie but can no longer resolve the user, so the sign-in SPA re-issues the authorization request without its OIDC parameters. lico answers that bare request with a relative, self-referential `?error=unsupported_response_type` redirect back to the same authorize endpoint, which the browser then follows forever.

This adds a small idp middleware (`RecoverStaleSession`) that detects the stuck loop and recovers from it entirely within oCIS — no vendored-lico change and no new dependencies. An OAuth2 `error` parameter is a *response* field; a legitimate inbound authorization request never carries one, so its presence on the authorize endpoint is an unambiguous signal that the flow is stuck. When detected, the middleware expires the stale logon cookie server-side (the equivalent of clearing the browser data) and restarts a clean login, so the sign-in form is shown again and a different user can log in immediately.

The trigger is deliberately narrow (authorize path **and** an `error` query param), so healthy flows are untouched: normal logins carry no `error`, and genuine OAuth error responses go to the client's redirect URI (`/oidc-callback`), not back to the authorize endpoint.

## Related Issue
- Fixes OCISDEV-128

## Motivation and Context
A deleted user's stale browser session made the login page unusable for everyone on that browser — the app looped on the error page with no way out short of manually clearing site data. This restores the ability to sign in as a different user without any manual browser cleanup.

## How Has This Been Tested?
- test environment: `deployments/examples/ocis_full` with a locally built ocis image
- test case 1 (reproduction): logged in, deleted the current user, reloaded the web UI — previously looped on `.../identifier/_/authorize?error=unsupported_response_type`; with the fix the stale session is cleared and the sign-in form is shown again
- test case 2 (unit): `go test ./services/idp/pkg/middleware/` — error-loop request clears the logon cookie and redirects to the issuer; a regular authorization request and an `error` param on a non-authorize route both pass through untouched

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>
