### PR TITLE
fix: [8.1] set the correct value of IV

### DIFF
--- a/services/proxy/pkg/config/config.go
+++ b/services/proxy/pkg/config/config.go
@@ -132,7 +132,7 @@ type JWKS struct {
 type MFAConfig struct {
 	Enabled         bool     `yaml:"enabled" env:"OCIS_MFA_ENABLED" desc:"Enable MFA enforcement. If enabled users need to complete MFA before they can access specific paths" introductionVersion:"7.3.0"`
 	AuthLevelNames  []string `yaml:"auth_level_name" env:"OCIS_MFA_AUTH_LEVEL_NAMES" desc:"This authentication level name indicates that multi-factor authentication was performed. The name must match the ACR claim in the access token received. Note: If multiple names are required, use a comma-separated list. The front-end service will use the first name in the list when requesting multi-factor authentication (MFA)." introductionVersion:"7.3.0"`
-	SessionDuration int      `yaml:"session_duration" env:"OCIS_MFA_SESSION_DURATION" desc:"The duration in seconds that a multi-factor authentication session is valid for non-OIDC requests. Defaults to 3600 (1 hour)." introductionVersion:"7.3.0"`
+	SessionDuration int      `yaml:"session_duration" env:"OCIS_MFA_SESSION_DURATION" desc:"The duration in seconds that a multi-factor authentication session is valid for non-OIDC requests. Defaults to 3600 (1 hour)." introductionVersion:"8.1.0"`
 }
 
 // Cache is a TTL cache configuration.


### PR DESCRIPTION
The envvar `OCIS_MFA_SESSION_DURATION` has two occurrences: `frontend` and `proxy`.
For whatever reason, the ennvar in proxy was falsly set to an IV of `7.3.0` which is wrong. The correct IV is `8.1.0`
This most likely happened unintentionally by a backport recently to 8.1

This is fixed now.