### PR TITLE
fix(graph): [stable-8.1] keep shares visible in sharedWithMe when a resource cannot be statted

### DIFF
--- a/changelog/unreleased/bugfix-sharedwithme-degraded-items.md
+++ b/changelog/unreleased/bugfix-sharedwithme-degraded-items.md
@@ -1,0 +1,25 @@
+Bugfix: Keep shares visible in sharedWithMe when a resource cannot be statted
+
+The graph `sharedWithMe` handler resolves each received share by fanning out a per-resource
+`Stat` call with a concurrency limit, all sharing the request context. When a `Stat` failed
+for any reason (slow or stuck downstream, deleted space, gateway error, deadline exceeded)
+the worker logged at debug and returned without emitting a drive item, so the share was
+silently omitted from the response and the handler still returned `200 OK` with a partial,
+non-deterministic list. A single chronically-slow share could therefore make other,
+recently-accepted shares intermittently invisible, and repeated calls returned different
+subsets of the user's shares.
+
+The handler now:
+
+- bounds each per-share `Stat` with its own timeout derived from the request context, so one
+  slow resource can no longer consume the deadline shared by all the other shares. The bound
+  is configurable via `GRAPH_RECEIVED_SHARES_STAT_TIMEOUT` (default `10s`);
+- returns a degraded drive item built from the data already present in the share record
+  (ids, permissions, grantees, timestamps, mountpoint name) when the resource cannot be statted
+  due to a transient or indeterminate failure (timeout, slow or unavailable downstream), so the
+  share stays visible instead of intermittently disappearing. A genuinely missing resource or
+  revoked access (for example after the sharer was deleted) still drops the share, as before;
+- logs the dropped/degraded shares at warning level with a per-request count for operator
+  visibility.
+
+https://github.com/owncloud/ocis/pull/12430

--- a/changelog/unreleased/security-bump-grpc.md
+++ b/changelog/unreleased/security-bump-grpc.md
@@ -1,0 +1,6 @@
+Security: Bump google.golang.org/grpc to v1.83.1
+
+Upgraded google.golang.org/grpc from v1.83.0 to v1.83.1 to address
+CVE-2026-84304 (HIGH) reported by the Trivy vulnerability scan.
+
+https://github.com/owncloud/ocis/pull/12861

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d
-	google.golang.org/grpc v1.83.0
+	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools/v3 v3.5.2

--- a/go.sum
+++ b/go.sum
@@ -1344,6 +1344,8 @@ google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
 google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc/examples v0.0.0-20211102180624-670c133e568e h1:m7aQHHqd0q89mRwhwS9Bx2rjyl/hsFAeta+uGrHsQaU=
 google.golang.org/grpc/examples v0.0.0-20211102180624-670c133e568e/go.mod h1:gID3PKrg7pWKntu9Ss6zTLJ0ttC0X9IHgREOCZwbCVU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	UnifiedRoles      UnifiedRoles `yaml:"unified_roles"`
 	MaxConcurrency    int          `yaml:"max_concurrency" env:"OCIS_MAX_CONCURRENCY;GRAPH_MAX_CONCURRENCY" desc:"The maximum number of concurrent requests the service will handle." introductionVersion:"7.0.0"`
 
-	ReceivedSharesStatTimeout time.Duration `yaml:"received_shares_stat_timeout" env:"GRAPH_RECEIVED_SHARES_STAT_TIMEOUT" desc:"The maximum duration to wait for the storage to respond while resolving a single received share's resource when listing 'sharedWithMe'. Bounding each resource lookup individually prevents one slow or unreachable resource from consuming the request deadline shared by all the other shares. A share whose resource cannot be statted within this time is still listed as a degraded item instead of being dropped. Defaults to '10s'. See the Environment Variable Types description for more details." introductionVersion:"NEXT"`
+	ReceivedSharesStatTimeout time.Duration `yaml:"received_shares_stat_timeout" env:"GRAPH_RECEIVED_SHARES_STAT_TIMEOUT" desc:"The maximum duration to wait for the storage to respond while resolving a single received share's resource when listing 'sharedWithMe'. Bounding each resource lookup individually prevents one slow or unreachable resource from consuming the request deadline shared by all the other shares. A share whose resource cannot be statted within this time is still listed as a degraded item instead of being dropped. Defaults to '10s'. See the Environment Variable Types description for more details." introductionVersion:"8.2.0"`
 
 	Keycloak       Keycloak            `yaml:"keycloak"`
 	ServiceAccount ServiceAccount      `yaml:"service_account" mask:"struct"`

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	UnifiedRoles      UnifiedRoles `yaml:"unified_roles"`
 	MaxConcurrency    int          `yaml:"max_concurrency" env:"OCIS_MAX_CONCURRENCY;GRAPH_MAX_CONCURRENCY" desc:"The maximum number of concurrent requests the service will handle." introductionVersion:"7.0.0"`
 
