### PR TITLE
[tests-only][full-ci] test: add missing wait for virus scan completion in uploadSessions scenario

### DIFF
--- a/tests/acceptance/features/cliCommands/uploadSessions.feature
+++ b/tests/acceptance/features/cliCommands/uploadSessions.feature
@@ -125,6 +125,7 @@ Feature: List upload sessions via CLI command
       | antivirus      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
     And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt"
     And the config "POSTPROCESSING_DELAY" has been set to "10s" for "postprocessing" service
+    And the administrator has waited until the file "virusFile.txt" has finished processing
     And user "Alice" has uploaded file with content "upload content" to "/file1.txt"
     When the administrator cleans upload sessions with the following flags:
       | processing=false |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Fix flaky test in `cliCommands/uploadSessions.feature:121` ("clean all upload sessions that are not in post-processing").
Suite: `cliCommands`
<details>
<summary>CI Failure Logs</summary>

```gherkin

Scenario: clean all upload sessions that are not in post-processing                                # /home/runner/work/ocis/ocis/tests/acceptance/features/cliCommands/uploadSessions.feature:121
 Given the following configs have been set:                                                       # OcisConfigContext::theConfigHasBeenSetToValue()
      | service        | config                           | value     |
      | postprocessing | POSTPROCESSING_STEPS             | virusscan |
      | antivirus      | ANTIVIRUS_INFECTED_FILE_HANDLING | abort     |
And user "Alice" has uploaded file "filesForUpload/filesWithVirus/eicar.com" to "/virusFile.txt" # FeatureContext::userHasUploadedAFileTo()
And the config "POSTPROCESSING_DELAY" has been set to "10s" for "postprocessing" service         # OcisConfigContext::theConfigHasBeenSetTo()
And user "Alice" has uploaded file with content "upload content" to "/file1.txt"                 # FeatureContext::userHasUploadedAFileWithContentTo()
    When the administrator cleans upload sessions with the following flags:                          # CliContext::theAdministratorCleansUploadSessionsWithTheFollowingFlags()
      | processing=false |
    Then the command should be successful                                                            # CliContext::theCommandShouldBeSuccessful()
    And the CLI response should contain these entries:                                               # CliContext::theCLIResponseShouldContainTheseEntries()
      | virusFile.txt |
      The resource 'virusFile.txt' was not found in the response.
      Failed asserting that false is true.

```

</details>

#### Root Cause

Missing synchronization step between uploading the virus file and running the clean command. The test uploads `virusFile.txt` (eicar.com), then immediately sets `POSTPROCESSING_DELAY=10s` (triggering a server restart), then uploads `file1.txt` and runs the clean command with `--processing=false`.

The race: if clamav has not finished scanning `virusFile.txt` when the clean command runs, the file is still marked as `processing=true` and gets filtered out by `--processing=false`. The assertion "should contain virusFile.txt" then fails.

#### Fix

Add the existing `theAdministratorHasWaitedUntilFileHasFinishedProcessing` step after the virus file upload and before the clean command. This polls the `--processing` list until `virusFile.txt` disappears (30s timeout), guaranteeing the scan completed. This is the same pattern used in scenario 25 ("list all upload sessions that are currently in postprocessing") which has an identical setup.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
