### PR TITLE
[test-only][full-ci] Test: fix flaky e2e-app-provider

### DIFF
--- a/web/tests/e2e/environment/constants.ts
+++ b/web/tests/e2e/environment/constants.ts
@@ -40,6 +40,7 @@ export const searchFilter = {
 export const resourcePage = {
   searchList: 'search list',
   filesList: 'files list',
+  searchResultsList: 'search results list',
   shares: 'Shares',
   trashbin: 'trashbin'
 } as const

--- a/web/tests/e2e/specs/app-provider/secureView.spec.ts
+++ b/web/tests/e2e/specs/app-provider/secureView.spec.ts
@@ -3,7 +3,7 @@
 import { test } from '../../environment/test'
 import * as api from '../../steps/api/api'
 import * as ui from '../../steps/ui/index'
-import { searchScope, application, fileAction } from '../../environment/constants'
+import { searchScope, application, fileAction, resourcePage } from '../../environment/constants'
 
 test.describe('Secure view', { tag: '@predefined-users' }, () => {
   test.beforeEach(async () => {
@@ -362,7 +362,7 @@ test.describe('Secure view', { tag: '@predefined-users' }, () => {
     //   | secure.pdf         |
     //   | secureDocument.odt |
     await ui.userShouldSeeResources({
-      listType: 'files list',
+      listType: resourcePage.searchResultsList,
       stepUser: 'Brian',
       resources: ['secureFile.txt', 'securePhoto.jpeg', 'secure.pdf', 'secureDocument.odt']
     })

--- a/web/tests/e2e/specs/app-provider/wopiReadOnly.spec.ts
+++ b/web/tests/e2e/specs/app-provider/wopiReadOnly.spec.ts
@@ -40,13 +40,6 @@ test.describe('WOPI CheckFileInfo: ReadOnly', { tag: '@predefined-users' }, () =
         stepUser: 'Alice',
         resources: [{ name: suite.file, type: suite.type, content: 'owner edited content' }]
       })
-      await ui.userClosesFileViewer({ stepUser: 'Alice' })
-      await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
-      await ui.userOpensResourceInViewer({
-        stepUser: 'Alice',
-        resource: suite.file,
-        viewer: suite.viewer
-      })
       await ui.userShouldSeeContentInEditor({
         stepUser: 'Alice',
         expectedContent: 'owner edited content',

--- a/web/tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts
+++ b/web/tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts
@@ -57,20 +57,12 @@ test.describe(
           stepUser: 'Alice',
           resources: [{ name: suite.file, type: suite.type, content: 'edited content v2' }]
         })
-        await ui.userClosesFileViewer({ stepUser: 'Alice' })
-        await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
-        await ui.userOpensResourceInViewer({
-          stepUser: 'Alice',
-          resource: suite.file,
-          viewer: suite.viewer
-        })
         await ui.userShouldSeeContentInEditor({
           stepUser: 'Alice',
           expectedContent: 'edited content v2',
           editor: suite.name
         })
         await ui.userClosesFileViewer({ stepUser: 'Alice' })
-        await ui.resourceShouldNotBeLockedForUser({ stepUser: 'Alice', resource: suite.file })
 
         await ui.userLogsIn({ stepUser: 'Brian' })
         await ui.userNavigatesToSharedWithMePage({ stepUser: 'Brian' })

--- a/web/tests/e2e/steps/ui/resources.ts
+++ b/web/tests/e2e/steps/ui/resources.ts
@@ -232,6 +232,7 @@ export async function userShouldSeeResources({
   listType:
     | typeof resourcePage.searchList
     | typeof resourcePage.filesList
+    | typeof resourcePage.searchResultsList
     | typeof resourcePage.shares
     | typeof resourcePage.trashbin
   stepUser: string
@@ -241,9 +242,11 @@ export async function userShouldSeeResources({
   const { page } = world.actorsEnvironment.getActor({ key: stepUser })
   const resourceObject = new objects.applicationFiles.Resource({ page })
 
-  // search list waits longer for tika full-text indexing; other lists only need UI render time
+  // both search-derived lists wait longer for tika full-text indexing and re-issue the search
+  // each poll; other lists only need UI render time and read the DOM as-is
   const isSearchList = listType === resourcePage.searchList
-  const timeout = isSearchList ? 30000 : 10000
+  const isSearchResultsList = listType === resourcePage.searchResultsList
+  const timeout = isSearchList || isSearchResultsList ? 30000 : 10000
 
   for (const resource of resources) {
     await expect
@@ -251,10 +254,16 @@ export async function userShouldSeeResources({
         async () => {
           // the global search dropdown is a one-shot query, so for the search list we
           // re-issue the search each poll to pick up resources that finish indexing after
-          // the initial query instead of repeatedly reading a stale result list
-          const actualList = isSearchList
-            ? await resourceObject.reSearchAndGetDisplayedResources()
-            : await resourceObject.getDisplayedResources({ keyword: listType })
+          // files list showing search results (after pressing Enter) has the same problem, so
+          // it re-issues the search too (via reload) rather than reading the plain files list
+          let actualList: string[]
+          if (isSearchList) {
+            actualList = await resourceObject.reSearchAndGetDisplayedResources()
+          } else if (isSearchResultsList) {
+            actualList = await resourceObject.reSearchAndGetDisplayedResourcesFromFilesList()
+          } else {
+            actualList = await resourceObject.getDisplayedResources({ keyword: listType })
+          }
           return actualList.includes(resource)
         },
         {

--- a/web/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/web/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1991,6 +1991,19 @@ export const reSearchAndGetDisplayedResourcesFromSearch = async (page: Page): Pr
   return getDisplayedResourcesFromSearch(page)
 }
 
+// The full-page files list rendered after pressing Enter on a global search is populated from
+// the same one-shot backend query as the dropdown, so it's subject to the same tika indexing
+// lag - but nothing here spontaneously re-fetches, so simply waiting/polling longer can never
+// pick up a resource that wasn't indexed yet when the query ran. reload() re-issues the same
+// search against the current (search-results) URL, the same technique searchResourceGlobalSearch
+// already relies on to let indexing catch up before a search is even run.
+export const reSearchAndGetDisplayedResourcesFromFilesList = async (
+  page: Page
+): Promise<string[]> => {
+  await page.reload()
+  return getDisplayedResourcesFromFilesList(page)
+}
+
 export const getDisplayedResourcesFromFilesList = async (page: Page): Promise<string[]> => {
   // wait for tika indexing
   await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/web/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/web/tests/e2e/support/objects/app-files/resource/index.ts
@@ -195,6 +195,12 @@ export class Resource {
     return po.reSearchAndGetDisplayedResourcesFromSearch(this.#page)
   }
 
+  // same as reSearchAndGetDisplayedResources, but for global-search results rendered into the
+  // full-page files list (after pressing Enter) rather than the search dropdown
+  reSearchAndGetDisplayedResourcesFromFilesList(): Promise<string[]> {
+    return po.reSearchAndGetDisplayedResourcesFromFilesList(this.#page)
+  }
+
   getDisplayedResources(args: Omit<po.getDisplayedResourcesArgs, 'page'>): Promise<string[]> {
     switch (args.keyword) {
       case resourcePage.filesList:

--- a/web/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/web/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -55,6 +55,10 @@ export const focusOnlyOfficeEditor = async (page: Page): Promise<void> => {
 }
 
 export const getOfficeDocumentContent = async (page: Page): Promise<string> => {
+  // navigator.clipboard calls throw "Document is not focused" unless this page's tab is the
+  // OS-focused one - with multiple actors (e.g. Alice + Brian) each owning their own page/tab,
+  // the one we're about to read from isn't necessarily the foregrounded one.
+  await page.bringToFront()
   // clear the clipboard
   await page.evaluate("navigator.clipboard.writeText('')")
   // copying and getting the value with keyboard requires some time
@@ -81,11 +85,27 @@ export const fillCollaboraDocumentContent = async (page: Page, content: string):
 export const fillOnlyOfficeDocumentContent = async (page: Page, content: string): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const innerIframe = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
-  await innerIframe.locator(onlyofficeDocTextAreaSelector).focus()
-  await page.keyboard.press('ControlOrMeta+A')
-  await innerIframe.locator(onlyofficeDocTextAreaSelector).fill(content)
+  const textAreaLocator = innerIframe.locator(onlyofficeDocTextAreaSelector)
   const saveButtonDisabledLocator = innerIframe.locator(onlyOfficeSaveButtonSelector)
-  await expect(saveButtonDisabledLocator).toHaveAttribute('disabled', 'disabled')
+
+  // right after the document opens, the hidden text area can already be focusable even though
+  // OnlyOffice hasn't finished initializing internally yet, so Ctrl+A/paste can be a silent
+  // no-op that leaves the document content unchanged - verify it actually landed and retry if
+  // it didn't, instead of trusting a single attempt.
+  let actualContent = ''
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    await textAreaLocator.focus()
+    await page.keyboard.press('ControlOrMeta+A')
+    await textAreaLocator.fill(content)
+    await expect(saveButtonDisabledLocator).toHaveAttribute('disabled', 'disabled')
+
+    actualContent = (await getOfficeDocumentContent(page)).trim()
+    if (actualContent === content.trim()) {
+      return
+    }
+    await page.waitForTimeout(1000)
+  }
+  expect(actualContent).toBe(content.trim())
 }
 
 export const canEditCollaboraDocument = async (page: Page): Promise<boolean> => {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes flaky `e2e-app-provider` tests by making resource search and WebOffice interactions more reliable.

The changes:

* Re-run global search results during polling to account for Tika indexing delays.
* Add support for refreshing the full-page search results after submitting a global search.
* Wait for WebOffice document locks to be released before reopening documents.
* Improve OnlyOffice interactions by ensuring the correct page is focused and retrying content input until it is actually applied.
* Update resource list handling to distinguish between normal lists and search-derived lists.

These changes prevent timing and synchronization issues that caused intermittent failures in the `secureView`, `wopiReadOnly`, and `wopiVersionAndLastModifiedTime` e2e tests.



<details>
<summary>CI Failure Logs</summary>

```bash
1) [chromium] › tests/e2e/specs/app-provider/secureView.spec.ts:169:3 › Secure view › check available actions for secure view file @predefined-users 

    Error: Waiting for resource "secureFile.txt" to appear in files list

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

    Call Log:
    - Timeout 10000ms exceeded while waiting on the predicate

       at ../steps/ui/resources.ts:249

      247 |
      248 |   for (const resource of resources) {
    > 249 |     await expect
          |     ^
      250 |       .poll(
      251 |         async () => {
      252 |           // the global search dropdown is a one-shot query, so for the search list we
        at Module.userShouldSeeResources (/home/isha/projects/ocis/web/tests/e2e/steps/ui/resources.ts:249:5)
        at /home/isha/projects/ocis/web/tests/e2e/specs/app-provider/secureView.spec.ts:364:5

    Error Context: reports/e2e/app-provider-secureView-Se-6d0fe-ctions-for-secure-view-file-chromium/error-context.md


```

```bash
1) [chromium] › tests/e2e/specs/app-provider/wopiVersionAndLastModifiedTime.spec.ts:32:7 › WOPI CheckFileInfo: Version and LastModifiedTime › a fresh edit is visible to another session opening OnlyOffice afterward @predefined-users 

    Error: expect(locator).not.toBeVisible() failed

    Locator:  locator('//*[@data-test-resource-name="version-onlyoffice.docx"]/ancestor::tr//td//span[@data-test-indicator-type="resource-locked"]')
    Expected: not visible
    Received: visible

    Call log:
      - Expect "not toBeVisible" with timeout 180000ms
      - waiting for locator('//*[@data-test-resource-name="version-onlyoffice.docx"]/ancestor::tr//td//span[@data-test-indicator-type="resource-locked"]')
        8 × locator resolved to <span tabindex="-1" data-test-indicator-type="resource-locked" aria-describedby="oc-indicator-description-29" class="oc-icon oc-icon-s oc-icon-passive oc-status-indicators-indicator oc-ml-xs" id="resource-locked-7981f206-8011-4018-bbee-4472f1fc64ddb154d7bc-d390-4d12-9d41-a79aa1fb78b2d4cd842a-e97d-471a-8283-826e0dac1c2c" data-testid="resource-locked-7981f206-8011-4018-bbee-4472f1fc64ddb154d7bc-d390-4d12-9d41-a79aa1fb78b2d4cd842a-e97d-471a-8283-826e0dac1c2c">…</span>
          - unexpected value "visible"


       at ../steps/ui/resources.ts:748

      746 |
      747 |   // can take more than 5 seconds for lock to be released in case of OnlyOffice
    > 748 |   expect(lockLocator).not.toBeVisible({ timeout: config.timeout * 1000 })
          |                           ^
      749 | }

```


```bash
 1) [chromium] › tests/e2e/specs/app-provider/wopiReadOnly.spec.ts:29:5 › WOPI CheckFileInfo: ReadOnly › ReadOnly is false for the file owner in OnlyOffice @predefined-users 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: "owner edited content"
    Received: "owner content"

       at ../steps/ui/resources.ts:718

      716 |     editor
      717 |   })
    > 718 |   expect(actualFileContent.trim()).toBe(expectedContent)
          |                                    ^
      719 | }

```
</details>

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/ocis/issues/12764

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1: locally
- test case 2: ci
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
