### PR TITLE
[tests-only][full-ci][k8s] test: expose ldap ports

### DIFF
--- a/tests/config/k8s/expose-debug-svc.sh
+++ b/tests/config/k8s/expose-debug-svc.sh
@@ -45,6 +45,10 @@ declare -A DEBUG_PORTS=(
     [webfinger]=9279
 )
 
+declare -A LDAPS_PORTS=(
+    [idm]=9235
+)
+
 declare -A GRPC_PORTS=(
     [appregistry]=9242
     [authapp]=9246
@@ -93,6 +97,12 @@ should_expose() {
     esac
 }
 
+# k3d maps host ports 9100-9399 to NodePorts 30100-30399 (see `-p` in ../Makefile),
+# a fixed +21000 offset. A plain ClusterIP Service (kubectl expose's default) is
+# never reachable through that mapping, so these services must be NodePort with a
+# nodePort that lands on the matching offset.
+NODEPORT_OFFSET=21000
+
 expose() {
     local deployment=$1
     local service=$2
@@ -108,10 +118,30 @@ expose() {
         return
     fi
 
-    kubectl -n "$NAMESPACE" expose deployment "$deployment" \
-        --name="$service" \
-        --port="$port" \
-        --target-port="$port"
+    # Only ports in the 9100-9399 band are forwarded by k3d's loadbalancer
+    # (see ../Makefile); anything else can't be reached from outside the
+    # cluster via a nodePort anyway, so leave it as a plain ClusterIP.
+    if (( port >= 9100 && port <= 9399 )); then
+        local node_port=$((port + NODEPORT_OFFSET))
+        # Generate the manifest client-side (still derives the correct
+        # selector from the deployment) and inject the desired nodePort
+        # before the service ever exists, so there is no intermediate
+        # auto-assigned port that could collide with another iteration's
+        # target nodePort.
+        kubectl -n "$NAMESPACE" expose deployment "$deployment" \
+            --name="$service" \
+            --port="$port" \
+            --target-port="$port" \
+            --type=NodePort \
+            --dry-run=client -o json \
+            | jq ".spec.ports[0].nodePort = $node_port" \
+            | kubectl -n "$NAMESPACE" apply -f -
+    else
+        kubectl -n "$NAMESPACE" expose deployment "$deployment" \
+            --name="$service" \
+            --port="$port" \
+            --target-port="$port"
+    fi
 }
 
 for svc in "${!DEBUG_PORTS[@]}"; do
@@ -120,4 +150,8 @@ done
 
 for svc in "${!GRPC_PORTS[@]}"; do
     expose "$svc" "${svc}-grpc" "${GRPC_PORTS[$svc]}"
+done
+
+for svc in "${!LDAPS_PORTS[@]}"; do
+    expose "$svc" "${svc}-ldaps" "${LDAPS_PORTS[$svc]}"
 done

--- a/tests/ociswrapper/ocis/k8s.go
+++ b/tests/ociswrapper/ocis/k8s.go
@@ -328,7 +328,15 @@ func waitPodDelete(podName string, timeout int) (string, error) {
 
 func K8sRollback() (bool, string) {
 	for service, config := range K8sOcisInitEnv {
-		envs := config.Envs
+		// A var added by a test (not present in the original baseline) would
+		// otherwise never get unset: `kubectl set env` only sets the vars it's
+		// given, it doesn't remove anything else already on the deployment.
+		currentEnvs, err := getInitialEnvs(service)
+		if err != nil {
+			return false, "error getting current envs"
+		}
+		extraEnvs := diffEnvs(config.Envs, currentEnvs)
+		envs := append(append([]string{}, config.Envs...), extraEnvs...)
 		log.Println(fmt.Sprintf("[%s] Rolling envs: %s", service, strings.Join(envs, ", ")))
 		podName, err := getPodName(service)
 		if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
In K8s deployment the following test failed.
```feature
@env-config @issue-11775
Scenario: admin creates a group with the configured LDAP group object class                                        # /home/runner/work/ocis/ocis/tests/acceptance/features/apiGraphGroup/createGroup.feature:52
  Given the config "OCIS_LDAP_GROUP_OBJECTCLASS" has been set to "groupOfUniqueNames" for "graph" service          # OcisConfigContext::theConfigHasBeenSetTo()
  When the administrator creates a group "uniquegroup" using the Graph API                                         # GraphContext::userCreatesGroupUsingTheGraphApi()
  Then the HTTP status code should be "201"                                                                        # FeatureContext::thenTheHTTPStatusCodeShouldBe()
  And the LDAP entry "cn=uniquegroup,ou=groups,o=libregraph-idm" should have the object class "groupOfUniqueNames" # FeatureContext::theLdapEntryShouldHaveObjectClass()
    0x51 (Can't contact LDAP server; getLastError: could not call ldap_get_option because LDAP resource was not of type resource): ldaps://ocis-server:9235 (Laminas\Ldap\Exception\LdapException)
  And the LDAP entry "cn=uniquegroup,ou=groups,o=libregraph-idm" should not have the object class "groupOfNames"
```

The reason to this failure, In k8s, `idm` is its own Deployment/Service. The test runner lives outside the cluster and only reaches the cluster through the k3d loadbalancer port range `9100-9300`, and only for ports that `expose-debug-svc.sh` explicitly exoses as extra services. The script's `DEBUG_PORTS` map has `[idm]=9239` - that's IDM's debug port, not its ldap port. Port `9235` is never exposed outside the cluster. So, `ldaps://ocis-server:9235` gets no TCP endpoint from the runner `ldap_connect` bind fails at the transport level.

To fix this expose the idm's ldap port in `tests/config/k8s/expose-debug-svc.sh`.

Failed workflows:
- https://github.com/owncloud/ocis/actions/runs/34114880433/job/101719256073
- https://github.com/owncloud/ocis/actions/runs/34091987678/job/101677176422