### PR TITLE
fix(storage-users): [stable-8.0] add --orphaned upload session filter

### DIFF
--- a/changelog/unreleased/bugfix-orphaned-upload-sessions.md
+++ b/changelog/unreleased/bugfix-orphaned-upload-sessions.md
@@ -1,0 +1,28 @@
+Bugfix: Release the quota of upload sessions with unreadable node metadata
+
+When an upload's target node lost its metadata, e.g. because an ancestor was
+moved to the trash while the upload was still in flight, the upload could never
+finish processing. It stayed in "Processing" forever, could not be downloaded or
+deleted, and kept consuming the space quota.
+
+Cleaning such a session up with `ocis storage-users uploads sessions --clean`
+did not help either: it removed the uploaded bytes and the session info file
+before failing to revert the node, so it destroyed the only copy of the data
+without releasing any quota.
+
+Cleanup now reverts the node before removing anything irreversible and falls
+back to the session metadata when the node cannot be read, so the quota is
+released and the orphaned node is removed. If the quota cannot be released the
+upload is kept so it can be retried instead of being lost.
+
+A new `--orphaned` filter lists the affected sessions:
+
+```
+ocis storage-users uploads sessions --orphaned
+ocis storage-users uploads sessions --orphaned --clean
+```
+
+Note that evaluating the filter reads the node metadata of every session, so it
+is only done when the flag is set.
+
+https://github.com/owncloud/ocis/pull/12739

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/open-policy-agent/opa v1.19.0
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
-	github.com/owncloud/reva/v2 v2.0.0-20260813081353-3dbd3c2711ea
+	github.com/owncloud/reva/v2 v2.0.0-20260910093159-40663c5bb3cb
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.24.1

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,8 @@ github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HD
 github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245 h1:JRidLTAKhnvyLMRtVtSF4lhBa0NSAOs6fof+d6JnKII=
 github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245/go.mod h1:z61VMGAJRtR1nbgXWiNoCkxUXP1B3Je9rMuJbnGd+Og=
-github.com/owncloud/reva/v2 v2.0.0-20260813081353-3dbd3c2711ea h1:68rl8e2cYHE46s+PFJRpp0IP4VLyqAILQE8GD9F2FjE=
-github.com/owncloud/reva/v2 v2.0.0-20260813081353-3dbd3c2711ea/go.mod h1:LSXqMWTC7Ya6uxmqp1ksrWYZXBuZ6PhcmVimxyG8U5o=
+github.com/owncloud/reva/v2 v2.0.0-20260910093159-40663c5bb3cb h1:pbFDeaDFhJ5dJF/ZYOyRf/FtD6MbG5BIPlOUeoh1vIs=
+github.com/owncloud/reva/v2 v2.0.0-20260910093159-40663c5bb3cb/go.mod h1:LSXqMWTC7Ya6uxmqp1ksrWYZXBuZ6PhcmVimxyG8U5o=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pablodz/inotifywaitgo v0.0.12 h1:DVJJTFMDlSAdO46yisPF2vzozs/r+4k6ih8MVghq78M=

--- a/services/storage-users/README.md
+++ b/services/storage-users/README.md
@@ -86,6 +86,7 @@ OPTIONS:
    --processing  filter sessions by processing status (default: unset)
    --expired     filter sessions by expired status (default: unset)
    --has-virus   filter sessions by virus scan result (default: unset)
+   --orphaned    filter sessions by whether their node metadata is unreadable (default: unset)
    --json        output as json (default: false)
    --restart     send restart event for all listed sessions (default: false)
    --resume      send resume event for all listed sessions (default: false)
