### PR TITLE
fix(storage-users): configure mount_id, events, and tokens for posix driver

### DIFF
--- a/changelog/unreleased/fix-posix-mount-id.md
+++ b/changelog/unreleased/fix-posix-mount-id.md
@@ -1,0 +1,9 @@
+Bugfix: Configure mount_id, events, and tokens for posix storage driver
+
+Configure `mount_id`, `events`, and `tokens` in the POSIX driver configuration
+for the data provider, and introduce `PosixNoEvents` for the storage provider.
+Without `mount_id`, asynchronous file uploads on POSIX storage failed to
+finalize because the `PostprocessingFinished` event check dropped the event as
+belonging to a different storage provider, leaving uploads permanently stuck.
+
+https://github.com/owncloud/ocis/pull/12780

--- a/services/storage-users/pkg/revaconfig/drivers.go
+++ b/services/storage-users/pkg/revaconfig/drivers.go
@@ -87,6 +87,7 @@ func Local(cfg *config.Config) map[string]interface{} {
 // Posix is the config mapping for the Posix storage driver
 func Posix(cfg *config.Config, enableFSWatch bool) map[string]interface{} {
 	return map[string]interface{}{
+		"mount_id":                   cfg.MountID,
 		"root":                       cfg.Drivers.Posix.Root,
 		"personalspacepath_template": cfg.Drivers.Posix.PersonalSpacePathTemplate,
 		"generalspacepath_template":  cfg.Drivers.Posix.GeneralSpacePathTemplate,
@@ -125,6 +126,67 @@ func Posix(cfg *config.Config, enableFSWatch bool) map[string]interface{} {
 		"watch_type":                 cfg.Drivers.Posix.WatchType,
 		"watch_path":                 cfg.Drivers.Posix.WatchPath,
 		"watch_folder_kafka_brokers": cfg.Drivers.Posix.WatchFolderKafkaBrokers,
+		"events": map[string]interface{}{
+			"numconsumers":   cfg.Events.NumConsumers,
+			"consumer_group": cfg.Events.ConsumerGroup,
+		},
+		"tokens": map[string]interface{}{
+			"transfer_shared_secret": cfg.Commons.TransferSecret,
+			"transfer_expires":       cfg.TransferExpires,
+			"download_endpoint":      cfg.DataServerURL,
+			"datagateway_endpoint":   cfg.DataGatewayURL,
+		},
+	}
+}
+
+// PosixNoEvents is the config mapping for the posix storage driver emitting no events
+func PosixNoEvents(cfg *config.Config, enableFSWatch bool) map[string]interface{} {
+	return map[string]interface{}{
+		"mount_id":                   cfg.MountID,
+		"root":                       cfg.Drivers.Posix.Root,
+		"personalspacepath_template": cfg.Drivers.Posix.PersonalSpacePathTemplate,
+		"generalspacepath_template":  cfg.Drivers.Posix.GeneralSpacePathTemplate,
+		"permissionssvc":             cfg.Drivers.Posix.PermissionsEndpoint,
+		"permissionssvc_tls_mode":    cfg.Commons.GRPCClientTLS.Mode,
+		"treetime_accounting":        true,
+		"treesize_accounting":        true,
+		"asyncfileuploads":           cfg.Drivers.Posix.AsyncUploads,
+		"scan_debounce_delay":        cfg.Drivers.Posix.ScanDebounceDelay,
+		"idcache": map[string]interface{}{
+			"cache_store":               cfg.IDCache.Store,
+			"cache_nodes":               cfg.IDCache.Nodes,
+			"cache_database":            cfg.IDCache.Database,
+			"cache_ttl":                 cfg.IDCache.TTL,
+			"cache_disable_persistence": cfg.IDCache.DisablePersistence,
+			"cache_auth_username":           cfg.IDCache.AuthUsername,
+			"cache_auth_password":           cfg.IDCache.AuthPassword,
+			"cache_enable_tls":              cfg.IDCache.EnableTLS,
+			"cache_tls_insecure":            cfg.IDCache.TLSInsecure,
+			"cache_tls_root_ca_certificate": cfg.IDCache.TLSRootCACertificate,
+		},
+		"filemetadatacache": map[string]interface{}{
+			"cache_store":               cfg.FilemetadataCache.Store,
+			"cache_nodes":               cfg.FilemetadataCache.Nodes,
+			"cache_database":            cfg.FilemetadataCache.Database,
+			"cache_ttl":                 cfg.FilemetadataCache.TTL,
+			"cache_disable_persistence": cfg.FilemetadataCache.DisablePersistence,
+			"cache_auth_username":           cfg.FilemetadataCache.AuthUsername,
+			"cache_auth_password":           cfg.FilemetadataCache.AuthPassword,
+			"cache_enable_tls":              cfg.FilemetadataCache.EnableTLS,
+			"cache_tls_insecure":            cfg.FilemetadataCache.TLSInsecure,
+			"cache_tls_root_ca_certificate": cfg.FilemetadataCache.TLSRootCACertificate,
+		},
+		"use_space_groups":           cfg.Drivers.Posix.UseSpaceGroups,
+		"watch_fs":                   enableFSWatch,
+		"watch_type":                 cfg.Drivers.Posix.WatchType,
+		"watch_path":                 cfg.Drivers.Posix.WatchPath,
+		"watch_folder_kafka_brokers": cfg.Drivers.Posix.WatchFolderKafkaBrokers,
+		"tokens": map[string]interface{}{
+			"transfer_shared_secret": cfg.Commons.TransferSecret,
+			"transfer_expires":       cfg.TransferExpires,
+			"download_endpoint":      cfg.DataServerURL,
+			"datagateway_endpoint":   cfg.DataGatewayURL,
+		},
 	}
 }
 

--- a/services/storage-users/pkg/revaconfig/user.go
+++ b/services/storage-users/pkg/revaconfig/user.go
@@ -14,7 +14,7 @@ func StorageProviderDrivers(cfg *config.Config) map[string]interface{} {
 		"ocis":        OcisNoEvents(cfg),
 		"s3":          S3(cfg),
 		"s3ng":        S3NGNoEvents(cfg),
-		"posix":       Posix(cfg, true),
+		"posix":       PosixNoEvents(cfg, true),
 	}
 }
 


### PR DESCRIPTION
## Description
When using the POSIX storage driver with asynchronous file uploads enabled (`OCIS_ASYNC_UPLOADS: true`, which is the default), file uploads fail to finalize.

### Root Cause
In `services/storage-users/pkg/revaconfig/drivers.go`, the `Posix` driver configuration omitted `mount_id`, `events`, and `tokens` (unlike `Ocis()` and `S3NG()`). As a result, the decomposedfs option `MountID` remained an empty string (`""`).

When the postprocessing service publishes `events.PostprocessingFinished`, `ev.ResourceID.GetStorageId()` contains the gateway mount ID (`40b68bc0-...`). In `decomposedfs.go`:
```go
if ev.ResourceID != nil && ev.ResourceID.GetStorageId() != "" && ev.ResourceID.GetStorageId() != fs.o.MountID {
    sublog.Debug().Msg("ignoring event for different storage")
    return
}
```
Because `fs.o.MountID` was `""`, the check `ev.ResourceID.GetStorageId() != fs.o.MountID` evaluated to true, and every postprocessing finished event was silently dropped. Consequently:
- `session.Finalize(ctx)` was never called.
- Target files remained at 0 bytes (or an older revision).
- The extended attribute `user.ocis.nodestatus` remained perpetually set to `processing:<upload_id>`, resulting in subsequent HTTP 425 ("Too Early") errors on read/delete operations.
- TUS sessions accumulated indefinitely in the uploads directory.

### Solution
1. Add `mount_id`, `events`, and `tokens` to `Posix(cfg *config.Config, enableFSWatch bool)` in `services/storage-users/pkg/revaconfig/drivers.go`.
2. Introduce `PosixNoEvents(cfg *config.Config, enableFSWatch bool)` to avoid starting duplicate event consumers in the gRPC storage provider, mirroring the pattern of `OcisNoEvents` and `S3NGNoEvents`.
3. Add a calens changelog entry in `changelog/unreleased/fix-posix-mount-id.md`.

## Related Issue / PR
N/A
