### PR TITLE
fix: apply renewed access token in embed mode with delegated authentication

### DIFF
--- a/changelog/unreleased/bugfix-web-embed-delegated-token-renewal.md
+++ b/changelog/unreleased/bugfix-web-embed-delegated-token-renewal.md
@@ -1,4 +1,4 @@
-Bugfix: Apply renewed access token in Web embed mode with delegated authentication
+Bugfix: Apply renewed access token in embed mode with delegated authentication
 
 In embed mode with delegated authentication the host application renews the
 access token by posting an "owncloud-embed:update-token" message into the

--- a/changelog/unreleased/bugfix-web-embed-delegated-token-renewal.md
+++ b/changelog/unreleased/bugfix-web-embed-delegated-token-renewal.md
@@ -1,0 +1,12 @@
+Bugfix: Apply renewed access token in Web embed mode with delegated authentication
+
+In embed mode with delegated authentication the host application renews the
+access token by posting an "owncloud-embed:update-token" message into the
+iframe. The message listener was registered as an unbound method reference, so
+it crashed on every incoming message before the renewed token could be applied.
+It also passed the whole message payload to the user context update instead of
+the access token string. The embedded Web instance therefore kept using the
+initial access token until it expired and the user got logged out, even though
+the host had delivered fresh tokens in time.
+
+https://github.com/owncloud/ocis/pull/12856

--- a/web/packages/web-runtime/src/services/auth/authService.ts
+++ b/web/packages/web-runtime/src/services/auth/authService.ts
@@ -405,7 +405,7 @@ export class AuthService implements AuthServiceInterface {
     return user?.refresh_token
   }
 