@@ -140,6 +141,23 @@ ocis storage-users uploads sessions --expired=true --clean
 ocis storage-users uploads sessions --processing=true --has-virus=false --resume
 ```
 
+Uploads whose node metadata can no longer be read are orphaned: they can never finish
+postprocessing, because the destination of the upload cannot be resolved. Such uploads stay
+in processing state indefinitely and keep consuming the quota of their space. Use the
+`--orphaned` filter to list them, and `--clean` to remove them and release the quota.
+
+```bash
+# lists all orphaned upload sessions
+ocis storage-users uploads sessions --orphaned=true
+
+# removes them and releases the quota they consume
+ocis storage-users uploads sessions --orphaned=true --clean
+```
+
+Note: `--orphaned` reads the node metadata of every upload session, so it is slower than the
+other filters. Cleaning an orphaned session deletes the uploaded bytes, which are the only
+copy as long as postprocessing has not finished. Run the command without `--clean` first.
+
 
 #### Delete Stale Nodes command
 
@@ -183,6 +201,92 @@ Use `--verbose` to get more information about what is happening
 ocis storage-users uploads delete-stale-nodes --dry-run=false --verbose
 ```
 
+
+### Check and Inspect the Blobstore
+
+The `blobstore` command group provides tools to verify connectivity to the configured blobstore and to inspect individual blobs. Both the `ocis` and `s3ng` storage drivers are supported.
+
+```bash
+ocis storage-users blobstore <command>
+```
+
+```plaintext
+COMMANDS:
+   check  check blobstore connectivity via an upload/download/delete round-trip
+   get    get a blob from the blobstore by ID
+```
+
+#### Check
+
+Verifies that the blobstore is reachable and fully operational by uploading a random blob, downloading and verifying it, then deleting it again. All three steps must succeed.
+
+```bash
+ocis storage-users blobstore check [command options]
+```
+
+```
+OPTIONS:
+   --blob-size value  size of the random blob to upload, e.g. 64, 1KB, 1MB, 4MiB (default: "64")
+   --help, -h         show help
+```
+
+**Examples:**
+
+```bash
+# Basic connectivity check using the default 64-byte payload
+ocis storage-users blobstore check
+
+# Use a larger payload to also stress-test throughput
+ocis storage-users blobstore check --blob-size=4MiB
+```
+
+```plaintext
+Uploading test blob: spaceID=a5c9bd5c-7348-4e9e-a462-d4d9e5287d01 blobID=3f1e5a82-b7e3-4c91-a110-1d5e2f3a4b6c
+Upload: OK
+Download and verify: OK
+Delete: OK
+Blobstore check successful.
+```
+
+#### Get
+
+Downloads a single blob by its ID to verify it exists and is readable. Useful when investigating errors in log lines that contain a blob path such as:
+
+```
+decomposedfs: error download blob '04ba5496-...': blob path: b19ec764-.../61/03/ab/c3/-b08a-...: The specified key does not exist.
+```
+
+The blob can be identified either by passing the raw path from the log line with `--path`, or by supplying `--blob-id` and `--space-id` individually.
+
+```bash
+ocis storage-users blobstore get [command options]
+```
+
+```
+OPTIONS:
+   --path value      blobstore path as it appears in log lines; spaceID and blobID are extracted automatically.
+                     Supports both s3ng format ("<spaceID>/<pathified_blobID>") and ocis format
+                     ("…/spaces/<pathified_spaceID>/blobs/<pathified_blobID>").
+   --blob-id value   blob ID to download (required when --path is not set)
+   --space-id value  space ID the blob belongs to (required when --path is not set)
+   --blob-size value expected blob size in bytes; only needed for the s3ng driver when the size is known
+                     upfront. If omitted or wrong, a size mismatch triggers one automatic retry with the
+                     actual size returned by s3ng. (default: 0)
+   --help, -h        show help
+```
+
+**Examples:**
+
+```bash
+# Identify a blob using the path from a log line (s3ng)
+ocis storage-users blobstore get --path="b19ec764-5398-458a-8ff1-1925bd906999/61/03/ab/c3/-b08a-4556-9937-2bf3065c1202"
+
+# Identify a blob using the full filesystem path from a log line (ocis driver)
+ocis storage-users blobstore get --path="/var/lib/ocis/storage/users/spaces/b1/9ec764-5398-458a-8ff1-1925bd906999/blobs/61/03/ab/c3/-b08a-4556-9937-2bf3065c1202"
+
+# Identify a blob using explicit IDs
+ocis storage-users blobstore get --space-id=b19ec764-5398-458a-8ff1-1925bd906999 --blob-id=6103abc3-b08a-4556-9937-2bf3065c1202
+```
 
 ### Manage Spaces
 
