### PR TITLE
ci: pass untrusted workflow inputs through env: instead of interpolating them into the shell

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Check if changes are docs-only
         id: check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Always run full CI on workflow_dispatch, tags, or when PR title contains [full-ci]
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -25,7 +27,6 @@ jobs:
             exit 0
           fi
 
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qi "\[full-ci\]"; then
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
           fetch-tags: true
 
       - id: info
+        env:
+          VERSION_OVERRIDE: ${{ inputs.version_override }}
         run: |
           next_dev() {
             # If latest tag is already a pre-release (e.g. v8.0.2-dev.1), reuse its base
@@ -53,12 +55,23 @@ jobs:
           }
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version_override }}"
+            VERSION="$VERSION_OVERRIDE"
             [[ -z "$VERSION" ]] && VERSION=$(next_dev)
           elif [[ "${{ github.ref_type }}" == "branch" ]]; then
             VERSION=$(next_dev)
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+
+          # `version` below is read back by nine `run:` blocks in this file (thirteen
+          # interpolations) as ${{ needs.determine-release-type.outputs.version }}, and each
+          # of those is substituted into the script text before bash sees it. Refusing
+          # anything that is not a version token here is what keeps those nine safe, instead
+          # of nine more env: blocks -- and a release version that is not a version token is
+          # a bug in its own right.
+          if [[ ! "$VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z.+-]*$ ]]; then
+            echo "::error title=Invalid release version::'$VERSION' is not a version string (expected ^[0-9A-Za-z][0-9A-Za-z.+-]*$)"
+            exit 1
           fi
 
           IS_PRODUCTION=false

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -20,13 +20,14 @@ jobs:
 
       - name: Check if web/ changed
         id: check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "web-changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qi "\[full-ci\]"; then
             echo "web-changed=true" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
`acceptance-tests.yml` and `web-tests.yml` each build their `detect-*` step script with

```yaml
run: |
  ...
  PR_TITLE="${{ github.event.pull_request.title }}"
```

`${{ }}` is substituted into the script **text** before `bash` parses it, so the title is
source code, not data. A pull request titled

```
fix: something harmless" ; echo "docs-only=true" >> "$GITHUB_OUTPUT" ; touch /tmp/PWNED ; #
```

closes the quote and runs the rest as commands on the runner.

### Why it is worth fixing even though the token is read-only

These are `pull_request` workflows, so a fork PR gets a read-only `GITHUB_TOKEN` and no
secrets. This is **not** a secret-exfiltration report, and I would rather say that plainly
than inflate it.

What it does give an attacker is arbitrary command execution on the runner, and one
specific consequence that is worth more than the shell access: both steps write the value
that **gates the rest of the workflow** to `$GITHUB_OUTPUT` —

- `acceptance-tests.yml` → `docs-only`, consumed by `if: needs.detect-changes.outputs.docs-only != 'true'`
- `web-tests.yml` → `web-changed`, consumed by `if: needs.detect-web-changes.outputs.web-changed == 'true'`

so an injected title can forge that output and make its own pull request skip the suite
that is supposed to test it. A reviewer looking at a green checks column would see the
tests reported as intentionally skipped, not failed.

I reproduced both halves locally against the current step bodies rather than asserting them:

```
vulnerable   arbitrary command ran: YES   forged CI-gating output: 1
fixed        arbitrary command ran: no    forged CI-gating output: 0
```

### The change

Move the title to `env:` so it arrives as an environment variable and is never parsed as
source. This is the mitigation GitHub documents for untrusted `github.event` values.

```diff
        id: check
+       env:
+         PR_TITLE: ${{ github.event.pull_request.title }}
        run: |
-         PR_TITLE="${{ github.event.pull_request.title }}"
          if echo "$PR_TITLE" | grep -qi "\[full-ci\]"; then
```

+4 / −2 across the two files.

### Behaviour is unchanged

The `[full-ci]` check reads the same variable and matches the same way:

| title | result |
|---|---|
| `fix(proxy): ordinary title` | falls through |
| `[full-ci] run everything` | full CI |
| `test: mixed [FULL-CI] case` | full CI (still case-insensitive) |
| `chore: title with 'quotes' and $dollar` | falls through |
| *(empty, e.g. `workflow_dispatch`)* | falls through |

The fourth row is a small bonus: under the old form a `$dollar` or backtick in an ordinary
title was expanded by the shell, so titles could change the script's meaning by accident as
well as on purpose.

I left the pre-existing `no-permissions` warnings on these files alone to keep the diff to
the one issue.


---

### `release.yml` — added 2026-08-29 at @LukasHirt's request

Same defect class in `release.yml:56`, where the free-text `workflow_dispatch` input
`version_override` is interpolated into the `determine-release-type` script.

`env:` alone does not fix that one. The value becomes the `version` job output, and **nine
later `run:` blocks in the same file (thirteen interpolations) read it back as
`${{ needs.determine-release-type.outputs.version }}` and substitute it into their own
script text** — lines 106, 150, 154, 222, 242–244, 248–250, 288, 354, 422. Line 288 is
unquoted. So a payload containing no `"` at all passes line 56 harmlessly and executes in a
*different job*:

```
ON master
  payload `v9.9.9" ; touch /tmp/PWNED ; echo "8.0.1`
    command ran in the `info` step   : YES
  payload `8.0.1;touch /tmp/PWNED`
    command ran in the `info` step   : no          <- line 56 looks clean
    version output carried to job 2  : '8.0.1;touch /tmp/PWNED'
    command ran in job 2, line 288   : YES

WITH THIS CHANGE
  both payloads                      : step exit 1, no command ran, no output written
```

So the change here is `env:` **plus** an allow-list on `$VERSION` after the `if/fi`
(`^[0-9A-Za-z][0-9A-Za-z.+-]*$`, which accepts all of semver including pre-release and
`+build`). That closes all nine consumers at the source rather than adding nine more `env:`
blocks. +14 / −1.

**Severity, stated plainly: this one is hardening, not a privilege boundary.**
`workflow_dispatch` needs write access, and a write-access actor can already run this
pipeline by pushing a `feat/release-pipeline**` branch (line 8). No escalation is claimed.
It is worth doing because it is the same pattern the two `pull_request` files get genuinely
wrong, and because a release job that accepts `8.0.1;touch …` as a version and tags Docker
images with it will misbehave long before anyone attacks it.

Behaviour is unchanged on every legitimate path — dispatch with `8.0.1`, `7.2.0`,
`8.0.2-dev.1`, `1.0.0+build.5` and empty (auto-detect), push to
`feat/release-pipeline-x`, and push of tag `v5.0.9` all produce byte-identical
`version` / `is_production` / `is_prerelease` outputs to `master`.