+	ReceivedSharesStatTimeout time.Duration `yaml:"received_shares_stat_timeout" env:"GRAPH_RECEIVED_SHARES_STAT_TIMEOUT" desc:"The maximum duration to wait for the storage to respond while resolving a single received share's resource when listing 'sharedWithMe'. Bounding each resource lookup individually prevents one slow or unreachable resource from consuming the request deadline shared by all the other shares. A share whose resource cannot be statted within this time is still listed as a degraded item instead of being dropped. Defaults to '10s'. See the Environment Variable Types description for more details." introductionVersion:"NEXT"`
+
 	Keycloak       Keycloak            `yaml:"keycloak"`
 	ServiceAccount ServiceAccount      `yaml:"service_account" mask:"struct"`
 	MultiInstance  MultiInstanceConfig `yaml:"multi_instance"`

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -132,7 +132,8 @@ func DefaultConfig() *config.Config {
 			Cluster:   "ocis-cluster",
 			EnableTLS: false,
 		},
-		MaxConcurrency: 20,
+		MaxConcurrency:            20,
+		ReceivedSharesStatTimeout: 10 * time.Second,
 		UnifiedRoles: config.UnifiedRoles{
 			AvailableRoles: nil, // will be populated with defaults in EnsureDefaults
 		},

--- a/services/graph/pkg/service/v0/base.go
+++ b/services/graph/pkg/service/v0/base.go
@@ -87,7 +87,7 @@ func (g BaseGraphService) CS3ReceivedSharesToDriveItems(ctx context.Context, rec
 	}
 
 	availableRoles := unifiedrole.GetRoles(unifiedrole.RoleFilterIDs(g.config.UnifiedRoles.AvailableRoles...))