@@ -321,3 +425,106 @@ Store specific notes:
   -   When using `redis-sentinel`, the Redis master to use is configured via e.g. `OCIS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
   -   When using `nats-js-kv` it is recommended to set `OCIS_CACHE_STORE_NODES` to the same value as `OCIS_EVENTS_ENDPOINT`. That way the cache uses the same nats instance as the event bus.
   -   When using the `nats-js-kv` store, it is possible to set `OCIS_CACHE_DISABLE_PERSISTENCE` to instruct nats to not persist cache data on disc.
+
+## Vault Mode
+
+Vault mode provides a dedicated, separately stored vault storage that can be MFA-protected. Vault resources are isolated from the default user storage and have their own search, shares, and spaces — while public links are explicitly disallowed.
+
+### Architecture
+
+*   A dedicated `storage-users` vault storage instance is configured with a `VaultStorageProviderID` and mounted at `/vault/users` and `/vault/projects`.
+*   The `graph` service API is extended to serve the `/vault` prefix when vault mode is active.
+*   WebDAV access is supported for vault resources.
+*   Search is scoped separately for default and vault files, including their shares and spaces.
+*   Public links are disallowed for vault resources. The capabilities endpoint accepts a `vault=true` query parameter to advertise vault-specific capabilities.
+
+#### The `vault mode` Configuration and Environment Variables
+
+Set\
+`OCIS_MFA_ENABLED: true`\
+`OCIS_ENABLE_VAULT_MODE: true` and\
+to enable the vault mode in a OCIS.\
+Only applicapable if the storage-users-vault service, a special configured storage-users service is configured.
+
+The storage-users-vault configuration:
+```
+STORAGE_USERS_SERVICE_NAME: storage-users-vault
+STORAGE_USERS_GRPC_ADDR: storage-users-vault:9285
+STORAGE_USERS_HTTP_ADDR: storage-users-vault:9286
+STORAGE_USERS_DATA_SERVER_URL: http://storage-users-vault:9286/data
+STORAGE_USERS_DEBUG_ADDR: storage-users-vault:9287
+STORAGE_USERS_OCIS_ROOT: /var/lib/ocis/storage/users-vault
+STORAGE_USERS_EVENTS_CONSUMER_GROUP: vault-dcfs
+```
+
+```
+~/.ocis/storage
+$ tree  users*
+users
+├── indexes
+│   ├── by-group-id
+│   ├── by-type
+│   │   └── personal.mpk
+│   └── by-user-id
+│       └── a032f2bd-fa5c-430b-a163-2c19f54190d0.mpk
+├── spaces
+│   └── a0
+│       └── 32f2bd-fa5c-430b-a163-2c19f54190d0
+│           └── nodes
+│               └── a0
+│                   └── 32
+│                       └── f2
+│                           └── bd
+│                               ├── -fa5c-430b-a163-2c19f54190d0
+│                               ├── -fa5c-430b-a163-2c19f54190d0.mlock
+│                               └── -fa5c-430b-a163-2c19f54190d0.mpk
+└── uploads
+users-vault
+├── indexes
+│   ├── by-group-id
+│   ├── by-type
+│   │   └── personal.mpk
+│   └── by-user-id
+│       └── a032f2bd-fa5c-430b-a163-2c19f54190d0.mpk
+├── spaces
+│   └── a0
+│       └── 32f2bd-fa5c-430b-a163-2c19f54190d0
+│           └── nodes
+│               └── a0
+│                   └── 32
+│                       └── f2
+│                           └── bd
+│                               ├── -fa5c-430b-a163-2c19f54190d0
+│                               ├── -fa5c-430b-a163-2c19f54190d0.mlock
+│                               └── -fa5c-430b-a163-2c19f54190d0.mpk
+└── uploads
+```
+
+### Checking Vault Mode in the Frontend
+
+To check whether vault mode is enabled in the frontend, use the `@ownclouders/web-pkg` package:
+
+```typescript
+import { useAbility } from '@ownclouders/web-pkg'
+import { useCapabilityStore } from '@ownclouders/web-pkg'
+
+const capabilityStore = useCapabilityStore()
+const { can } = useAbility()
+
+const isVaultModeEnabled = capabilityStore.vaultEnabled && can('read-all', 'Vault')
+```
+
+### Running with Docker
+
+To enable vault mode in the `ocis_full` docker-compose stack, edit `deployments/examples/ocis_full/.env` and uncomment the following lines:
+
+```.env
+KEYCLOAK=:keycloak.yml
+VAULT_STORAGE=:vault-storage.yml
+```
+
+Then start the stack:
+
+```bash
+docker compose up -d
+```

--- a/services/storage-users/pkg/command/uploads.go
+++ b/services/storage-users/pkg/command/uploads.go
@@ -94,6 +94,11 @@ func ListUploadSessions(cfg *config.Config) *cli.Command {
 				Usage:       "filter sessions by virus scan result",
 			},
 			&cli.BoolFlag{
+				Name:        "orphaned",
+				DefaultText: "unset",
+				Usage:       "filter sessions by whether their node metadata is unreadable. Such sessions can never finish processing and can be removed with --clean",
+			},
+			&cli.BoolFlag{
 				Name:  "json",
 				Usage: "output as json",
 			},
@@ -259,6 +264,10 @@ func buildFilter(c *cli.Context) storage.UploadSessionFilter {
 		infectedValue := c.Bool("has-virus")
 		filter.HasVirus = &infectedValue
 	}
+	if c.IsSet("orphaned") {
+		orphanedValue := c.Bool("orphaned")
+		filter.Orphaned = &orphanedValue
+	}
 	if c.IsSet("id") {
 		idValue := c.String("id")
 		filter.ID = &idValue
@@ -312,6 +321,24 @@ func buildInfo(filter storage.UploadSessionFilter) string {
 			b.WriteString("Virusinfected")
 		} else {
 			b.WriteString("virusinfected")
+		}
+	}
+
+	if filter.Orphaned != nil {
+		if b.Len() != 0 {
+			b.WriteString(", ")
+		}
+		if !*filter.Orphaned {
+			if b.Len() == 0 {
+				b.WriteString("Not ")
+			} else {
+				b.WriteString("not ")
+			}
+		}
+		if b.Len() == 0 {
+			b.WriteString("Orphaned")
+		} else {
+			b.WriteString("orphaned")
 		}
 	}
 

--- a/services/storage-users/pkg/command/uploads_test.go
+++ b/services/storage-users/pkg/command/uploads_test.go
@@ -63,6 +63,26 @@ func TestBuildInfo(t *testing.T) {
 			filter:       storage.UploadSessionFilter{Processing: boolPtr(true), Expired: boolPtr(false), HasVirus: boolPtr(true), ID: strPtr("123")},
 			expectedInfo: "Processing, not expired, virusinfected session with id '123':",
 		},
+		{
+			alias:        "orphaned",
+			filter:       storage.UploadSessionFilter{Orphaned: boolPtr(true)},
+			expectedInfo: "Orphaned sessions:",
+		},
+		{
+			alias:        "not orphaned",
+			filter:       storage.UploadSessionFilter{Orphaned: boolPtr(false)},
+			expectedInfo: "Not orphaned sessions:",
+		},
+		{
+			alias:        "processing and orphaned",
+			filter:       storage.UploadSessionFilter{Processing: boolPtr(true), Orphaned: boolPtr(true)},
+			expectedInfo: "Processing, orphaned sessions:",
+		},
+		{
+			alias:        "expired, not virus infected and orphaned",
+			filter:       storage.UploadSessionFilter{Expired: boolPtr(true), HasVirus: boolPtr(false), Orphaned: boolPtr(true)},
+			expectedInfo: "Expired, not virusinfected, orphaned sessions:",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/uploads.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/uploads.go
@@ -87,4 +87,8 @@ type UploadSessionFilter struct {
 	Processing *bool
 	Expired    *bool
 	HasVirus   *bool
+	// Orphaned filters sessions by whether their target node can still be
+	// resolved. Evaluating it requires reading the node metadata of every
+	// session, so it is only evaluated when set.
+	Orphaned *bool
 }

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -296,7 +296,12 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 
 			n, err := session.Node(ctx)
 			if err != nil {
-				sublog.Error().Err(err).Msg("could not read node")
+				// The node metadata is unreadable, so this upload can never finish:
+				// the destination cannot be resolved. Clean the session up instead of
+				// leaving it behind to be retried forever. Cleanup falls back to the
+				// session metadata to release the quota.
+				sublog.Error().Err(err).Msg("could not read node, cleaning up orphaned session")
+				session.Cleanup(true, true, true, false)
 				continue
 			}
 			sublog = log.With().Str("spaceid", session.SpaceID()).Str("nodeid", session.NodeID()).Logger()

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload.go
@@ -411,6 +411,11 @@ func (fs *Decomposedfs) ListUploadSessions(ctx context.Context, filter storage.U
 				continue
 			}
 		}
+		// evaluated last: unlike the other filters this reads the node metadata
+		// from disk, so it is only done for sessions that passed all other filters
+		if filter.Orphaned != nil && *filter.Orphaned != session.IsOrphaned(ctx) {
+			continue
+		}
 		filteredSessions = append(filteredSessions, session)
 	}
 	return filteredSessions, nil

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/session.go
@@ -34,6 +34,7 @@ import (
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/owncloud/reva/v2/pkg/appctx"
 	ctxpkg "github.com/owncloud/reva/v2/pkg/ctx"
+	"github.com/owncloud/reva/v2/pkg/errtypes"
 	"github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/owncloud/reva/v2/pkg/utils"
 )
@@ -164,6 +165,43 @@ func (s *OcisSession) HeaderIfUnmodifiedSince() string {
 // Node returns the node for the session
 func (s *OcisSession) Node(ctx context.Context) (*node.Node, error) {
 	return node.ReadNode(ctx, s.store.lu, s.SpaceID(), s.info.Storage["NodeId"], false, nil, true)
+}
+
+// IsOrphaned returns true if the session's target node can no longer be
+// resolved. This happens when the node file still exists but its metadata is
+// gone, e.g. because an ancestor was moved to the trash while the upload was in
+// flight. Such a session can never finish postprocessing: reading the node
+// fails before the destination can be determined.
+func (s *OcisSession) IsOrphaned(ctx context.Context) bool {
+	_, err := s.Node(ctx)
+	return err != nil
+}
+
+// syntheticNode builds a node from the session metadata alone, without reading
+// the node from disk. It is used to clean up sessions whose node metadata is
+// unreadable: the parent id is still recorded in the session, which is all that
+// is needed to walk up the tree and revert the size propagation.
+func (s *OcisSession) syntheticNode(ctx context.Context) (*node.Node, error) {
+	if s.NodeID() == "" || s.NodeParentID() == "" {
+		return nil, errtypes.InternalError("session has no node and parent id")
+	}
+	n := node.New(
+		s.SpaceID(),
+		s.NodeID(),
+		s.NodeParentID(),
+		s.Filename(),
+		s.Size(),
+		s.ID(),
+		provider.ResourceType_RESOURCE_TYPE_FILE,
+		nil,
+		s.store.lu,
+	)
+	spaceRoot, err := node.ReadNode(ctx, s.store.lu, s.SpaceID(), s.SpaceID(), false, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	n.SpaceRoot = spaceRoot
+	return n, nil
 }
 
 // ID returns the upload session id

--- a/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/vendor/github.com/owncloud/reva/v2/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -330,9 +330,70 @@ func (session *OcisSession) removeNode(ctx context.Context) {
 	}
 }
 
+// revertNode undoes the node changes made when the upload was initiated. For a
+// readable node this restores the previous revision. When the node metadata can
+// no longer be read the node is orphaned and can never finish postprocessing; in
+// that case the node is removed and the optimistic size propagation is reverted
+// using the parent id recorded in the session, so the space quota is released.
+func (session *OcisSession) revertNode(ctx context.Context) error {
+	n, err := session.Node(ctx)
+	if err == nil {
+		curUpload, perr := n.ProcessingID(ctx)
+		if perr == nil && curUpload == session.ID() {
+			if rerr := n.RevertCurrentRevision(ctx); rerr != nil {
+				return rerr
+			}
+		}
+		return nil
+	}
+
+	// The node is unreadable. Fall back to the session metadata, which still
+	// carries the node and parent ids needed to release the quota.
+	log := appctx.GetLogger(ctx)
+	log.Info().Err(err).Str("sessionid", session.ID()).Msg("node unreadable, cleaning up orphaned upload")
+
+	sn, serr := session.syntheticNode(ctx)
+	if serr != nil {
+		return serr
+	}
+
+	if sizeDiff := session.SizeDiff(); sizeDiff != 0 {
+		if perr := session.store.tp.Propagate(ctx, sn, -sizeDiff); perr != nil {
+			// Without the propagation the quota would stay consumed. Stop here
+			// so the session can be retried instead of losing the upload.
+			return perr
+		}
+	}
+
+	// The orphaned node file cannot be resolved by any other means, remove it
+	// together with its metadata files. A missing node is not an error here:
+	// the node may never have been created.
+	nodePath := sn.InternalPath()
+	if rerr := utils.RemoveItem(nodePath); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+		log.Error().Err(rerr).Str("nodepath", nodePath).Msg("removing orphaned node failed")
+	}
+	if perr := session.store.lu.MetadataBackend().Purge(ctx, nodePath); perr != nil && !errors.Is(perr, fs.ErrNotExist) {
+		log.Error().Err(perr).Str("nodepath", nodePath).Msg("purging orphaned node metadata failed")
+	}
+
+	return nil
+}
+
 // cleanup cleans up after the upload is finished
 func (session *OcisSession) Cleanup(revertNodeMetadata, cleanBin, cleanInfo, unmarkPostprocessing bool) {
 	ctx := session.Context(context.Background())
+
+	if revertNodeMetadata {
+		// Revert before removing the bin and info files. Both are needed to
+		// recover from a failure here: the bin file holds the only copy of the
+		// uploaded data as long as the blob has not been written, and the info
+		// file is the only remaining source of the node's parent id once the
+		// node metadata is gone.
+		if err := session.revertNode(ctx); err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("sessionid", session.ID()).Msg("reverting node failed, keeping upload")
+			return
+		}
+	}
 
 	if cleanBin {
 		if err := os.Remove(session.binPath()); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -343,22 +404,6 @@ func (session *OcisSession) Cleanup(revertNodeMetadata, cleanBin, cleanInfo, unm
 	if cleanInfo {
 		if err := os.Remove(session.infoPath()); err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("session", session.ID()).Msg("removing upload info failed")
-		}
-	}
-
-	if revertNodeMetadata {
-		n, err := session.Node(ctx)
-		if err != nil {
-			appctx.GetLogger(ctx).Error().Err(err).Str("sessionid", session.ID()).Msg("reading node for session failed")
-			return
-		}
-
-		curUpload, err := n.ProcessingID(ctx)
-		if err == nil && curUpload == session.ID() {
-			if err := n.RevertCurrentRevision(ctx); err != nil {
-				appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", n.InternalPath()).Msg("reverting node metadata failed")
-				return
-			}
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1325,7 +1325,7 @@ github.com/orcaman/concurrent-map
 # github.com/owncloud/libre-graph-api-go v1.0.5-0.20260216101009-eeac018af245
 ## explicit; go 1.18
 github.com/owncloud/libre-graph-api-go
-# github.com/owncloud/reva/v2 v2.0.0-20260813081353-3dbd3c2711ea
+# github.com/owncloud/reva/v2 v2.0.0-20260910093159-40663c5bb3cb
 ## explicit; go 1.24.0
 github.com/owncloud/reva/v2/cmd/revad/internal/grace
 github.com/owncloud/reva/v2/cmd/revad/runtime


### PR DESCRIPTION
backports: https://github.com/owncloud/ocis/pull/12739

Depends on reva stable-8.0 backport https://github.com/owncloud/reva/pull/730 — **merged** as `40663c5bb3cb223d1fb56a83091fcdec5da9adcc`.

reva is pinned to that merged commit (pseudo-version `v2.0.0-20260910093159-40663c5bb3cb`). Ready to merge.