-  private handleDelegatedTokenUpdate(event: MessageEvent) {
+  private handleDelegatedTokenUpdate = (event: MessageEvent) => {
     if (event.origin !== this.configStore.options.embed?.delegateAuthenticationOrigin) {
       return
     }
@@ -414,8 +414,13 @@ export class AuthService implements AuthServiceInterface {
       return
     }
 
+    const accessToken = event.data.data?.access_token
+    if (!accessToken) {
+      return
+    }
+
     console.debug('[authService:handleDelegatedTokenUpdate] - going to update the access_token')
-    return this.userManager.updateContext(event.data, false)
+    return this.userManager.updateContext(accessToken, false)
   }
 
   /**

--- a/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -67,6 +67,68 @@ describe('AuthService', () => {
     )
   })
 
+  describe('handleDelegatedTokenUpdate', () => {
+    let authService: AuthService
+
+    const signInDelegated = async () => {
+      authService = new AuthService()
+
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getUser: vi.fn().mockResolvedValue(null),
+          getAndClearPostLoginRedirectUrl: vi.fn().mockReturnValue('/'),
+          updateContext: mockUpdateContext
+        })
+      })
+
+      const configStore = useConfigStore()
+      configStore.options = {
+        embed: {
+          enabled: true,
+          delegateAuthentication: true,
+          delegateAuthenticationOrigin: 'https://host.example.org'
+        }
+      }
+      initAuthService({ authService, configStore, router: createRouter() })
+
+      await authService.signInCallback('initial-token')
+      mockUpdateContext.mockClear()
+    }
+
+    afterEach(() => {
+      window.removeEventListener(
+        'message',
+        (authService as any).handleDelegatedTokenUpdate as EventListener
+      )
+    })
+
+    it('ignores "owncloud-embed:update-token" messages from unexpected origins', async () => {
+      await signInDelegated()
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
+          origin: 'https://attacker.example.org'
+        })
+      )
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+
+    it('updates the user context with the access token from "owncloud-embed:update-token" messages', async () => {
+      await signInDelegated()
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
+          origin: 'https://host.example.org'
+        })
+      )
+
+      expect(mockUpdateContext).toHaveBeenCalledWith('renewed-token', false)
+    })
+  })
+
   describe('initializeContext', () => {
     it('when embed mode is disabled and access_token is present, should call updateContext', async () => {
       const authService = new AuthService()

--- a/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -67,68 +67,6 @@ describe('AuthService', () => {
     )
   })
 
-  describe('handleDelegatedTokenUpdate', () => {
-    let authService: AuthService
-
-    const signInDelegated = async () => {
-      authService = new AuthService()
-
-      Object.defineProperty(authService, 'userManager', {
-        value: mock<UserManager>({
-          getUser: vi.fn().mockResolvedValue(null),
-          getAndClearPostLoginRedirectUrl: vi.fn().mockReturnValue('/'),
-          updateContext: mockUpdateContext
-        })
-      })
-
-      const configStore = useConfigStore()
-      configStore.options = {
-        embed: {
-          enabled: true,
-          delegateAuthentication: true,
-          delegateAuthenticationOrigin: 'https://host.example.org'
-        }
-      }
-      initAuthService({ authService, configStore, router: createRouter() })
-
-      await authService.signInCallback('initial-token')
-      mockUpdateContext.mockClear()
-    }
-
-    afterEach(() => {
-      window.removeEventListener(
-        'message',
-        (authService as any).handleDelegatedTokenUpdate as EventListener
-      )
-    })
-
-    it('ignores "owncloud-embed:update-token" messages from unexpected origins', async () => {
-      await signInDelegated()
-
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
-          origin: 'https://attacker.example.org'
-        })
-      )
-
-      expect(mockUpdateContext).not.toHaveBeenCalled()
-    })
-
-    it('updates the user context with the access token from "owncloud-embed:update-token" messages', async () => {
-      await signInDelegated()
-
-      window.dispatchEvent(
-        new MessageEvent('message', {
-          data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
-          origin: 'https://host.example.org'
-        })
-      )
-
-      expect(mockUpdateContext).toHaveBeenCalledWith('renewed-token', false)
-    })
-  })
-
   describe('initializeContext', () => {
     it('when embed mode is disabled and access_token is present, should call updateContext', async () => {
       const authService = new AuthService()
@@ -287,6 +225,81 @@ describe('AuthService', () => {
       ;(authService as any).handleDelegatedTokenUpdate(buildMessageEvent('https://trusted.example'))
 
       expect(mockUpdateContext).toHaveBeenCalled()
+    })
+
+    describe('when dispatched through the window message listener', () => {
+      let authService: AuthService
+
+      const signInDelegated = async () => {
+        authService = new AuthService()
+
+        Object.defineProperty(authService, 'userManager', {
+          value: mock<UserManager>({
+            getUser: vi.fn().mockResolvedValue(null),
+            getAndClearPostLoginRedirectUrl: vi.fn().mockReturnValue('/'),
+            updateContext: mockUpdateContext
+          })
+        })
+
+        const configStore = useConfigStore()
+        configStore.options = {
+          embed: {
+            enabled: true,
+            delegateAuthentication: true,
+            delegateAuthenticationOrigin: 'https://host.example.org'
+          }
+        }
+        initAuthService({ authService, configStore, router: createRouter() })
+
+        await authService.signInCallback('initial-token')
+        mockUpdateContext.mockClear()
+      }
+
+      afterEach(() => {
+        window.removeEventListener(
+          'message',
+          (authService as any).handleDelegatedTokenUpdate as EventListener
+        )
+      })
+
+      it('ignores "owncloud-embed:update-token" messages from unexpected origins', async () => {
+        await signInDelegated()
+
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
+            origin: 'https://attacker.example.org'
+          })
+        )
+
+        expect(mockUpdateContext).not.toHaveBeenCalled()
+      })
+
+      it('ignores "owncloud-embed:update-token" messages without an access token', async () => {
+        await signInDelegated()
+
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { name: 'owncloud-embed:update-token', data: {} },
+            origin: 'https://host.example.org'
+          })
+        )
+
+        expect(mockUpdateContext).not.toHaveBeenCalled()
+      })
+
+      it('updates the user context with the access token from "owncloud-embed:update-token" messages', async () => {
+        await signInDelegated()
+
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { name: 'owncloud-embed:update-token', data: { access_token: 'renewed-token' } },
+            origin: 'https://host.example.org'
+          })
+        )
+
+        expect(mockUpdateContext).toHaveBeenCalledWith('renewed-token', false)
+      })
     })
   })
 

--- a/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/web/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -160,10 +160,10 @@ describe('AuthService', () => {
   })
 
   describe('handleDelegatedTokenUpdate', () => {
-    const buildMessageEvent = (origin: string) =>
+    const buildMessageEvent = (origin: string, accessToken = 'attacker-token') =>
       mock<MessageEvent>({
         origin,
-        data: { name: 'owncloud-embed:update-token', data: { access_token: 'attacker-token' } }
+        data: { name: 'owncloud-embed:update-token', data: { access_token: accessToken } }
       })
 
     it('when delegateAuthenticationOrigin is not configured, should reject the message regardless of its origin', () => {
@@ -222,9 +222,11 @@ describe('AuthService', () => {
         }
       }
       initAuthService({ authService, configStore })
-      ;(authService as any).handleDelegatedTokenUpdate(buildMessageEvent('https://trusted.example'))
+      ;(authService as any).handleDelegatedTokenUpdate(
+        buildMessageEvent('https://trusted.example', 'renewed-token')
+      )
 
-      expect(mockUpdateContext).toHaveBeenCalled()
+      expect(mockUpdateContext).toHaveBeenCalledWith('renewed-token', false)
     })
 
     describe('when dispatched through the window message listener', () => {


### PR DESCRIPTION
## Description

Fixes token renewal in Web embed mode with delegated authentication. The `owncloud-embed:update-token` message listener in `AuthService` had two defects that made renewal impossible:

1. It was registered as an unbound method reference (`window.addEventListener('message', this.handleDelegatedTokenUpdate)`), so `this` was not the `AuthService` instance and the handler threw `TypeError` on its first line for every incoming message. The method is now an arrow function class property, which keeps `this` bound and preserves a stable reference for the listener.
2. It passed the whole message payload (`event.data`, i.e. `{ name, data: { access_token } }`) to `updateContext(accessToken: string, …)`. It now extracts `event.data.data?.access_token` — consistent with the initial token handover in `oidcCallback.vue` — and ignores messages without a token.

Adds two unit tests: a renewed token from the configured origin is applied via `updateContext`, and messages from unexpected origins are ignored. Both tests fail against the previous implementation.

## Related Issue

- Fixes https://github.com/owncloud/ocis/issues/12855

## Motivation and Context

Token renewal in embed mode with delegated authentication has never worked (the defects exist since the feature was introduced in owncloud/web v8.0.0). Host applications that deliver renewed tokens per the documented contract still lose the embedded session as soon as the initial access token expires, which makes the embed mode unusable for sessions longer than one access token lifetime.

## How Has This Been Tested?

- test environment: oCIS 8.2.0 / Web 12.5.0 deployment embedded in a host application, Keycloak as IdP with a short access token lifespan to force frequent renewals
- test case 1: without the fix — every `owncloud-embed:update-token` message logs `Uncaught TypeError: can't access property "options", this.configStore is undefined`, requests keep the expired token, user is logged out on token expiry
- test case 2: with the fixed handler — renewed tokens are applied, requests carry the fresh token and the embedded session survives token rotations indefinitely
- test case 3: `pnpm vitest run authService.spec` — 17 tests pass; the two new tests fail against the unfixed implementation

## Screenshots (if appropriate):

## Open tasks:
