### PR TITLE
[test-only] ci: fix flaky e2e-app-provider

### DIFF
--- a/web/tests/e2e/specs/app-provider/wopiReadOnly.spec.ts
+++ b/web/tests/e2e/specs/app-provider/wopiReadOnly.spec.ts
@@ -40,6 +40,13 @@ test.describe('WOPI CheckFileInfo: ReadOnly', { tag: '@predefined-users' }, () =
         stepUser: 'Alice',
         resources: [{ name: suite.file, type: suite.type, content: 'owner edited content' }]
       })
+      await ui.userClosesFileViewer({ stepUser: 'Alice' })
+      await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
+      await ui.userOpensResourceInViewer({
+        stepUser: 'Alice',
+        resource: suite.file,
+        viewer: suite.viewer
+      })
       await ui.userShouldSeeContentInEditor({
         stepUser: 'Alice',
         expectedContent: 'owner edited content',

--- a/web/tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts
+++ b/web/tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts
@@ -57,12 +57,20 @@ test.describe(
           stepUser: 'Alice',
           resources: [{ name: suite.file, type: suite.type, content: 'edited content v2' }]
         })
+        await ui.userClosesFileViewer({ stepUser: 'Alice' })
+        await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
+        await ui.userOpensResourceInViewer({
+          stepUser: 'Alice',
+          resource: suite.file,
+          viewer: suite.viewer
+        })
         await ui.userShouldSeeContentInEditor({
           stepUser: 'Alice',
           expectedContent: 'edited content v2',
           editor: suite.name
         })
         await ui.userClosesFileViewer({ stepUser: 'Alice' })
+        await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
 
         await ui.userLogsIn({ stepUser: 'Brian' })
         await ui.userNavigatesToSharedWithMePage({ stepUser: 'Brian' })

--- a/web/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/web/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -122,7 +122,7 @@ export default class Collaborator {
       'account page'
     )
     await collaboratorInputLocator.focus()
-    // await page.locator('.vs--open').waitFor()
+    await page.locator('.vs--open').waitFor()
     await page
       .locator(util.format(Collaborator.collaboratorDropdownItem, collaborator.displayName))
       .first() // in CI, resolves to two elements

--- a/web/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/web/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -122,7 +122,7 @@ export default class Collaborator {
       'account page'
     )
     await collaboratorInputLocator.focus()
-    await page.locator('.vs--open').waitFor()
+    // await page.locator('.vs--open').waitFor()
     await page
       .locator(util.format(Collaborator.collaboratorDropdownItem, collaborator.displayName))
       .first() // in CI, resolves to two elements


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes the flaky pipeline for e2e-app-provider, at `wopiVersionAndLastModifiedTime.spec.ts` & `wopiReadOnly.spec.ts`

<details>
<summary>CI Failure Logs</summary>

```bash
1) [chromium] › tests/e2e/specs/app-provider/wopiReadOnly.spec.ts:51:5 › WOPI CheckFileInfo: ReadOnly › ReadOnly is true for a view-only share recipient in OnlyOffice @predefined-users 

    Test timeout of 180000ms exceeded.

    Error: locator.waitFor: Target page, context or browser has been closed
    Call log:
      - waiting for locator('.vs--open') to be visible


       at ../support/objects/app-files/share/collaborator.ts:125

      123 |     )
      124 |     await collaboratorInputLocator.focus()
    > 125 |     await page.locator('.vs--open').waitFor()
          |                                     ^
      126 |     await page
      127 |       .locator(util.format(Collaborator.collaboratorDropdownItem, collaborator.displayName))
      128 |       .first() // in CI, resolves to two elements
```


```bash
 2) [chromium] › tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts:32:7 › WOPI CheckFileInfo: Version and LastModifiedTime › a fresh edit is visible to another session opening OnlyOffice afterward @predefined-users 

    Test timeout of 180000ms exceeded.

    Error: locator.waitFor: Target page, context or browser has been closed
    Call log:
      - waiting for locator('//button[contains(@id, "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a")]') to be visible


       at ../support/objects/app-files/share/collaborator.ts:216

      214 |     // dispatchEvent since Tippy close-on-click intercepts .click() before Vue handler fires
      215 |     const roleSelector = util.format(itemSelector, role)
    > 216 |     await page.locator(roleSelector).waitFor()
          |                                      ^
      217 |     await page.evaluate((xpathSelector) => {
      218 |       const btn = document.evaluate(
      219 |         xpathSelector,

```
</details>

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1: locally
- test case 2: ci
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
