### PR TITLE
fix: [OCISDEV-1360] Cache LDAP instance mapper lookups

### DIFF
--- a/changelog/unreleased/bugfix-ldap-instance-mapper-cache.md
+++ b/changelog/unreleased/bugfix-ldap-instance-mapper-cache.md
@@ -1,0 +1,10 @@
+Bugfix: Cache LDAP instance mapper lookups
+
+In multi-instance deployments, resolving a user's instance name/ID during
+`GET /graph/v1.0/users` (and group member expansion) issued a fresh, uncached
+LDAP search per instance/guest attribute value on every request. Under load
+this multiplied into large numbers of redundant LDAP round-trips per page of
+users, saturating the LDAP connection pool and causing request timeouts. The
+LDAP identity backend now caches instance mapper lookups, including negative
+(not-found) results, for a configurable TTL
+(`OCIS_LDAP_INSTANCE_MAPPER_CACHE_TTL`, default 60s).

--- a/services/graph/pkg/config/config.go
+++ b/services/graph/pkg/config/config.go
@@ -120,6 +120,7 @@ type LDAP struct {
 	InstanceMapperIDAttribute      string `yaml:"instance_mapper_id_attribute" env:"OCIS_LDAP_INSTANCE_MAPPER_ID_ATTRIBUTE" desc:"LDAP Attribute of the instance ID. Requires OCIS_MULTI_INSTANCE_ENABLED." introductionVersion:"8.0.0"`
 	CrossInstanceReferenceTemplate string `yaml:"cross_instance_reference_template" env:"OCIS_LDAP_CROSS_INSTANCE_REFERENCE_TEMPLATE" desc:"Template for the users unique reference across oCIS instances. Requires OCIS_MULTI_INSTANCE_ENABLED." introductionVersion:"8.0.0"`
 	InstanceURLTemplate            string `yaml:"instance_url_template" env:"OCIS_LDAP_INSTANCE_URL_TEMPLATE" desc:"Template for the instance URL. Requires OCIS_MULTI_INSTANCE_ENABLED." introductionVersion:"8.0.0"`
+	InstanceMapperCacheTTL         int    `yaml:"instance_mapper_cache_ttl" env:"OCIS_LDAP_INSTANCE_MAPPER_CACHE_TTL" desc:"Max TTL in seconds for the LDAP instance mapper cache. Requires OCIS_MULTI_INSTANCE_ENABLED." introductionVersion:"8.0.0"`
 }
 
 // LDAPEducationConfig represents the LDAP configuration for education related resources

