### PR TITLE
fix(graph): [stable-8.0] set introductionVersion 8.2.0 for GRAPH_RECEIVED_SHARES_STAT_TIMEOUT

### DIFF
--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	UnifiedRoles      UnifiedRoles `yaml:"unified_roles"`
 	MaxConcurrency    int          `yaml:"max_concurrency" env:"OCIS_MAX_CONCURRENCY;GRAPH_MAX_CONCURRENCY" desc:"The maximum number of concurrent requests the service will handle." introductionVersion:"7.0.0"`
 
-	ReceivedSharesStatTimeout time.Duration `yaml:"received_shares_stat_timeout" env:"GRAPH_RECEIVED_SHARES_STAT_TIMEOUT" desc:"The maximum duration to wait for the storage to respond while resolving a single received share's resource when listing 'sharedWithMe'. Bounding each resource lookup individually prevents one slow or unreachable resource from consuming the request deadline shared by all the other shares. A share whose resource cannot be statted within this time is still listed as a degraded item instead of being dropped. Defaults to '10s'. See the Environment Variable Types description for more details." introductionVersion:"NEXT"`
+	ReceivedSharesStatTimeout time.Duration `yaml:"received_shares_stat_timeout" env:"GRAPH_RECEIVED_SHARES_STAT_TIMEOUT" desc:"The maximum duration to wait for the storage to respond while resolving a single received share's resource when listing 'sharedWithMe'. Bounding each resource lookup individually prevents one slow or unreachable resource from consuming the request deadline shared by all the other shares. A share whose resource cannot be statted within this time is still listed as a degraded item instead of being dropped. Defaults to '10s'. See the Environment Variable Types description for more details." introductionVersion:"8.2.0"`
 
 	Keycloak       Keycloak            `yaml:"keycloak"`
 	ServiceAccount ServiceAccount      `yaml:"service_account"`


### PR DESCRIPTION
PR #12862 merged `GRAPH_RECEIVED_SHARES_STAT_TIMEOUT` with `introductionVersion:"NEXT"`, a placeholder the docs process rejects — it requires a real semver.

The variable was introduced in **8.2.0** (this is the value already committed on `master` and `stable-8.2`; the var was released in `v8.2.0`, its changelog lives in `changelog/8.2.0_2026-08-10/`, and it appears in the `8.1.0-8.2.0-added` env-var delta). This pins the stable-8.0 backport to the same canonical value.

Companion fix for the still-open stable-8.1 backport: #12861 (updated in place).