### PR TITLE
[tests-only][full-ci] test: fix blobstore flakiness

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -174,7 +174,6 @@ jobs:
   local-api-tests:
     name: ${{ matrix.suite }}
     needs: [build-and-test]
-    if: false # skipped — running only cliCommands
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -309,7 +308,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - cliCommands
+          - cliCommands,apiServiceAvailability   # grouped: both need ClamAV + email services
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -351,7 +350,6 @@ jobs:
     name: ldapPool-${{ matrix.suite }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-reports
     strategy:
@@ -400,7 +398,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-reports
     strategy:
@@ -496,7 +493,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     strategy:
       fail-fast: false
       matrix:
@@ -703,7 +699,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -729,7 +724,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -755,7 +749,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -781,7 +774,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -807,7 +799,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -841,7 +832,6 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -870,7 +860,7 @@ jobs:
 
   acceptance-coverage:
     name: acceptance-coverage
-    needs: [cli-tests]
+    needs: [local-api-tests, cli-tests, ldap-pool-tests, core-api-tests]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
@@ -910,7 +900,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   all-acceptance-tests:
-    needs: [detect-changes, cli-tests]
+    needs: [detect-changes, local-api-tests, cli-tests, ldap-pool-tests, core-api-tests, litmus, cs3api, wopi-builtin, wopi-cs3, e2e-tests, external-ldap-tests, external-ldap-distributed-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -174,6 +174,7 @@ jobs:
   local-api-tests:
     name: ${{ matrix.suite }}
     needs: [build-and-test]
+    if: false # skipped — running only cliCommands
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -308,7 +309,7 @@ jobs:
       fail-fast: false
       matrix:
         suite:
-          - cliCommands,apiServiceAvailability   # grouped: both need ClamAV + email services
+          - cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -350,6 +351,7 @@ jobs:
     name: ldapPool-${{ matrix.suite }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-reports
     strategy:
@@ -398,6 +400,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     env:
       GOCOVERDIR: ${{ github.workspace }}/coverage-reports
     strategy:
@@ -493,6 +496,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     strategy:
       fail-fast: false
       matrix:
@@ -699,6 +703,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -724,6 +729,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -749,6 +755,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -774,6 +781,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -799,6 +807,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -832,6 +841,7 @@ jobs:
     needs: [build-and-test]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    if: false # skipped — running only cliCommands
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -860,7 +870,7 @@ jobs:
 
   acceptance-coverage:
     name: acceptance-coverage
-    needs: [local-api-tests, cli-tests, ldap-pool-tests, core-api-tests]
+    needs: [cli-tests]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
@@ -900,7 +910,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   all-acceptance-tests:
-    needs: [detect-changes, local-api-tests, cli-tests, ldap-pool-tests, core-api-tests, litmus, cs3api, wopi-builtin, wopi-cs3, e2e-tests, external-ldap-tests, external-ldap-distributed-tests]
+    needs: [detect-changes, cli-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/tests/acceptance/bootstrap/CliContext.php
+++ b/tests/acceptance/bootstrap/CliContext.php
@@ -1332,7 +1332,20 @@ class CliContext implements Context {
 	 */
 	private function findNewestBlobPath(): string {
 		$storageRoot = $this->featureContext->getStorageUsersRoot();
-		$blobDirs = \glob($storageRoot . '/spaces/*/*/blobs', GLOB_ONLYDIR) ?: [];
+		// Async postprocessing may not have moved the blob to its final
+		// location yet — poll until the directory appears or we give up.
+		$blobDirs = [];
+		$retried = 0;
+		do {
+			$blobDirs = \glob($storageRoot . '/spaces/*/*/blobs', GLOB_ONLYDIR) ?: [];
+			if (!empty($blobDirs)) {
+				break;
+			}
+			$retried++;
+			echo "Blobstore directories not found under $storageRoot, retrying ($retried)...\n";
+			\usleep(500 * 1000);
+		} while ($retried < STANDARD_RETRY_COUNT);
+
 		Assert::assertNotEmpty($blobDirs, "No blobstore directory found under $storageRoot");
 
 		$newestPath = null;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR fixes the flakiness blobstore CLI test for `cliCommands` test suite.
`Scenario: administrator gets a blob from the blobstore using the --path flag`

<details>
<summary>CI Failure Logs</summary>

```bash
@skipOnOcis-S3NG-Storage
  Scenario: administrator gets a blob from the blobstore using the --path flag              # /home/runner/work/ocis/ocis/tests/acceptance/features/cliCommands/blobstore.feature:50
    Given user "Alice" has been created with default attributes                             # FeatureContext::userHasBeenCreatedWithDefaultAttributes()
{"level":"error","service":"proxy","time":"2026-09-01T06:57:23Z","message":"no user in context"}
    And user "Alice" has uploaded file with content "hello world" to "/textfile0.txt"       # FeatureContext::userHasUploadedAFileWithContentTo()
    When the administrator gets a blob from the blobstore using the --path flag via the CLI # CliContext::theAdministratorGetsABlobFromTheBlobstoreUsingThePathFlagViaTheCli()
      No blobstore directory found under /home/runner/.ocis/storage/users
      Failed asserting that an array is not empty.
    Then the command should be successful                                                   # CliContext::theCommandShouldBeSuccessful()
    And the command output should contain "Download: OK"                                    # CliContext::theCommandOutputShouldContain()
```

</details>

**Root cause:** `findNewestBlobPath()` does `glob(spaces/*/*/blobs)` immediately after a WebDAV PUT. oCIS returns HTTP 201 before async postprocessing moves the blob from `uploads/` to `spaces/*/blobs/`. The glob finds nothing and the assertion fails.

**Fix:** Poll the blobstore directory with 5 retries x 500ms (2.5s max), matching the existing `SpacesContext::getSpaceByName` retry pattern. Both `--path` and `--blob-id` scenarios benefit since they share `findNewestBlobPath()`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