--- a/services/graph/pkg/config/defaults/defaultconfig.go
+++ b/services/graph/pkg/config/defaults/defaultconfig.go
@@ -119,6 +119,8 @@ func DefaultConfig() *config.Config {
 				GroupMemberAttribute:      "member",
 				GroupIDAttribute:          "owncloudUUID",
 				EducationResourcesEnabled: false,
+				// 1 minute
+				InstanceMapperCacheTTL: 60,
 			},
 		},
 		Cache: &config.Cache{
@@ -220,4 +222,5 @@ func Sanitize(cfg *config.Config) {
 	cfg.Spaces.ExtendedSpacePropertiesCacheTTL = cfg.Spaces.ExtendedSpacePropertiesCacheTTL * int(time.Second)
 	cfg.Spaces.GroupsCacheTTL = cfg.Spaces.GroupsCacheTTL * int(time.Second)
 	cfg.Spaces.UsersCacheTTL = cfg.Spaces.UsersCacheTTL * int(time.Second)
+	cfg.Identity.LDAP.InstanceMapperCacheTTL = cfg.Identity.LDAP.InstanceMapperCacheTTL * int(time.Second)
 }

--- a/services/graph/pkg/identity/ldap.go
+++ b/services/graph/pkg/identity/ldap.go
@@ -15,6 +15,7 @@ import (
 	backoff "github.com/cenkalti/backoff/v5"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/google/uuid"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/libregraph/idm/pkg/ldapdn"
 	libregraph "github.com/owncloud/libre-graph-api-go"
 
@@ -70,14 +71,14 @@ type LDAP struct {
 	disableUserMechanism    DisableUserMechanismType
 	localUserDisableGroupDN string
 
-	groupBaseDN          string
-	groupCreateBaseDN    string
-	groupFilter          string
-	groupObjectClass                string
-	groupAdditionalObjectClasses    []string
-	groupIDisOctetString            bool
-	groupScope           int
-	groupAttributeMap    groupAttributeMap
+	groupBaseDN                  string
+	groupCreateBaseDN            string
+	groupFilter                  string
+	groupObjectClass             string
+	groupAdditionalObjectClasses []string
+	groupIDisOctetString         bool
+	groupScope                   int
+	groupAttributeMap            groupAttributeMap
 
 	educationConfig educationConfig
 
@@ -96,7 +97,18 @@ type LDAP struct {
 	instanceMapperIDAttribute      string
 	crossInstanceReferenceTemplate *template.Template
 	instanceURLTemplate            *template.Template
+	instanceCache                  *ttlcache.Cache[string, string]
 }
+
+// instanceCacheKeySep separates the fields of an instanceCache key. A NUL byte can't
+// appear in an LDAP attribute name or search value, so it can't cause key collisions
+// between different (searchAttribute, resultAttribute, searchValue) triples.
+const instanceCacheKeySep = "\x00"
+
+// instanceCacheNotFound is stored in instanceCache to negatively cache a lookup
+// that resolved to ErrNotFound, so repeatedly requested stale instance references
+// don't cost a fresh LDAP round-trip on every call.
+const instanceCacheNotFound = instanceCacheKeySep + "not-found"
 
 type userAttributeMap struct {
 	displayName         string
@@ -204,6 +216,12 @@ func NewLDAPBackend(lc ldap.Client, config config.LDAP, logger *log.Logger, inst
 		}
 	}
 
+	instanceCache := ttlcache.New(
+		ttlcache.WithTTL[string, string](time.Duration(config.InstanceMapperCacheTTL)),
+		ttlcache.WithDisableTouchOnHit[string, string](),
+	)
+	go instanceCache.Start()
+
 	return &LDAP{
 		useServerUUID:                  config.UseServerUUID,
 		usePwModifyExOp:                config.UsePasswordModExOp,
@@ -241,6 +259,7 @@ func NewLDAPBackend(lc ldap.Client, config config.LDAP, logger *log.Logger, inst
 		instanceMapperIDAttribute:      config.InstanceMapperIDAttribute,
 		crossInstanceReferenceTemplate: crossInstanceReferenceTemplate,
 		instanceURLTemplate:            instanceURLTemplate,
+		instanceCache:                  instanceCache,
 	}, nil
 }
 
@@ -1596,6 +1615,14 @@ func (i *LDAP) getInstance(searchValue, searchAttribute, resultAttribute string)
 		return searchValue, nil
 	}
 
+	cacheKey := searchAttribute + instanceCacheKeySep + resultAttribute + instanceCacheKeySep + searchValue
+	if item := i.instanceCache.Get(cacheKey); item != nil {
+		if item.Value() == instanceCacheNotFound {
+			return "", ErrNotFound
+		}
+		return item.Value(), nil
+	}
+
 	searchRequest := ldap.NewSearchRequest(
 		i.instanceMapperBaseDN,
 		ldap.ScopeWholeSubtree,
@@ -1607,23 +1634,30 @@ func (i *LDAP) getInstance(searchValue, searchAttribute, resultAttribute string)
 
 	res, err := i.conn.Search(searchRequest)
 	if err != nil {
+		// Not cached: this is a transient LDAP failure, not a definitive answer.
 		i.logger.Error().Err(err).Str("backend", "ldap").Str("dn", i.instanceMapperBaseDN).Str("searchValue", searchValue).Str("searchAttribute", searchAttribute).Str("resultAttribute", resultAttribute).Msg("Search instance failed")
 		return "", errorcode.New(errorcode.ItemNotFound, "instanceid search failed")
 	}
 	if len(res.Entries) == 0 {
 		// expected behaviour - we log debug in case something is fishy. This log can be removed when the feature proves stable
 		i.logger.Debug().Str("backend", "ldap").Str("dn", i.instanceMapperBaseDN).Str("searchValue", searchValue).Interface("result", res).Msg("Search instance empty")
+		i.instanceCache.Set(cacheKey, instanceCacheNotFound, ttlcache.DefaultTTL)
 		return "", ErrNotFound
 	}
 	if len(res.Entries) > 1 {
+		// Not cached: ambiguous data, don't freeze it in.
 		i.logger.Error().Str("backend", "ldap").Str("dn", i.instanceMapperBaseDN).Str("searchValue", searchValue).Interface("result", res).Msg("Search instance returned multiple responses.")
 		return "", errorcode.New(errorcode.ItemNotFound, "instanceid search returned multiple responses")
 	}
 	if len(res.Entries[0].Attributes) == 0 || len(res.Entries[0].Attributes[0].Values) == 0 {
+		// Not cached: malformed data, don't freeze it in.
 		i.logger.Error().Str("backend", "ldap").Str("dn", i.instanceMapperBaseDN).Str("searchValue", searchValue).Interface("result", res).Msg("Search instance returned malformed response")
 		return "", errorcode.New(errorcode.ItemNotFound, "instanceid search response malformed")
 	}
-	return res.Entries[0].Attributes[0].Values[0], nil
+
+	value := res.Entries[0].Attributes[0].Values[0]
+	i.instanceCache.Set(cacheKey, value, ttlcache.DefaultTTL)
+	return value, nil
 }
 
 func (i *LDAP) getInstanceID(instancename string) (string, error) {

--- a/services/graph/pkg/identity/ldap_instance_cache_test.go
+++ b/services/graph/pkg/identity/ldap_instance_cache_test.go
@@ -1,0 +1,73 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/config"
+	"github.com/owncloud/ocis/v2/services/graph/pkg/identity/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var instanceMapperConfig = config.LDAP{
+	UserBaseDN:               "ou=people,dc=test",
+	UserObjectClass:          "inetOrgPerson",
+	UserSearchScope:          "sub",
+	UserDisplayNameAttribute: "displayname",
+	UserIDAttribute:          "entryUUID",
+	UserEmailAttribute:       "mail",
+	UserNameAttribute:        "uid",
+
+	GroupBaseDN:          "ou=groups,dc=test",
+	GroupObjectClass:     "groupOfNames",
+	GroupSearchScope:     "sub",
+	GroupNameAttribute:   "cn",
+	GroupMemberAttribute: "member",
+	GroupIDAttribute:     "entryUUID",
+
+	InstanceMapperEnabled:       true,
+	InstanceMapperBaseDN:        "ou=instances,dc=test",
+	InstanceMapperNameAttribute: "instanceName",
+	InstanceMapperIDAttribute:   "instanceID",
+}
+
+func TestGetInstanceNameIsCached(t *testing.T) {
+	lm := &mocks.Client{}
+	b, err := getMockedBackend(lm, instanceMapperConfig, &logger)
+	assert.Nil(t, err)
+
+	instanceEntry := ldap.NewEntry("instanceID=instance-1,ou=instances,dc=test",
+		map[string][]string{
+			"instanceName": {"Instance One"},
+		})
+	lm.On("Search", mock.Anything).
+		Return(&ldap.SearchResult{Entries: []*ldap.Entry{instanceEntry}}, nil)
+
+	name1, err1 := b.getInstanceName("instance-1")
+	assert.Nil(t, err1)
+	assert.Equal(t, "Instance One", name1)
+
+	name2, err2 := b.getInstanceName("instance-1")
+	assert.Nil(t, err2)
+	assert.Equal(t, "Instance One", name2)
+
+	lm.AssertNumberOfCalls(t, "Search", 1)
+}
+
+func TestGetInstanceNameCachesNotFound(t *testing.T) {
+	lm := &mocks.Client{}
+	b, err := getMockedBackend(lm, instanceMapperConfig, &logger)
+	assert.Nil(t, err)
+
+	lm.On("Search", mock.Anything).
+		Return(&ldap.SearchResult{Entries: []*ldap.Entry{}}, nil)
+
+	_, err1 := b.getInstanceName("stale-instance")
+	assert.ErrorIs(t, err1, ErrNotFound)
+
+	_, err2 := b.getInstanceName("stale-instance")
+	assert.ErrorIs(t, err2, ErrNotFound)
+
+	lm.AssertNumberOfCalls(t, "Search", 1)
+}


### PR DESCRIPTION
Issue:
Uncached N+1 LDAP lookup during user listing in the graph service's LDAP identity backend, triggered by the multi-tenant/instance-mapper configuration.

Call chain
GET /graph/v1.0/users → Graph.GetUsers (services/graph/pkg/service/v0/users.go:316) → LDAP.GetUsers → LDAP.FilterUsers (services/graph/pkg/identity/ldap.go:761/766) — one LDAP search returns the whole page of users.
usersFromLDAPEntries (ldap.go:823) loops over every returned user and calls createUserModelFromLDAP per entry.
Because instanceURLTemplate/crossInstanceReferenceTemplate are configured, createUserModelFromLDAP (ldap.go:1061-1122) loops over each user's instance/guest attribute values and, for each one, calls getInstanceName → getInstance (ldap.go:1602/1616), which fires a brand-new LDAP Search to resolve the tenant/instance name.
getInstance has no cache — every call goes straight to LDAP (unlike other identity lookups in services/graph/pkg/identity/cache.go, which are cached).
Several referenced instance/member DNs don't resolve (stale data, recur every ~1s), so those lookups fail with itemnotfound — but still cost a full LDAP round-trip.
Net effect: a single GET /graph/v1.0/users call turns into N (users per page) × M (instance attrs per user) synchronous, uncached LDAP round-trips. Under 100 concurrent VUs this saturates the LDAP connection pool.

Bugfix: Cache LDAP instance mapper lookups
In multi-instance deployments, resolving a user's instance name/ID during
GET /graph/v1.0/users (and group member expansion) issued a fresh, uncached
LDAP search per instance/guest attribute value on every request. Under load
this multiplied into large numbers of redundant LDAP round-trips per page of
users, saturating the LDAP connection pool and causing request timeouts. The
LDAP identity backend now caches instance mapper lookups, including negative
(not-found) results, for a configurable TTL
(OCIS_LDAP_INSTANCE_MAPPER_CACHE_TTL, default 60s).