### PR TITLE
fix: [stable-8.0] Remove the unmarshalable request body field from graph log messages

### DIFF
--- a/changelog/unreleased/bugfix-graph-drop-unmarshalable-body-log-field.md
+++ b/changelog/unreleased/bugfix-graph-drop-unmarshalable-body-log-field.md
@@ -1,0 +1,13 @@
+Bugfix: Remove the unmarshalable request body field from graph log messages
+
+We've removed the `body` field from the log messages of the graph service's HTTP
+handlers. The field was set from `http.Request.Body`, an `io.ReadCloser`, which
+can never be serialized into a useful log value.
+
+The tracing middleware replaces the request body with a wrapper that carries an
+exported function field, so serializing it failed outright and the log line was
+emitted with `"body": "marshaling error: json: unsupported type: func(int64)"`
+instead of the payload. Without the tracing middleware the field serialized to an
+empty object. In both cases the intended payload was never logged.
+
+https://github.com/owncloud/ocis/pull/12918

--- a/services/graph/pkg/service/v0/api_driveitem_permissions_links.go
+++ b/services/graph/pkg/service/v0/api_driveitem_permissions_links.go
@@ -167,7 +167,7 @@ func (api DriveItemPermissionsApi) CreateLink(w http.ResponseWriter, r *http.Req
 
 	var createLink libregraph.DriveItemCreateLink
 	if err = StrictJSONUnmarshal(r.Body, &createLink); err != nil {
-		logger.Error().Err(err).Interface("body", r.Body).Msg("could not create link: invalid body schema definition")
+		logger.Error().Err(err).Msg("could not create link: invalid body schema definition")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}
@@ -196,7 +196,7 @@ func (api DriveItemPermissionsApi) CreateSpaceRootLink(w http.ResponseWriter, r 
 
 	var createLink libregraph.DriveItemCreateLink
 	if err = StrictJSONUnmarshal(r.Body, &createLink); err != nil {
-		logger.Error().Err(err).Interface("body", r.Body).Msg("could not create link: invalid body schema definition")
+		logger.Error().Err(err).Msg("could not create link: invalid body schema definition")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}

--- a/services/graph/pkg/service/v0/approleassignments.go
+++ b/services/graph/pkg/service/v0/approleassignments.go
@@ -139,7 +139,7 @@ func (g Graph) CreateAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 // DeleteAppRoleAssignment implements the Service interface.
 func (g Graph) DeleteAppRoleAssignment(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
-	logger.Info().Interface("body", r.Body).Msg("calling delete appRoleAssignment")
+	logger.Info().Msg("calling delete appRoleAssignment")
 
 	userID := chi.URLParam(r, "userID")
 

--- a/services/graph/pkg/service/v0/drives.go
+++ b/services/graph/pkg/service/v0/drives.go
@@ -391,7 +391,7 @@ func (g Graph) createDrive(w http.ResponseWriter, r *http.Request, apiVersion AP
 
 	drive := libregraph.Drive{}
 	if err := StrictJSONUnmarshal(r.Body, &drive); err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create drive: invalid body schema definition")
+		logger.Debug().Err(err).Msg("could not create drive: invalid body schema definition")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}
@@ -524,7 +524,7 @@ func (g Graph) updateDrive(w http.ResponseWriter, r *http.Request, apiVersion AP
 
 	drive := libregraph.DriveUpdate{}
 	if err = StrictJSONUnmarshal(r.Body, &drive); err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update drive, invalid request body")
+		logger.Debug().Err(err).Msg("could not update drive, invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: error: %v", err.Error()))
 		return
 	}

--- a/services/graph/pkg/service/v0/educationclasses.go
+++ b/services/graph/pkg/service/v0/educationclasses.go
@@ -54,7 +54,7 @@ func (g Graph) PostEducationClass(w http.ResponseWriter, r *http.Request) {
 	class := libregraph.NewEducationClassWithDefaults()
 	err := StrictJSONUnmarshal(r.Body, class)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create education class: invalid request body")
+		logger.Debug().Err(err).Msg("could not create education class: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -110,7 +110,7 @@ func (g Graph) PatchEducationClass(w http.ResponseWriter, r *http.Request) {
 	changes := libregraph.NewEducationClassWithDefaults()
 	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not change class: invalid request body")
+		logger.Debug().Err(err).Msg("could not change class: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -315,10 +315,7 @@ func (g Graph) PostEducationClassMember(w http.ResponseWriter, r *http.Request) 
 	memberRef := libregraph.NewMemberReference()
 	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
-		logger.Debug().
-			Err(err).
-			Interface("body", r.Body).
-			Msg("could not add class member: invalid request body")
+		logger.Debug().Err(err).Msg("could not add class member: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -461,10 +458,7 @@ func (g Graph) PostEducationClassTeacher(w http.ResponseWriter, r *http.Request)
 	memberRef := libregraph.NewMemberReference()
 	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
-		logger.Debug().
-			Err(err).
-			Interface("body", r.Body).
-			Msg("could not add class teacher: invalid request body")
+		logger.Debug().Err(err).Msg("could not add class teacher: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}

--- a/services/graph/pkg/service/v0/educationschools.go
+++ b/services/graph/pkg/service/v0/educationschools.go
@@ -54,7 +54,7 @@ func (g Graph) PostEducationSchool(w http.ResponseWriter, r *http.Request) {
 	school := libregraph.NewEducationSchool()
 	err := StrictJSONUnmarshal(r.Body, school)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create school: invalid request body")
+		logger.Debug().Err(err).Msg("could not create school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -131,7 +131,7 @@ func (g Graph) PatchEducationSchool(w http.ResponseWriter, r *http.Request) {
 	school := libregraph.NewEducationSchool()
 	err = StrictJSONUnmarshal(r.Body, school)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update school: invalid request body")
+		logger.Debug().Err(err).Msg("could not update school: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -330,10 +330,7 @@ func (g Graph) PostEducationSchoolUser(w http.ResponseWriter, r *http.Request) {
 	memberRef := libregraph.NewMemberReference()
 	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
-		logger.Debug().
-			Err(err).
-			Interface("body", r.Body).
-			Msg("could not add school user: invalid request body")
+		logger.Debug().Err(err).Msg("could not add school user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -485,10 +482,7 @@ func (g Graph) PostEducationSchoolClass(w http.ResponseWriter, r *http.Request) 
 	memberRef := libregraph.NewMemberReference()
 	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
-		logger.Debug().
-			Err(err).
-			Interface("body", r.Body).
-			Msg("could not add school class: invalid request body")
+		logger.Debug().Err(err).Msg("could not add school class: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}

--- a/services/graph/pkg/service/v0/educationuser.go
+++ b/services/graph/pkg/service/v0/educationuser.go
@@ -52,11 +52,11 @@ func (g Graph) GetEducationUsers(w http.ResponseWriter, r *http.Request) {
 // PostEducationUser implements the Service interface.
 func (g Graph) PostEducationUser(w http.ResponseWriter, r *http.Request) {
 	logger := g.logger.SubloggerWithRequestID(r.Context())
-	logger.Info().Interface("body", r.Body).Msg("calling create education user")
+	logger.Info().Msg("calling create education user")
 	u := libregraph.NewEducationUser()
 	err := StrictJSONUnmarshal(r.Body, u)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create education user: invalid request body")
+		logger.Debug().Err(err).Msg("could not create education user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %v", err.Error()))
 		return
 	}
@@ -321,7 +321,7 @@ func (g Graph) PatchEducationUser(w http.ResponseWriter, r *http.Request) {
 	changes := libregraph.NewEducationUser()
 	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update education user: invalid request body")
+		logger.Debug().Err(err).Msg("could not update education user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
 			fmt.Sprintf("invalid request body: %s", err.Error()))
 		return

--- a/services/graph/pkg/service/v0/groups.go
+++ b/services/graph/pkg/service/v0/groups.go
@@ -99,7 +99,7 @@ func (g Graph) PostGroup(w http.ResponseWriter, r *http.Request) {
 	grp := libregraph.NewGroup()
 	err := StrictJSONUnmarshal(r.Body, grp)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not create group: invalid request body")
+		logger.Debug().Err(err).Msg("could not create group: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
@@ -164,13 +164,13 @@ func (g Graph) PatchGroup(w http.ResponseWriter, r *http.Request) {
 	changes := libregraph.NewGroup()
 	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not change group: invalid request body")
+		logger.Debug().Err(err).Msg("could not change group: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}
 
 	if reflect.ValueOf(*changes).IsZero() {
-		logger.Debug().Interface("body", r.Body).Msg("ignoring empyt request body")
+		logger.Debug().Msg("ignoring empyt request body")
 		render.Status(r, http.StatusNoContent)
 		render.NoContent(w, r)
 		return
@@ -366,10 +366,7 @@ func (g Graph) PostGroupMember(w http.ResponseWriter, r *http.Request) {
 	memberRef := libregraph.NewMemberReference()
 	err = StrictJSONUnmarshal(r.Body, memberRef)
 	if err != nil {
-		logger.Debug().
-			Err(err).
-			Interface("body", r.Body).
-			Msg("could not add group member: invalid request body")
+		logger.Debug().Err(err).Msg("could not add group member: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
 	}

--- a/services/graph/pkg/service/v0/tags.go
+++ b/services/graph/pkg/service/v0/tags.go
@@ -54,7 +54,7 @@ func (g Graph) AssignTags(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err := StrictJSONUnmarshal(r.Body, &assignment); err != nil {
-		g.logger.Debug().Err(err).Interface("body", r.Body).Msg("could not decode tag assignment request")
+		g.logger.Debug().Err(err).Msg("could not decode tag assignment request")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}
@@ -161,7 +161,7 @@ func (g Graph) UnassignTags(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err := StrictJSONUnmarshal(r.Body, &unassignment); err != nil {
-		g.logger.Debug().Err(err).Interface("body", r.Body).Msg("could not decode tag assignment request")
+		g.logger.Debug().Err(err).Msg("could not decode tag assignment request")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest, "invalid body schema definition")
 		return
 	}

--- a/services/graph/pkg/service/v0/users.go
+++ b/services/graph/pkg/service/v0/users.go
@@ -861,7 +861,7 @@ func (g Graph) PatchMe(w http.ResponseWriter, r *http.Request) {
 	changes := libregraph.NewUserUpdate()
 	err := StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update user: invalid request body")
+		logger.Debug().Err(err).Msg("could not update user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
 			fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
@@ -893,7 +893,7 @@ func (g Graph) PatchUser(w http.ResponseWriter, r *http.Request) {
 	changes := libregraph.NewUserUpdate()
 	err = StrictJSONUnmarshal(r.Body, changes)
 	if err != nil {
-		logger.Debug().Err(err).Interface("body", r.Body).Msg("could not update user: invalid request body")
+		logger.Debug().Err(err).Msg("could not update user: invalid request body")
 		errorcode.InvalidRequest.Render(w, r, http.StatusBadRequest,
 			fmt.Sprintf("invalid request body: %s", err.Error()))
 		return
@@ -934,7 +934,7 @@ func (g Graph) patchUser(w http.ResponseWriter, r *http.Request, nameOrID string
 	}
 
 	if reflect.ValueOf(*changes).IsZero() {
-		logger.Debug().Interface("body", r.Body).Msg("ignoring empty request body")
+		logger.Debug().Msg("ignoring empty request body")
 		render.Status(r, http.StatusNoContent)
 		render.NoContent(w, r)
 		return


### PR DESCRIPTION
Backport of #12915 to `stable-8.0`.

## Summary
- We've removed the `body` field from the log messages of the graph service's HTTP handlers. The field was set from `http.Request.Body`, an `io.ReadCloser`, which can never be serialized into a useful log value.