### PR TITLE
[tests-only][full-ci] test:start auth-bearer service separately instead of via OCIS_ADD_RUN_SERVICES

### DIFF
--- a/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature
+++ b/tests/acceptance/features/apiServiceAvailability/serviceAvailabilityCheck.feature
@@ -122,9 +122,8 @@ Feature: service health check
 
   @env-config @issue-10661
   Scenario: check auth-bearer service health
-    Given the following configs have been set:
+    And the administrator has started service "auth-bearer" separately with the following configs:
       | config                 | value        |
-      | OCIS_ADD_RUN_SERVICES  | auth-bearer  |
       | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149 |
     When a user requests these URLs with "GET" and no authentication
       | endpoint                                | service     |
@@ -133,9 +132,8 @@ Feature: service health check
 
   @env-config @issue-10661
   Scenario: check auth-bearer service readiness
-    Given the following configs have been set:
+    And the administrator has started service "auth-bearer" separately with the following configs:
       | config                 | value        |
-      | OCIS_ADD_RUN_SERVICES  | auth-bearer  |
       | AUTH_BEARER_DEBUG_ADDR | 0.0.0.0:9149 |
     When a user requests these URLs with "GET" and no authentication
       | endpoint                               | service     |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
auth-bearer was intentionally removed from the runtime supervisor ([commit 5d121b4bad0](https://github.com/owncloud/ocis/commit/5d121b4bad05158b66ec4e329bbea50889e2bc84#diff-0592eab66ff0d2d4d945791b45713db11c276a28ceb3cd69e72594c3e2ad45e6L124)) and never re-registered via `areg()`. This means `OCIS_ADD_RUN_SERVICES=auth-bearer` silently skips the service - it never starts and port `9149` never opens.

Switch the two `auth-bearer` test scenarios to use the wrapper's `POST /services/auth-bearer` endpoint instead, which starts the service as a standalone process and waits for the debug port to be ready.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