-	return cs3ReceivedSharesToDriveItems(ctx, g.logger, gatewayClient, g.identityCache, receivedShares, availableRoles)
+	return cs3ReceivedSharesToDriveItems(ctx, g.logger, gatewayClient, g.identityCache, receivedShares, availableRoles, g.config.ReceivedSharesStatTimeout)
 }
 
 func (g BaseGraphService) CS3ReceivedOCMSharesToDriveItems(ctx context.Context, receivedShares []*ocm.ReceivedShare) ([]libregraph.DriveItem, error) {

--- a/services/graph/pkg/service/v0/sharedwithme.go
+++ b/services/graph/pkg/service/v0/sharedwithme.go
@@ -46,7 +46,7 @@ func (g Graph) listSharedWithMe(ctx context.Context) ([]libregraph.DriveItem, er
 	listReceivedSharesResponse.Shares = filterVaultShares(ctx, listReceivedSharesResponse.GetShares())
 
 	availableRoles := unifiedrole.GetRoles(unifiedrole.RoleFilterIDs(g.config.UnifiedRoles.AvailableRoles...))
-	driveItems, err := cs3ReceivedSharesToDriveItems(ctx, g.logger, gatewayClient, g.identityCache, listReceivedSharesResponse.GetShares(), availableRoles)
+	driveItems, err := cs3ReceivedSharesToDriveItems(ctx, g.logger, gatewayClient, g.identityCache, listReceivedSharesResponse.GetShares(), availableRoles, g.config.ReceivedSharesStatTimeout)
 	if err != nil {
 		g.logger.Error().Err(err).Msg("could not convert received shares to drive items")
 		return nil, err

--- a/services/graph/pkg/service/v0/sharedwithme_test.go
+++ b/services/graph/pkg/service/v0/sharedwithme_test.go
@@ -376,6 +376,157 @@ var _ = Describe("SharedWithMe", func() {
 			Expect(jsonData.Get("id").String()).To(Equal(getUserResponseShareCreator.User.Id.OpaqueId))
 		})
 
+		It("returns a degraded drive item when a share's resource stat times out", func() {
+			// a second share, pointing at a different resource, whose Stat times out (transport error)
+			brokenShare := &collaborationv1beta1.ReceivedShare{
+				Share: &collaborationv1beta1.Share{
+					ResourceId: toResourceID("7$8!9"),
+					Id: &collaborationv1beta1.ShareId{
+						OpaqueId: "broken:share:id",
+					},
+					Permissions: &collaborationv1beta1.SharePermissions{
+						Permissions: roleconversions.NewViewerRole().CS3ResourcePermissions(),
+					},
+					Creator: getUserResponseShareCreator.User.Id,
+					Ctime:   utils.TSNow(),
+				},
+				MountPoint: &providerv1beta1.Reference{Path: "broken folder"},
+				State:      collaborationv1beta1.ShareState_SHARE_STATE_ACCEPTED,
+			}
+			listReceivedSharesResponse.Shares = append(listReceivedSharesResponse.Shares, brokenShare)
+
+			// reset and re-register the gateway expectations so Stat fails for the
+			// broken share's resource but succeeds for the others.
+			gatewayClient.ExpectedCalls = nil
+			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponseDefault, nil)
+			gatewayClient.On("ListReceivedShares", mock.Anything, mock.Anything).Return(listReceivedSharesResponse, nil)
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(func(_ context.Context, r *providerv1beta1.StatRequest, _ ...grpc.CallOption) (*providerv1beta1.StatResponse, error) {
+				if r.Ref.ResourceId == brokenShare.Share.ResourceId {
+					return nil, context.DeadlineExceeded
+				}
+				return &providerv1beta1.StatResponse{
+					Status: status.NewOK(ctx),
+					Info: &providerv1beta1.ResourceInfo{
+						Id:   r.Ref.ResourceId,
+						Type: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					},
+				}, nil
+			})
+
+			svc.ListSharedWithMe(
+				tape,
+				httptest.NewRequest(http.MethodGet, "/graph/v1beta1/me/drive/sharedWithMe", nil),
+			)
+
+			driveItems := libregraph.CollectionOfDriveItems{}
+			err := json.Unmarshal(tape.Body.Bytes(), &driveItems)
+			Expect(err).To(BeNil())
+
+			// both shares must be present: the broken one is returned as a degraded
+			// item built from the share record, not silently dropped.
+			Expect(len(driveItems.Value)).To(Equal(2))
+
+			var remoteIDs []string
+			for _, di := range driveItems.GetValue() {
+				ri := di.GetRemoteItem()
+				remoteIDs = append(remoteIDs, ri.GetId())
+			}
+			Expect(remoteIDs).To(ContainElement(storagespace.FormatResourceID(brokenShare.Share.ResourceId)))
+		})
+
+		It("bounds the per-share Stat with the configured GRAPH_RECEIVED_SHARES_STAT_TIMEOUT", func() {
+			// Use a value distinct from the 10s default so we can tell the
+			// configured timeout (not the default) is the one applied. The service
+			// holds cfg by pointer, so setting it here is observed by the handler.
+			cfg.ReceivedSharesStatTimeout = 3 * time.Second
+
+			var statDeadline time.Time
+			var statHadDeadline bool
+			gatewayClient.ExpectedCalls = nil
+			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponseDefault, nil)
+			gatewayClient.On("ListReceivedShares", mock.Anything, mock.Anything).Return(listReceivedSharesResponse, nil)
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(func(statCtx context.Context, r *providerv1beta1.StatRequest, _ ...grpc.CallOption) (*providerv1beta1.StatResponse, error) {
+				// the worker writes these before returning; cs3ReceivedSharesToDriveItems
+				// only returns after group.Wait(), so reading them after the handler
+				// call is race-free.
+				statDeadline, statHadDeadline = statCtx.Deadline()
+				return &providerv1beta1.StatResponse{
+					Status: status.NewOK(ctx),
+					Info: &providerv1beta1.ResourceInfo{
+						Id:   r.Ref.ResourceId,
+						Type: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					},
+				}, nil
+			})
+
+			svc.ListSharedWithMe(
+				tape,
+				httptest.NewRequest(http.MethodGet, "/graph/v1beta1/me/drive/sharedWithMe", nil),
+			)
+
+			Expect(tape.Code).To(Equal(http.StatusOK))
+			// the per-share Stat must carry a deadline derived from the configured
+			// timeout: never above the configured 3s, and clearly below the 10s default.
+			Expect(statHadDeadline).To(BeTrue())
+			Expect(time.Until(statDeadline)).To(BeNumerically("<=", 3*time.Second))
+			Expect(time.Until(statDeadline)).To(BeNumerically(">", 2*time.Second))
+		})
+
+		It("drops a share when the storage returns an error for its resource (e.g. the sharer was deleted)", func() {
+			// a second share whose resource the storage cannot serve (definitive status error) must not be listed
+			goneShare := &collaborationv1beta1.ReceivedShare{
+				Share: &collaborationv1beta1.Share{
+					ResourceId: toResourceID("7$8!9"),
+					Id: &collaborationv1beta1.ShareId{
+						OpaqueId: "gone:share:id",
+					},
+					Permissions: &collaborationv1beta1.SharePermissions{
+						Permissions: roleconversions.NewViewerRole().CS3ResourcePermissions(),
+					},
+					Creator: getUserResponseShareCreator.User.Id,
+					Ctime:   utils.TSNow(),
+				},
+				MountPoint: &providerv1beta1.Reference{Path: "gone folder"},
+				State:      collaborationv1beta1.ShareState_SHARE_STATE_ACCEPTED,
+			}
+			listReceivedSharesResponse.Shares = append(listReceivedSharesResponse.Shares, goneShare)
+
+			gatewayClient.ExpectedCalls = nil
+			gatewayClient.On("GetUser", mock.Anything, mock.Anything).Return(getUserResponseDefault, nil)
+			gatewayClient.On("ListReceivedShares", mock.Anything, mock.Anything).Return(listReceivedSharesResponse, nil)
+			gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(func(_ context.Context, r *providerv1beta1.StatRequest, _ ...grpc.CallOption) (*providerv1beta1.StatResponse, error) {
+				if r.Ref.ResourceId == goneShare.Share.ResourceId {
+					return &providerv1beta1.StatResponse{Status: status.NewInternal(ctx, "node broken after sharer deletion")}, nil
+				}
+				return &providerv1beta1.StatResponse{
+					Status: status.NewOK(ctx),
+					Info: &providerv1beta1.ResourceInfo{
+						Id:   r.Ref.ResourceId,
+						Type: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					},
+				}, nil
+			})
+
+			svc.ListSharedWithMe(
+				tape,
+				httptest.NewRequest(http.MethodGet, "/graph/v1beta1/me/drive/sharedWithMe", nil),
+			)
+
+			driveItems := libregraph.CollectionOfDriveItems{}
+			err := json.Unmarshal(tape.Body.Bytes(), &driveItems)
+			Expect(err).To(BeNil())
+
+			// the dead share (resource gone) is dropped; only the healthy share remains
+			Expect(len(driveItems.Value)).To(Equal(1))
+
+			var remoteIDs []string
+			for _, di := range driveItems.GetValue() {
+				ri := di.GetRemoteItem()
+				remoteIDs = append(remoteIDs, ri.GetId())
+			}
+			Expect(remoteIDs).ToNot(ContainElement(storagespace.FormatResourceID(goneShare.Share.ResourceId)))
+		})
+
 		It("returns a single drive item when multiple shares exist for the same resource", func() {
 			anotherShare := &collaborationv1beta1.ReceivedShare{
 				Share: &collaborationv1beta1.Share{

--- a/services/graph/pkg/service/v0/utils.go
+++ b/services/graph/pkg/service/v0/utils.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"path"
 	"reflect"
+	"sync/atomic"
+	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	cs3User "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -175,17 +177,38 @@ func identitySetToSpacePermissionID(identitySet libregraph.SharePointIdentitySet
 	return id
 }
 
+// _receivedShareStatTimeout is the default bound for how long the resource Stat
+// for a single received share may take. It is used when the configured
+// GRAPH_RECEIVED_SHARES_STAT_TIMEOUT is not set (or non-positive). Without a
+// per-share bound, one slow or stuck downstream resource consumes the whole
+// request deadline budget, which causes the other shares to be dropped from the
+// sharedWithMe listing (and the request to occasionally 502). Keeping it small
+// relative to a typical request deadline lets one bad share fail fast without
+// affecting the visibility of the others.
+const _receivedShareStatTimeout = 10 * time.Second
+
 func cs3ReceivedSharesToDriveItems(ctx context.Context,
 	logger *log.Logger,
 	gatewayClient gateway.GatewayAPIClient,
 	identityCache identity.IdentityCache,
 	receivedShares []*collaboration.ReceivedShare,
 	availableRoles []*libregraph.UnifiedRoleDefinition,
+	statTimeout time.Duration,
 ) ([]libregraph.DriveItem, error) {
+
+	// Fall back to the default when unconfigured: a non-positive timeout would
+	// make context.WithTimeout cancel immediately and drop every share.
+	if statTimeout <= 0 {
+		statTimeout = _receivedShareStatTimeout
+	}
 
 	group := new(errgroup.Group)
 	// Set max concurrency
 	group.SetLimit(10)
+
+	// number of shares that could not be fully resolved and were returned as a
+	// degraded drive item built from the share record alone.
+	var degradedShares atomic.Int64
 
 	receivedSharesByResourceID := make(map[string][]*collaboration.ReceivedShare, len(receivedShares))
 	for _, receivedShare := range receivedShares {
@@ -202,18 +225,39 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 		receivedShares := receivedSharesForResource
 
 		group.Go(func() error {
-			var err error // redeclare
-			shareStat, err := gatewayClient.Stat(ctx, &storageprovider.StatRequest{
+			// Bound the per-share Stat so one slow/stuck resource cannot consume
+			// the request deadline shared by all the other shares.
+			statCtx, cancel := context.WithTimeout(ctx, statTimeout)
+			defer cancel()
+			shareStat, err := gatewayClient.Stat(statCtx, &storageprovider.StatRequest{
 				Ref: &storageprovider.Reference{
 					ResourceId: receivedShares[0].GetShare().GetResourceId(),
 				},
 			})
 
-			if err := errorcode.FromCS3Status(shareStat.GetStatus(), err); err != nil {
-				logger.Debug().Err(err).
+			if err != nil {
+				// The storage could not be reached in time (per-share timeout,
+				// cancellation, or an unavailable downstream). The resource most
+				// likely still exists, so keep the share visible as a degraded item
+				// built from the share record instead of dropping it: a single slow
+				// share must neither vanish nor take the other shares down with it.
+				logger.Warn().Err(err).
 					Str("shareid", receivedShares[0].GetShare().GetId().GetOpaqueId()).
 					Str("resourceid", storagespace.FormatResourceID(receivedShares[0].GetShare().GetResourceId())).
-					Msg("could not stat received share, skipping")
+					Msg("could not stat received share, returning a degraded drive item")
+				degradedShares.Add(1)
+				ch <- *buildDegradedDriveItemFromReceivedShares(ctx, logger, identityCache, receivedShares, availableRoles)
+				return nil
+			}
+
+			if statErr := errorcode.FromCS3Status(shareStat.GetStatus(), nil); statErr != nil {
+				// The storage answered with a definitive error (resource gone,
+				// access revoked, or a broken node, e.g. after the sharer was
+				// deleted). The share is dead and must not be listed.
+				logger.Debug().Err(statErr).
+					Str("shareid", receivedShares[0].GetShare().GetId().GetOpaqueId()).
+					Str("resourceid", storagespace.FormatResourceID(receivedShares[0].GetShare().GetResourceId())).
+					Msg("could not stat received share, skipping (resource unavailable)")
 				return nil
 			}
 
@@ -353,7 +397,66 @@ func cs3ReceivedSharesToDriveItems(ctx context.Context,
 		driveItems = append(driveItems, di)
 	}
 
+	if n := degradedShares.Load(); n > 0 {
+		logger.Warn().
+			Int64("degraded", n).
+			Int("total", len(receivedSharesByResourceID)).
+			Msg("some received shares could not be fully resolved and were returned as degraded drive items")
+	}
+
 	return driveItems, err
+}
+
+// buildDegradedDriveItemFromReceivedShares constructs a DriveItem for a set of
+// received shares pointing at the same resource when that resource could not be
+// statted. It exposes the data already contained in the share records (ids,
+// permissions, grantees, timestamps, mountpoint name) so the share stays
+// visible in the sharedWithMe listing instead of being silently dropped.
+// Properties that are only known from a successful Stat (size, etag, mime type,
+// owner, file/folder type) are intentionally left unset. It never returns an
+// error: if even the degraded build fails it falls back to a minimal item that
+// still carries the share identity.
+func buildDegradedDriveItemFromReceivedShares(ctx context.Context, logger *log.Logger,
+	identityCache identity.IdentityCache, receivedShares []*collaboration.ReceivedShare,
+	availableRoles []*libregraph.UnifiedRoleDefinition) *libregraph.DriveItem {
+
+	driveItem, err := fillDriveItemPropertiesFromReceivedShare(ctx, logger, identityCache, receivedShares, nil, availableRoles)
+	if err != nil {
+		logger.Warn().Err(err).
+			Str("shareid", receivedShares[0].GetShare().GetId().GetOpaqueId()).
+			Msg("could not build degraded drive item, returning a minimal item")
+		driveItem = libregraph.NewDriveItem()
+		driveItem.SetId(storagespace.FormatResourceID(&storageprovider.ResourceId{
+			StorageId: utils.ShareStorageProviderID,
+			OpaqueId:  receivedShares[0].GetShare().GetId().GetOpaqueId(),
+			SpaceId:   utils.ShareStorageSpaceID,
+		}))
+		driveItem.RemoteItem = libregraph.NewRemoteItem()
+	}
+
+	// the item lives in the virtual share jail, same as the fully-resolved item
+	driveItem.ParentReference = libregraph.NewItemReference()
+	driveItem.ParentReference.SetDriveType(_spaceTypeVirtual)
+	driveItem.ParentReference.SetDriveId(storagespace.FormatStorageID(utils.ShareStorageProviderID, utils.ShareStorageSpaceID))
+	driveItem.ParentReference.SetId(storagespace.FormatResourceID(&storageprovider.ResourceId{
+		StorageId: utils.ShareStorageProviderID,
+		OpaqueId:  utils.ShareStorageSpaceID,
+		SpaceId:   utils.ShareStorageSpaceID,
+	}))
+
+	if rid := receivedShares[0].GetShare().GetResourceId(); rid != nil {
+		driveItem.RemoteItem.SetId(storagespace.FormatResourceID(rid))
+		driveItem.RemoteItem.SpaceId = libregraph.PtrString(storagespace.FormatStorageID(rid.GetStorageId(), rid.GetSpaceId()))
+	}
+
+	// fall back to the mountpoint name when the resource name is unknown
+	if driveItem.GetName() == "" {
+		if name := receivedShares[0].GetMountPoint().GetPath(); name != "" {
+			driveItem.SetName(name)
+		}
+	}
+
+	return driveItem
 }
 
 func fillDriveItemPropertiesFromReceivedShare(ctx context.Context, logger *log.Logger,
@@ -448,26 +551,36 @@ func cs3ReceivedShareToLibreGraphPermissions(ctx context.Context, logger *log.Lo
 	}
 
 	if permissionSet := receivedShare.GetShare().GetPermissions().GetPermissions(); permissionSet != nil {
-		condition, err := roleConditionForResourceType(resourceInfo)
-		if err != nil {
-			return nil, err
-		}
+		// resourceInfo is nil for a degraded item, i.e. when the underlying
+		// resource could not be statted. The resource type, and therefore the
+		// unified role, cannot be determined in that case, so expose the raw
+		// actions instead of failing the whole listing.
+		if resourceInfo == nil {
+			if actions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(permissionSet); len(actions) > 0 {
+				permission.SetLibreGraphPermissionsActions(actions)
+			}
+		} else {
+			condition, err := roleConditionForResourceType(resourceInfo)
+			if err != nil {
+				return nil, err
+			}
 
-		role := unifiedrole.CS3ResourcePermissionsToRole(
-			availableRoles,
-			permissionSet,
-			condition,
-			false,
-		)
-		if role != nil {
-			permission.SetRoles([]string{role.GetId()})
-		}
+			role := unifiedrole.CS3ResourcePermissionsToRole(
+				availableRoles,
+				permissionSet,
+				condition,
+				false,
+			)
+			if role != nil {
+				permission.SetRoles([]string{role.GetId()})
+			}
 
-		actions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(permissionSet)
+			actions := unifiedrole.CS3ResourcePermissionsToLibregraphActions(permissionSet)
 
-		// actions only make sense if no role is set
-		if role == nil && len(actions) > 0 {
-			permission.SetLibreGraphPermissionsActions(actions)
+			// actions only make sense if no role is set
+			if role == nil && len(actions) > 0 {
+				permission.SetLibreGraphPermissionsActions(actions)
+			}
 		}
 	}
 	switch grantee := receivedShare.GetShare().GetGrantee(); {

--- a/services/graph/pkg/service/v0/utils_test.go
+++ b/services/graph/pkg/service/v0/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -265,6 +266,7 @@ var _ = Describe("Utils", func() {
 				identityCache,
 				receivedShares,
 				unifiedrole.GetRoles(unifiedrole.RoleFilterAll()),
+				10*time.Second,
 			)
 
 			Expect(err).ToNot(HaveOccurred())

--- a/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
+++ b/vendor/google.golang.org/grpc/internal/envconfig/envconfig.go
@@ -150,8 +150,18 @@ var (
 	// throttling limit if unforeseen issues arise, and it will be removed in a
 	// future release.
 	//
-	// TODO: Remove this env var once v1.83.0 is release.
+	// TODO: Remove this env var once v1.83.0 is released.
 	ControlBufferThrottleLimit = uint64FromEnv("GRPC_GO_EXPERIMENTAL_CONTROL_BUFFER_THROTTLE_LIMIT", 100, 1, 10000)
+
+	// EnableReceiveBufferCompaction enables the compaction of data buffers
+	// to reduce the number of buffers in the receive buffer.
+	//
+	// This environment variable serves as an escape hatch to disable the
+	// feature if unforeseen issues arise, and it will be removed in a future
+	// release.
+	//
+	// TODO: Remove this env var once v1.85.0 is released.
+	EnableReceiveBufferCompaction = boolFromEnv("GRPC_GO_EXPERIMENTAL_ENABLE_RECEIVE_BUFFER_COMPACTION", true)
 )
 
 func boolFromEnv(envVar string, def bool) bool {

--- a/vendor/google.golang.org/grpc/internal/mem/buffer_pool.go
+++ b/vendor/google.golang.org/grpc/internal/mem/buffer_pool.go
@@ -26,11 +26,25 @@ import (
 	"slices"
 	"sort"
 	"sync"
+
+	"google.golang.org/grpc/internal"
 )
 
 const (
 	goPageSize = 4 * 1024 // 4KiB. N.B. this must be a power of 2.
 )
+
+var (
+	// BufferPoolingThreshold is the minimum size of a buffer that can be pooled.
+	// This is used to determine whether to pool buffers or allocate them directly.
+	BufferPoolingThreshold = 1 << 10
+)
+
+func init() {
+	internal.SetBufferPoolingThresholdForTesting = func(threshold int) {
+		BufferPoolingThreshold = threshold
+	}
+}
 
 var uintSize = bits.UintSize // use a variable for mocking during tests.
 

--- a/vendor/google.golang.org/grpc/internal/transport/handler_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/handler_server.go
@@ -424,7 +424,7 @@ func (ht *serverHandlerTransport) HandleStreams(ctx context.Context, startStream
 		st:               ht,
 		headerWireLength: 0, // won't have access to header wire length until golang/go#18997.
 	}
-	s.Stream.buf.init()
+	s.Stream.buf.init(ht.bufferPool)
 	s.readRequester = s
 	s.trReader = transportReader{
 		reader:        recvBufferReader{ctx: s.ctx, ctxDone: s.ctx.Done(), recv: &s.buf},

--- a/vendor/google.golang.org/grpc/internal/transport/http2_client.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_client.go
@@ -500,7 +500,7 @@ func (t *http2Client) newStream(ctx context.Context, callHdr *CallHdr, handler s
 		headerChan:   make(chan struct{}),
 		statsHandler: handler,
 	}
-	s.Stream.buf.init()
+	s.Stream.buf.init(t.bufferPool)
 	s.Stream.wq.init(defaultWriteQuota, s.done)
 	s.readRequester = s
 	// The client side stream context should have exactly the same life cycle with the user provided context.

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -407,7 +407,7 @@ func (t *http2Server) operateHeaders(ctx context.Context, frame *http2.MetaHeade
 		st:               t,
 		headerWireLength: int(frame.Header().Length),
 	}
-	s.Stream.buf.init()
+	s.Stream.buf.init(t.bufferPool)
 	var (
 		// if false, content-type was missing or invalid
 		isGRPC      = false

--- a/vendor/google.golang.org/grpc/internal/transport/transport.go
+++ b/vendor/google.golang.org/grpc/internal/transport/transport.go
@@ -30,11 +30,14 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/internal/channelz"
+	"google.golang.org/grpc/internal/envconfig"
+	imem "google.golang.org/grpc/internal/mem"
 	"google.golang.org/grpc/internal/transport/internal"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/mem"
@@ -45,7 +48,30 @@ import (
 	"google.golang.org/grpc/tap"
 )
 
-const logLevel = 2
+const (
+	logLevel = 2
+	// recvMsgSize estimates the memory overhead of a recvMsg in the backlog.
+	// It accounts for the recvMsg struct itself and the slice header of the
+	// underlying buffer's data.
+	recvMsgSize = int(unsafe.Sizeof(recvMsg{}) + unsafe.Sizeof([]byte{}))
+
+	// utilizationFactor controls when we consider memory utilization acceptable.
+	// When backlogHeapSize / payloadSize <= utilizationFactor (meaning at least
+	// 50% of the heap memory is actual payload data), compaction is skipped.
+	utilizationFactor = 2
+)
+
+var (
+	// compactionThreshold is approx 57KB (on 64-bit systems). It allows
+	// accumulating up to 1024 1-byte payloads before triggering compaction.
+	//
+	// Because individual payloads <= 1024 bytes are allocated on the heap
+	// outside mem.BufferPool, waiting for at least 1024 bytes to accumulate
+	// ensures that compaction coalesces those small heap allocations into a
+	// single large buffer from mem.BufferPool, enabling buffer reuse while
+	// avoiding frequent copying for small bursts of frames.
+	compactionThreshold = imem.BufferPoolingThreshold * (recvMsgSize + 1)
+)
 
 func init() {
 	internal.TimeNowFunc = func() int64 { return time.Now().UnixNano() }
@@ -71,23 +97,31 @@ type recvBuffer struct {
 	c       chan recvMsg
 	mu      sync.Mutex
 	backlog []recvMsg
-	err     error
+	// uncompactedSuffixLen tracks the number of consecutive data messages at
+	// the tail of backlog that have not been compacted.
+	uncompactedSuffixLen int
+	// uncompactedBytes tracks the total payload bytes across the trailing
+	// uncompactedSuffixLen messages.
+	uncompactedBytes int
+	err              error
+	bufPool          mem.BufferPool
 }
 
 // init allows a recvBuffer to be initialized in-place, which is useful
 // for resetting a buffer or for avoiding a heap allocation when the buffer
 // is embedded in another struct.
-func (b *recvBuffer) init() {
+func (b *recvBuffer) init(pool mem.BufferPool) {
 	b.c = make(chan recvMsg, 1)
+	b.bufPool = pool
 }
 
 func (b *recvBuffer) put(r recvMsg) {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	if b.err != nil {
 		// drop the buffer on the floor. Since b.err is not nil, any subsequent reads
 		// will always return an error, making this buffer inaccessible.
 		r.buffer.Free()
-		b.mu.Unlock()
 		// An error had occurred earlier, don't accept more
 		// data or errors.
 		return
@@ -96,13 +130,70 @@ func (b *recvBuffer) put(r recvMsg) {
 	if len(b.backlog) == 0 {
 		select {
 		case b.c <- r:
-			b.mu.Unlock()
 			return
 		default:
 		}
 	}
 	b.backlog = append(b.backlog, r)
-	b.mu.Unlock()
+	b.compactBacklogLocked(r)
+}
+
+func (b *recvBuffer) compactBacklogLocked(r recvMsg) {
+	if !envconfig.EnableReceiveBufferCompaction {
+		return
+	}
+	if r.buffer == nil {
+		b.uncompactedBytes = 0
+		b.uncompactedSuffixLen = 0
+		return
+	}
+
+	b.uncompactedSuffixLen++
+	b.uncompactedBytes += r.buffer.Len()
+	backlogHeapSize := b.uncompactedSuffixLen*recvMsgSize + b.uncompactedBytes
+
+	// If the memory overhead is less than 50% of the heap usage (e.g., because
+	// a large DATA frame arrived), the average message size in the suffix is
+	// large enough that memory bloat is not a concern. Reset suffix tracking.
+	if backlogHeapSize <= utilizationFactor*b.uncompactedBytes {
+		b.uncompactedBytes = 0
+		b.uncompactedSuffixLen = 0
+		return
+	}
+	// Avoid compacting too frequently for short bursts of small frames.
+	// Wait until we have accumulated at least ~1024 small messages (~57 KB).
+	if backlogHeapSize <= compactionThreshold {
+		// Still can accumulate more payloads.
+		return
+	}
+
+	// Since the memory utilization is less than 50%, the average payload size
+	// of each recvMsg must be less than recvMsgSize (approx 56 bytes).
+	// In the worst case for bytes copied (where the average payload is just
+	// below recvMsgSize), compaction will occur once every:
+	//   compactionThreshold / (recvMsgSize + avg_payload) = ~520 messages,
+	// copying ~29KB of data.
+
+	start := 0
+	newBuf := b.bufPool.Get(b.uncompactedBytes)
+	startIdx := len(b.backlog) - b.uncompactedSuffixLen
+
+	for i := startIdx; i < len(b.backlog); i++ {
+		m := b.backlog[i]
+		b.backlog[i] = recvMsg{}
+		start += copy((*newBuf)[start:], m.buffer.ReadOnlyData())
+		m.buffer.Free()
+	}
+	b.backlog[startIdx] = recvMsg{
+		buffer: mem.NewBuffer(newBuf, b.bufPool),
+	}
+	b.backlog = b.backlog[:startIdx+1]
+	// After compaction, the suffix is replaced with a single message containing
+	// the combined payload. The new utilization is close to 1.0 (overhead of
+	// one recvMsg relative to the large compacted payload), which is well
+	// below the utilization factor of 2.
+	b.uncompactedBytes = 0
+	b.uncompactedSuffixLen = 0
 }
 
 func (b *recvBuffer) load() {
@@ -110,6 +201,13 @@ func (b *recvBuffer) load() {
 	if len(b.backlog) > 0 {
 		select {
 		case b.c <- b.backlog[0]:
+			// backlog[0] is only part of the tracked uncompacted suffix if the
+			// entire backlog currently consists of the suffix. If an earlier
+			// compaction or reset occurred, backlog[0] is already compacted.
+			if envconfig.EnableReceiveBufferCompaction && b.uncompactedSuffixLen == len(b.backlog) {
+				b.uncompactedSuffixLen--
+				b.uncompactedBytes -= b.backlog[0].buffer.Len()
+			}
 			b.backlog[0] = recvMsg{}
 			b.backlog = b.backlog[1:]
 		default:

--- a/vendor/google.golang.org/grpc/mem/buffer_pool.go
+++ b/vendor/google.golang.org/grpc/mem/buffer_pool.go
@@ -59,10 +59,6 @@ func init() {
 	internal.SetDefaultBufferPool = func(pool BufferPool) {
 		defaultBufferPool = pool
 	}
-
-	internal.SetBufferPoolingThresholdForTesting = func(threshold int) {
-		bufferPoolingThreshold = threshold
-	}
 }
 
 // DefaultBufferPool returns the current default buffer pool. It is a BufferPool

--- a/vendor/google.golang.org/grpc/mem/buffers.go
+++ b/vendor/google.golang.org/grpc/mem/buffers.go
@@ -29,6 +29,8 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+
+	"google.golang.org/grpc/internal/mem"
 )
 
 // A Buffer represents a reference counted piece of data (in bytes) that can be
@@ -63,8 +65,6 @@ type Buffer interface {
 }
 
 var (
-	bufferPoolingThreshold = 1 << 10
-
 	bufferObjectPool = sync.Pool{New: func() any { return new(buffer) }}
 )
 
@@ -72,7 +72,7 @@ var (
 // equal to the threshold for buffer pooling. This is used to determine whether
 // to pool buffers or allocate them directly.
 func IsBelowBufferPoolingThreshold(size int) bool {
-	return size <= bufferPoolingThreshold
+	return size <= mem.BufferPoolingThreshold
 }
 
 type buffer struct {

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.83.0"
+const Version = "1.83.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2419,7 +2419,7 @@ google.golang.org/genproto/googleapis/api/httpbody
 ## explicit; go 1.25.0
 google.golang.org/genproto/googleapis/rpc/errdetails
 google.golang.org/genproto/googleapis/rpc/status
-# google.golang.org/grpc v1.83.0
+# google.golang.org/grpc v1.83.1
 ## explicit; go 1.25.0
 google.golang.org/grpc
 google.golang.org/grpc/attributes


### PR DESCRIPTION
backports: https://github.com/owncloud/ocis/pull/12430